### PR TITLE
Add support for checking if OCP login is visible

### DIFF
--- a/tests/Resources/Page/LaunchJupyterHub.robot
+++ b/tests/Resources/Page/LaunchJupyterHub.robot
@@ -15,3 +15,4 @@ Launch Jupyterhub
    Input Text  xpath://input[@data-test-id="item-filter"]  jupyterhub
    Wait Until Page Contains  jupyterhub  timeout=15
    Click Element  partial link:https://jupyterhub
+   Switch Window  JupyterHub

--- a/tests/Resources/Page/LoginJupyterHub.robot
+++ b/tests/Resources/Page/LoginJupyterHub.robot
@@ -3,14 +3,10 @@ Library  SeleniumLibrary
 
 *** Keywords ***
 Login To Jupyterhub
-   #TODO: We should assume that the CURRENT browser window is where we are logging in
-   Switch Window  JupyterHub
    Wait Until Page Contains  Sign in with OpenShift
    Click Element  xpath=//*[@id="login-main"]/div/a
-   Wait Until Page Contains  Log in to your account
-   Input Text  id=inputUsername  ${TEST_USER_NAME}
-   Input Text  id=inputPassword  ${TEST_USER_PW}
-   Click Button  Log in
+   ${login_required} =  Is OpenShift Login Visible
+   Run Keyword If  ${login_required}  Login To Openshift
 
 Is Service Account Authorization Required
    ${title} =  Get Title

--- a/tests/Resources/Page/LoginPage.robot
+++ b/tests/Resources/Page/LoginPage.robot
@@ -6,6 +6,12 @@ Does Login Require Authentication Type
    ${authentication_required} =  Run Keyword and Return Status  Page Should Contain  Log in with
    [Return]  ${authentication_required}
 
+Is OpenShift Login Visible
+   ${login_prompt_visible} =  Run Keyword and Return Status  Page Should Contain  Log in with
+   Return From Keyword If  ${login_prompt_visible}  True
+   ${login_prompt_visible} =  Run Keyword and Return Status  Page Should Contain  Log in to your account
+   [Return]  ${login_prompt_visible}
+
 Select Login Authentication Type
    [Arguments]  ${auth_type}
    Wait Until Page Contains  Log in with  timeout=15
@@ -13,10 +19,8 @@ Select Login Authentication Type
    Click Element  link:${auth_type}
 
 Login To Openshift
-    #TODO: Move browser creation into its own keyword
-    Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     # Give the login prompt time to render after browser opens
-    Wait Until Element is Visible  xpath://div[@class="pf-c-login"]
+    Wait Until Element is Visible  xpath://div[@class="pf-c-login"]  timeout=15seconds
     ${select_auth_type} =  Does Login Require Authentication Type
     Run Keyword If  ${select_auth_type}  Select Login Authentication Type  ${USER_AUTH_TYPE}
     Wait Until Page Contains  Log in to your account

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -9,6 +9,7 @@ ${MYBROWSER} =  chrome
 *** Test Cases ***
 Logged into OpenShift
    [Tags]  Sanity
+    Open Browser  ${OCP_CONSOLE_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
    Login To Openshift
 
 Can Launch Jupyterhub


### PR DESCRIPTION
Refactor some keywords to de-duplicate OpenShift login actions and add logic paths for checking if login requires authentication type selection or service account authorization

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>