### PR TITLE
Sets headlesschrome as the default browser for test runs

### DIFF
--- a/test-variables.yml.example
+++ b/test-variables.yml.example
@@ -1,4 +1,7 @@
-BROWSER: chrome
+BROWSER:
+  NAME: headlesschrome
+  # List of Chrome options - https://peter.sh/experiments/chromium-command-line-switches/
+  OPTIONS: add_argument("--ignore-certificate-errors");add_argument("window-size=1920,1024")
 OCP_CONSOLE_URL: "http://console-openshift-console.apps.my-cluster.test.redhat.com/"
 USER_AUTH_TYPE: foo-auth
 TEST_USER_NAME: foo-user

--- a/tests/Resources/Page/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/JupyterHubSpawner.robot
@@ -4,14 +4,17 @@ Library  String
 
 *** Keywords ***
 Select Notebook Image
+   [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
    Click Element  id:ImageDropdownBtn
-   Wait Until Element Is Visible  id:${notebook_image}
-   Click Element  id:${notebook_image}
+   ${notebook_webelement} =  Get WebElement  xpath://a[contains(@id,"${notebook_image}")]
+   Wait Until Element Is Visible  ${notebook_webelement}
+   Click Element  ${notebook_webelement}
    ${selected_notebook} =  Get Text  id:ImageDropdownBtn
    Should Start With  ${selected_notebook}  ${notebook_image}
 
 Select Container Size
+   [Documentation]  Selects the container size based on the ${container_size} argument
    [Arguments]  ${container_size}
    Click Element  id:SizeDropdownBtn
    Wait Until Element Is Visible  id:${container_size}
@@ -20,11 +23,13 @@ Select Container Size
    Should Start With  ${selected_size}  ${container_size}
 
 Set Number of required GPUs
+   [Documentation]  Sets the gpu count based on the ${gpus} argument
    [Arguments]  ${gpus}
    Input Text  id:gpu-form  ${gpus}
    Textfield Value Should Be  id:gpu-form  ${gpus}
 
 Add Spawner Environment Variable
+   [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
    [Arguments]  ${env_var}  ${env_var_value}
    Click Button  Add
    Input Text  name:variable_name  ${env_var}
@@ -33,19 +38,23 @@ Add Spawner Environment Variable
    Element Attribute Value Should Be  name:${env_var_value}  value  ${env_var_value}
 
 Remove Spawner Environment Variable
+   [Documentation]  Removes an existing environment variable based on the ${env_var} argument
    [Arguments]  ${env_var}
    Click Element  xpath://*[@name="${env_var}"]/../../../button[.="Remove"]
 
 Spawner Environment Variable Exists
+   [Documentation]  Removes an existing environment variable based on the ${env_var} argument
    [Arguments]  ${env_var}
    Element Should Be Visible  name:${env_var}
 
 Get Spawner Environment Variable Value
+   [Documentation]  Get the value of an existing environment variable based on the ${env_var} argument
    [Arguments]  ${env_var}
    ${env_var_value} =  Get Value  name:${env_var}
    [Return]  ${env_var_value}
 
 Spawn Notebook
+   [Documentation]  Start the notebook pod spawn and wait ${spawner_timeout} seconds (DEFAULT: 600s)
    [Arguments]  ${spawner_timeout}=600 seconds
    Click Button  Start
    Wait Until Page Contains  Your server is starting up
@@ -53,9 +62,11 @@ Spawn Notebook
    Wait Until Page Does Not Contain Element  id:progress-bar  ${spawner_timeout}
 
 Get Spawner Progress Message
+   [Documentation]  Get the progress message currently displayed
    ${msg} =  Get Text  progress-message
    [Return]  ${msg}
 
 Get Spawner Event Log
+   [Documentation]  Get the spawner event log messages as a list
    ${event_elements} =  Get WebElements  class:progress-log-event
    [Return] @{event_elements}

--- a/tests/Resources/Page/LoginJupyterHub.robot
+++ b/tests/Resources/Page/LoginJupyterHub.robot
@@ -1,11 +1,21 @@
-*** Settings *** 
+*** Settings ***
 Library  SeleniumLibrary
 
 *** Keywords ***
-Can LoginTo Jupyterhub
-   Switch Window  NEW
+Login To Jupyterhub
+   #TODO: We should assume that the CURRENT browser window is where we are logging in
+   Switch Window  JupyterHub
    Wait Until Page Contains  Sign in with OpenShift
    Click Element  xpath=//*[@id="login-main"]/div/a
+   Wait Until Page Contains  Log in to your account
+   Input Text  id=inputUsername  ${TEST_USER_NAME}
+   Input Text  id=inputPassword  ${TEST_USER_PW}
+   Click Button  Log in
+
+Is Service Account Authorization Required
+   ${title} =  Get Title
+   ${result} =  Run Keyword And Return Status  Should Start With  ${title}  Authorize service account
+   [Return]  ${result}
 
 Authorize jupyterhub service account
   Wait Until Page Contains  Authorize Access

--- a/tests/Resources/Page/LoginPage.robot
+++ b/tests/Resources/Page/LoginPage.robot
@@ -13,7 +13,7 @@ Select Login Authentication Type
    Click Element  link:${auth_type}
 
 Login To Openshift
-    Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER}  options=add_argument("--ignore-certificate-errors")
+    Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     ${select_auth_type} =  Does Login Require Authentication Type
     Run Keyword If  ${select_auth_type}  Select Login Authentication Type  ${USER_AUTH_TYPE}
     Wait Until Page Contains  Log in to your account

--- a/tests/Resources/Page/LoginPage.robot
+++ b/tests/Resources/Page/LoginPage.robot
@@ -13,6 +13,7 @@ Select Login Authentication Type
    Click Element  link:${auth_type}
 
 Login To Openshift
+    #TODO: Move browser creation into its own keyword
     Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     ${select_auth_type} =  Does Login Require Authentication Type
     Run Keyword If  ${select_auth_type}  Select Login Authentication Type  ${USER_AUTH_TYPE}

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -17,7 +17,9 @@ Can Launch Jupyterhub
 
 Can Login to Jupyterhub
    [Tags]  Sanity
-   Can LoginTo Jupyterhub
+   Login To Jupyterhub
+   ${authorization_required} =  Is Service Account Authorization Required
+   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
 
 Can Spawn Notebook
    [Tags]  Sanity
@@ -27,9 +29,9 @@ Can Spawn Notebook
    # See: https://github.com/robotframework/robotframework/issues/3622
    Run Keyword If  ${on_dashboard}  Set Tags  SKIP
    Pass Execution If  ${on_dashboard}  SKIP:The user has an existing notebook pod running
-   Select Notebook Image  s2i-minimal-notebook:v0.0.4
-   Select Notebook Image  s2i-scipy-notebook:v0.0.1
-   Select Notebook Image  s2i-tensorflow-notebook:v0.0.1
+   Select Notebook Image  s2i-minimal-notebook
+   Select Notebook Image  s2i-scipy-notebook
+   Select Notebook Image  s2i-tensorflow-notebook
    Select Container Size  Small
    Set Number of required GPUs  9
    Set Number of required GPUs  0


### PR DESCRIPTION
Use `headlesschrome` as the default browser for test runs as defined with browser options in `test-variables.yml` file.

JH Notebook selection in the spawner webui can now use partial text matches for the notebook name