### PR TITLE
Use seleniumlibrary pip package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
         "reportportal-client",
         "robotframework",
         "robotframework-debuglibrary",
-        "robotframework-selenium2library",
+        "robotframework-seleniumlibrary",
         "pytest",
         "pytest-logger",
         "pyyaml",


### PR DESCRIPTION
Using the seleniumlibrary pip package since selenium2library was the
name of the repo to migrate to the selenium 2.x framework. Now that it
is stable, the developers have moved that work back into seleniumlibrary

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>