### PR TITLE
Add filter to OCP route search screen

### DIFF
--- a/tests/Resources/Page/LaunchJupyterHub.robot
+++ b/tests/Resources/Page/LaunchJupyterHub.robot
@@ -4,11 +4,14 @@ Library  SeleniumLibrary
 *** Keywords ***
 Launch Jupyterhub
    Wait Until Page Contains  Networking
-   Click Element  xpath=/html/body/div[2]/div/div/div/div/div[1]/div/div/nav/ul/li[4]/button
+   Click Link  Networking
    Wait Until Page Contains  Routes  timeout=15
-   Click Element  xpath=//*[@id="page-sidebar"]/div/nav/ul/li[4]/section/ul/li[2]/a
+   Click Link  Routes
    Maximize Browser Window
+   Wait Until Page Contains Element  xpath://input[@data-test-id="item-filter"]
+   Input Text  xpath://input[@data-test-id="item-filter"]  odh-dashboard
    Wait Until Page Contains  odh-dashboard
    Sleep  4s
+   Input Text  xpath://input[@data-test-id="item-filter"]  jupyterhub
    Wait Until Page Contains  jupyterhub  timeout=15
    Click Element  partial link:https://jupyterhub

--- a/tests/Resources/Page/LoginPage.robot
+++ b/tests/Resources/Page/LoginPage.robot
@@ -2,11 +2,20 @@
 Library  SeleniumLibrary
 
 *** Keywords ***
+Does Login Require Authentication Type
+   ${authentication_required} =  Run Keyword and Return Status  Page Should Contain  Log in with...
+   [Return]  ${authentication_required}
+
+Select Login Authentication Type
+   [Arguments]  ${auth_type}
+   Wait Until Page Contains  Log in with  timeout=15
+   Log  ${auth_type}
+   Click Element  link:${auth_type}
+
 Login To Openshift
     Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER}  options=add_argument("--ignore-certificate-errors")
-    Wait Until Page Contains  Log in with  timeout=15
-    Log  ${USER_AUTH_TYPE}
-    Click Element  link:${USER_AUTH_TYPE}
+    ${select_auth_type} =  Does Login Require Authentication Type
+    Run Keyword If  ${select_auth_type}  Select Login Authentication Type  ${USER_AUTH_TYPE}
     Wait Until Page Contains  Log in to your account
     Input Text  id=inputUsername  ${TEST_USER_NAME}
     Input Text  id=inputPassword  ${TEST_USER_PW}


### PR DESCRIPTION
Uses the filter text box to search for the odh-dashboard and jupyterhub routes