### PR TITLE
Use window title as selector for new py3 notebook window

### DIFF
--- a/tests/Resources/Page/LaunchPython3.robot
+++ b/tests/Resources/Page/LaunchPython3.robot
@@ -1,10 +1,11 @@
-*** Settings *** 
+*** Settings ***
 Library  SeleniumLibrary
 
 *** Keywords ***
 Launch Python3 JupyterHub
    Wait Until Page Contains  New
    Wait Until Page Contains  Files
-   Switch Window  NEW
-   Click Element  xpath=//*[@id="new-dropdown-button"]/span[2]
-   Click Element  xpath=//*[@id="kernel-python3"]/a
+   #TODO: This window title may change so we should be selecting something with more certainty
+   Switch Window  Home Page - Select or create a notebook
+   Click Button  new-dropdown-button
+   Click Link  Python 3


### PR DESCRIPTION
In the test that launches a new Python3 notebook, this PR changes the switch window logic to select the new window based on the window title instead of relying on `NEW` keyword which can throw an error when the NEW window == CURRENT window

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>