### PR TITLE
[WIP] Refactor/cleanup UI code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ test-variables.yml
 venv/
 ods_ci.egg-info/
 test-output/
+build/
+dist/

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-TEST_CASE_FILE=tests/Tests/test.robot
+TEST_CASE_FILE=tests/Tests/test-jupyterlab-git-notebook.robot
 TEST_VARIABLES_FILE=test-variables.yml
 TEST_VARIABLES=""
 TEST_ARTIFACT_DIR="test-output"

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-TEST_CASE_FILE=tests/Tests/test-jupyterlab-git-notebook.robot
+TEST_CASE_FILE=tests/Tests/test.robot
 TEST_VARIABLES_FILE=test-variables.yml
 TEST_VARIABLES=""
 TEST_ARTIFACT_DIR="test-output"

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -94,6 +94,6 @@ fi
 TEST_ARTIFACT_DIR=$(mktemp -d -p ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
 
 #run tests
-./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} ${TEST_CASE_FILE} ${EXTRA_ROBOT_ARGS}
+./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${TEST_CASE_FILE} ${EXTRA_ROBOT_ARGS}
 
 esac

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-TEST_CASE_FILE=tests/Tests/test.robot
+TEST_CASE_FILE=tests/Tests
 TEST_VARIABLES_FILE=test-variables.yml
 TEST_VARIABLES=""
 TEST_ARTIFACT_DIR="test-output"

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-TEST_CASE_FILE=tests/Tests/test.robot
+TEST_CASE_FILE=tests/Tests/test-minimal-image.robot
 TEST_VARIABLES_FILE=test-variables.yml
 TEST_VARIABLES=""
 TEST_ARTIFACT_DIR="test-output"

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -1,0 +1,15 @@
+*** Settings ***
+Library  JupyterLibrary
+
+*** Keywords ***
+Begin Web Test
+    Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+
+End Web Test
+    Click JupyterLab Menu  File
+    Click JupyterLab Menu Item  Hub Control Panel
+    Switch Window  JupyterHub
+    Sleep  5
+    Click Element  //*[@id="stop"]
+    Wait Until Page Contains  Start My Server  timeout=15
+    Close Browser

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -9,9 +9,11 @@ Begin Web Test
 End Web Test
     Clean Up Server
     Click JupyterLab Menu  File
+    Capture Page Screenshot
     Click JupyterLab Menu Item  Hub Control Panel
     Switch Window  JupyterHub
     Sleep  5
     Click Element  //*[@id="stop"]
     Wait Until Page Contains  Start My Server  timeout=15
+    Capture Page Screenshot
     Close Browser

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -1,11 +1,13 @@
 *** Settings ***
-Library  JupyterLibrary
+Resource  Page/ODH/JupyterHub/JupyterLabLauncher.robot
+Library   JupyterLibrary
 
 *** Keywords ***
 Begin Web Test
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
 
 End Web Test
+    Clean Up Server
     Click JupyterLab Menu  File
     Click JupyterLab Menu Item  Hub Control Panel
     Switch Window  JupyterHub

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -13,7 +13,7 @@ JupyterHub Spawner Is Visible
 Select Notebook Image
    [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
-   Wait Until Element Is Visibile  xpath:/html/body/div[1]/form/div/div/div[2]/div[2]/div[1]
+   Wait Until Element Is Visible  xpath:/html/body/div[1]/form/div/div/div[2]/div[2]/div[1]
    Click Element  xpath://input[contains(@id, "${notebook_image}")]
 
 Select Container Size

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -13,7 +13,7 @@ JupyterHub Spawner Is Visible
 Select Notebook Image
    [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
-   Sleep  1
+   Wait Until Element Is Visibile  xpath:/html/body/div[1]/form/div/div/div[2]/div[2]/div[1]
    Click Element  xpath://input[contains(@id, "${notebook_image}")]
 
 Select Container Size

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -14,11 +14,6 @@ Select Notebook Image
    [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
    Click Element  xpath://input[contains(@id, "${notebook_image}")]
-   #${notebook_webelement} =  Get WebElement  xpath://a[contains(@id,"${notebook_image}")]
-   #Wait Until Element Is Visible  ${notebook_webelement}
-   #Click Element  ${notebook_webelement}
-   #${selected_notebook} =  Get Text  id:ImageDropdownBtn
-   #Should Start With  ${selected_notebook}  ${notebook_image}
 
 Select Container Size
    [Documentation]  Selects the container size based on the ${container_size} argument
@@ -26,11 +21,6 @@ Select Container Size
    # Expand List
    Click Element  xpath:/html/body/div[1]/form/div/div/div[3]/div[3]/button
    Click Element  xpath://span[.="${container_size}"]/../..
-   #Click Element  id:SizeDropdownBtn
-   #Wait Until Element Is Visible  id:${container_size}
-   #Click Element  id:${container_size}
-   #${selected_size} =  Get Text  id:SizeDropdownBtn
-   #Should Start With  ${selected_size}  ${container_size}
 
 Set Number of required GPUs
    [Documentation]  Sets the gpu count based on the ${gpus} argument
@@ -38,8 +28,6 @@ Set Number of required GPUs
    # Expand list
    Click Element  xpath:/html/body/div[1]/form/div/div/div[3]/div[5]/button
    Click Element  xpath://li[.="${gpus}"]
-   #Input Text  id:gpu-form  ${gpus}
-   #Textfield Value Should Be  id:gpu-form  ${gpus}
 
 Add Spawner Environment Variable
    [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
@@ -49,11 +37,6 @@ Add Spawner Environment Variable
    Element Attribute Value Should Be  xpath://input[@id="${env_var}"]  value  ${env_var}
    Input Text  xpath://input[@id="${env_var}-value"]  ${env_var_value}
    Element Attribute Value Should Be  xpath://input[@id="${env_var}-value"]  value  ${env_var_value}
-   #Click Button  Add
-   #Input Text  id:KeyForm-  ${env_var}
-   #Element Attribute Value Should Be  name:${env_var}  value  ${env_var}
-   #Input Text  id:ValueForm-${env_var}  ${env_var_value}
-   #Element Attribute Value Should Be  id:ValueForm-${env_var}  value  ${env_var_value}
 
 Remove Spawner Environment Variable
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -23,17 +23,23 @@ Select Notebook Image
 Select Container Size
    [Documentation]  Selects the container size based on the ${container_size} argument
    [Arguments]  ${container_size}
-   Click Element  id:SizeDropdownBtn
-   Wait Until Element Is Visible  id:${container_size}
-   Click Element  id:${container_size}
-   ${selected_size} =  Get Text  id:SizeDropdownBtn
-   Should Start With  ${selected_size}  ${container_size}
+   # Expand List
+   Click Element  xpath:/html/body/div[1]/form/div/div/div[3]/div[3]/button
+   Click Element  xpath://span[.="${container_size}"]/../..
+   #Click Element  id:SizeDropdownBtn
+   #Wait Until Element Is Visible  id:${container_size}
+   #Click Element  id:${container_size}
+   #${selected_size} =  Get Text  id:SizeDropdownBtn
+   #Should Start With  ${selected_size}  ${container_size}
 
 Set Number of required GPUs
    [Documentation]  Sets the gpu count based on the ${gpus} argument
    [Arguments]  ${gpus}
-   Input Text  id:gpu-form  ${gpus}
-   Textfield Value Should Be  id:gpu-form  ${gpus}
+   # Expand list
+   Click Element  xpath:/html/body/div[1]/form/div/div/div[3]/div[5]/button
+   Click Element  xpath://li[.="${gpus}"]
+   #Input Text  id:gpu-form  ${gpus}
+   #Textfield Value Should Be  id:gpu-form  ${gpus}
 
 Add Spawner Environment Variable
    [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
@@ -52,7 +58,7 @@ Add Spawner Environment Variable
 Remove Spawner Environment Variable
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument
    [Arguments]  ${env_var}
-   Click Element  xpath://*[@name="${env_var}"]/../../../button[.="Remove"]
+   Click Element  xpath://input[@id="${env_var}"]/../../../../button
 
 Spawner Environment Variable Exists
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -13,6 +13,7 @@ JupyterHub Spawner Is Visible
 Select Notebook Image
    [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
+   Sleep  1
    Click Element  xpath://input[contains(@id, "${notebook_image}")]
 
 Select Container Size

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -2,20 +2,23 @@
 Library  JupyterLibrary
 Library  String
 
+*** Variables ***
+${JUPYTERHUB_SPAWNER_HEADER_XPATH} =  //div[contains(@class,"jsp-spawner__header__title") and .="Start a notebook server"]
+
 *** Keywords ***
 JupyterHub Spawner Is Visible
-   ${spawner_visible} =  Run Keyword and Return Status  Element Should Be Visible  xpath://h1[@id="header-text" and .="Spawner Options"]
+   ${spawner_visible} =  Run Keyword and Return Status  Wait Until Element Is Visible  xpath:${JUPYTERHUB_SPAWNER_HEADER_XPATH}
    [return]  ${spawner_visible}
 
 Select Notebook Image
    [Documentation]  Selects a notebook image based on a partial match of ${notebook_image} argument
    [Arguments]  ${notebook_image}
-   Click Element  id:ImageDropdownBtn
-   ${notebook_webelement} =  Get WebElement  xpath://a[contains(@id,"${notebook_image}")]
-   Wait Until Element Is Visible  ${notebook_webelement}
-   Click Element  ${notebook_webelement}
-   ${selected_notebook} =  Get Text  id:ImageDropdownBtn
-   Should Start With  ${selected_notebook}  ${notebook_image}
+   Click Element  xpath://input[contains(@id, "${notebook_image}")]
+   #${notebook_webelement} =  Get WebElement  xpath://a[contains(@id,"${notebook_image}")]
+   #Wait Until Element Is Visible  ${notebook_webelement}
+   #Click Element  ${notebook_webelement}
+   #${selected_notebook} =  Get Text  id:ImageDropdownBtn
+   #Should Start With  ${selected_notebook}  ${notebook_image}
 
 Select Container Size
    [Documentation]  Selects the container size based on the ${container_size} argument
@@ -35,11 +38,16 @@ Set Number of required GPUs
 Add Spawner Environment Variable
    [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
    [Arguments]  ${env_var}  ${env_var_value}
-   Click Button  Add
-   Input Text  id:KeyForm-  ${env_var}
-   Element Attribute Value Should Be  name:${env_var}  value  ${env_var}
-   Input Text  id:ValueForm-${env_var}  ${env_var_value}
-   Element Attribute Value Should Be  id:ValueForm-${env_var}  value  ${env_var_value}
+   Click Button  Add more variables
+   Input Text  xpath://input[@id="---NO KEY---"]  ${env_var}
+   Element Attribute Value Should Be  xpath://input[@id="${env_var}"]  value  ${env_var}
+   Input Text  xpath://input[@id="${env_var}-value"]  ${env_var_value}
+   Element Attribute Value Should Be  xpath://input[@id="${env_var}-value"]  value  ${env_var_value}
+   #Click Button  Add
+   #Input Text  id:KeyForm-  ${env_var}
+   #Element Attribute Value Should Be  name:${env_var}  value  ${env_var}
+   #Input Text  id:ValueForm-${env_var}  ${env_var_value}
+   #Element Attribute Value Should Be  id:ValueForm-${env_var}  value  ${env_var_value}
 
 Remove Spawner Environment Variable
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument
@@ -60,7 +68,7 @@ Get Spawner Environment Variable Value
 Spawn Notebook
    [Documentation]  Start the notebook pod spawn and wait ${spawner_timeout} seconds (DEFAULT: 600s)
    [Arguments]  ${spawner_timeout}=600 seconds
-   Click Button  Start
+   Click Button  Start server
    Wait Until Page Contains  Your server is starting up
    Wait Until Element is Visible  id:progress-bar
    Wait Until Page Does Not Contain Element  id:progress-bar  ${spawner_timeout}

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -36,10 +36,10 @@ Add Spawner Environment Variable
    [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
    [Arguments]  ${env_var}  ${env_var_value}
    Click Button  Add
-   Input Text  id:KeyForm-  ${env_var}
+   Input Text  xpath=//div[@id='EnvVarContainer']/div/div/div/input  ${env_var}
    Element Attribute Value Should Be  name:${env_var}  value  ${env_var}
-   Input Text  id:ValueForm-${env_var}  ${env_var_value}
-   Element Attribute Value Should Be  id:ValueForm-${env_var}  value  ${env_var_value}
+   Input Text  xpath=//div[@id='EnvVarContainer']/div/div/input  ${env_var_value}
+   Element Attribute Value Should Be  xpath=//div[@id='EnvVarContainer']/div/div/input  value  ${env_var_value}
 
 Remove Spawner Environment Variable
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -36,10 +36,10 @@ Add Spawner Environment Variable
    [Documentation]  Adds a new environment variables based on the ${env_var} ${env_var_value} arguments
    [Arguments]  ${env_var}  ${env_var_value}
    Click Button  Add
-   Input Text  xpath=//div[@id='EnvVarContainer']/div/div/div/input  ${env_var}
+   Input Text  id:KeyForm-  ${env_var}
    Element Attribute Value Should Be  name:${env_var}  value  ${env_var}
-   Input Text  xpath=//div[@id='EnvVarContainer']/div/div/input  ${env_var_value}
-   Element Attribute Value Should Be  xpath=//div[@id='EnvVarContainer']/div/div/input  value  ${env_var_value}
+   Input Text  id:ValueForm-${env_var}  ${env_var_value}
+   Element Attribute Value Should Be  id:ValueForm-${env_var}  value  ${env_var_value}
 
 Remove Spawner Environment Variable
    [Documentation]  Removes an existing environment variable based on the ${env_var} argument

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -84,7 +84,6 @@ Logout JupyterLab
 Run Cell And Check For Errors
   [Arguments]  ${input}
   Add and Run JupyterLab Code Cell  ${input}
-  Sleep  1
   Wait Until JupyterLab Code Cell Is Not Active
   #Get the text of the last output cell
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
@@ -97,3 +96,4 @@ Run Cell And Check Output
   #Get the text of the last output cell
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
   Should Match  ${output}  ${expected_output}
+  

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -60,16 +60,16 @@ Wait Until JupyterLab Code Cell Is Not Active
 Select Empty JupyterLab Code Cell
   Click Element  //div[contains(@class,"jp-mod-noOutputs jp-Notebook-cell")]
 
-Open JupyterHub Control Panel
-  Wait Until Page Contains Element  link:Control Panel
-  Click Link  Control Panel
-
 Start JupyterLab Notebook Server
   Open JupyterHub Control Panel
   Click Link  start
 
+Open JupyterLab Control Panel
+  Open With JupyterLab Menu  File  Hub Control Panel
+  Switch Window  JupyterHub
+  
 Stop JupyterLab Notebook Server
-  Open JupyterHub Control Panel
+  Open JupyterLab Control Panel
   Wait Until Page Contains  Stop My Server  30 seconds
   # This is a dumb sleep to give the Stop button in the WebUI time to actually work when clicked
   #TODO: Determine if there is any web element attribute that will allow signify when the Stop button will actually work

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -97,3 +97,15 @@ Run Cell And Check Output
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
   Should Match  ${output}  ${expected_output}
   
+Maybe Select Kernel  
+  ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
+  Run Keyword If  not ${is_kernel_selected}  Click Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
+
+Clean Up Server
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  Untitled.ipynb
+  Click Element  xpath://div[.="Open"]
+  Wait Until Untitled.ipynb JupyterLab Tab Is Selected
+  Close Other JupyterLab Tabs
+  Add and Run JupyterLab Code Cell  !rm -rf *
+

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -80,3 +80,20 @@ Stop JupyterLab Notebook Server
 
 Logout JupyterLab
   Open With JupyterLab Menu  File  Log Out
+
+Run Cell And Check For Errors
+  [Arguments]  ${input}
+  Add and Run JupyterLab Code Cell  ${input}
+  Sleep  1
+  Wait Until JupyterLab Code Cell Is Not Active
+  #Get the text of the last output cell
+  ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
+  Should Not Match  ${output}  ERROR*
+
+Run Cell And Check Output
+  [Arguments]  ${input}  ${expected_output}
+  Add and Run JupyterLab Code Cell  ${input}
+  Wait Until JupyterLab Code Cell Is Not Active
+  #Get the text of the last output cell
+  ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
+  Should Match  ${output}  ${expected_output}

--- a/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
@@ -3,7 +3,7 @@ Library  JupyterLibrary
 
 *** Keywords ***
 Launch Jupyterhub
-   Wait Until Page Contains  Networking  timeout=15
+   Wait Until Page Contains  Networking  timeout=30
    Click Button  Networking
    Wait Until Page Contains  Routes  timeout=15
    Click Link  Routes

--- a/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
@@ -3,7 +3,7 @@ Library  JupyterLibrary
 
 *** Keywords ***
 Launch Jupyterhub
-   Wait Until Page Contains  Networking
+   Wait Until Page Contains  Networking  timeout=15
    Click Button  Networking
    Wait Until Page Contains  Routes  timeout=15
    Click Link  Routes

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -16,6 +16,9 @@ Login To ODH Dashboard
    ${authorize_service_account} =  Is odh-dashboard Service Account Authorization Required
    Run Keyword If  ${authorize_service_account}  Authorize odh-dashboard service account
 
+Wait for ODH Dashboard to Load
+  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
+
 Wait Until ODH Dashboard ${dashboard_app} Is Visible
   # Ideally the timeout would be an arg but Robot does not allow "normal" and "embedded" arguments
   # Setting timeout to 10seconds since anything beyond that should be flagged as a UI bug 

--- a/tests/Tests/test-installation.robot
+++ b/tests/Tests/test-installation.robot
@@ -11,6 +11,7 @@ Suite Teardown  Close Browser
 
 *** Test Cases ***
 Can Install ODH Operator
+  [Tags]  TBC
   Open OperatorHub
   Install ODH Operator
   ODH Operator Should Be Installed

--- a/tests/Tests/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/test-jupyterlab-git-notebook.robot
@@ -1,6 +1,9 @@
 *** Settings ***
-Resource  ../Resources/ODS.robot
-Library         DebugLibrary
+Resource         ../Resources/ODS.robot
+Resource         ../Resources/Common.robot
+Library          DebugLibrary
+Suite Setup      Begin Web Test
+Suite Teardown   End Web Test
 
 *** Variables ***
 
@@ -8,9 +11,8 @@ Library         DebugLibrary
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
+  Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
@@ -28,15 +30,13 @@ Can Spawn Notebook
   ${spawner_visible} =  JupyterHub Spawner Is Visible
   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
   Select Notebook Image  s2i-generic-data-science-notebook
-  #This env is required until JupyterLab is the default interface in RHODS
-  Add Spawner Environment Variable  JUPYTER_ENABLE_LAB  true
   Spawn Notebook
 
 Can Launch Python3 Smoke Test Notebook
   [Tags]  Sanity
 
   Wait for JupyterLab Splash Screen
-
+  Maybe Select Kernel
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
   Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
   Launch a new JupyterLab Document
@@ -46,6 +46,7 @@ Can Launch Python3 Smoke Test Notebook
   ##################################################
   # Manual Notebook Input
   ##################################################
+  Sleep  5
   Add and Run JupyterLab Code Cell  !pip install boto3
   Wait Until JupyterLab Code Cell Is Not Active
   #Get the text of the last output cell

--- a/tests/Tests/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/test-jupyterlab-git-notebook.robot
@@ -62,11 +62,8 @@ Can Launch Python3 Smoke Test Notebook
   # Git clone repo and run existing notebook
   ##################################################
   Maybe Open JupyterLab Sidebar  File Browser
-  Sleep  1
   Navigate Home In JupyterLab Sidebar
-  Sleep  1
   Open With JupyterLab Menu  Git  Clone a Repository
-  Sleep  1
   Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/sophwats/notebook-smoke-test
   Click Element  xpath://div[.="CLONE"]
 

--- a/tests/Tests/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/test-jupyterlab-git-notebook.robot
@@ -27,7 +27,9 @@ Can Spawn Notebook
   # We need to skip this testcase if the user has an existing pod
   ${spawner_visible} =  JupyterHub Spawner Is Visible
   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
-  Select Notebook Image  s2i-lab-elyra
+  Select Notebook Image  s2i-generic-data-science-notebook
+  #This env is required until JupyterLab is the default interface in RHODS
+  Add Spawner Environment Variable  JUPYTER_ENABLE_LAB  true
   Spawn Notebook
 
 Can Launch Python3 Smoke Test Notebook

--- a/tests/Tests/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/test-jupyterlab-git-notebook.robot
@@ -10,7 +10,7 @@ Open ODH Dashboard
   [Tags]  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Open Data Hub Dashboard"
+  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
 
 Can Launch Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/test-jupyterlab-notebook.robot
+++ b/tests/Tests/test-jupyterlab-notebook.robot
@@ -13,7 +13,7 @@ Open ODH Dashboard
   [Tags]  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Open Data Hub Dashboard"
+  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
 
 Can Launch Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/test-jupyterlab-notebook.robot
+++ b/tests/Tests/test-jupyterlab-notebook.robot
@@ -2,6 +2,9 @@
 Resource  ../Resources/ODS.robot
 Library         DebugLibrary
 
+Suite Teardown  Stop JupyterLab Notebook Server
+
+
 *** Variables ***
 
 
@@ -27,7 +30,9 @@ Can Spawn Notebook
   # We need to skip this testcase if the user has an existing pod
   ${spawner_visible} =  JupyterHub Spawner Is Visible
   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
-  Select Notebook Image  s2i-lab-elyra
+  Select Notebook Image  s2i-generic-data-science-notebook
+  #This env is required until JupyterLab is the default interface in RHODS
+  Add Spawner Environment Variable  JUPYTER_ENABLE_LAB  true
   Spawn Notebook
 
 Can Launch Python3 Smoke Test Notebook
@@ -37,6 +42,7 @@ Can Launch Python3 Smoke Test Notebook
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
   Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
   Launch a new JupyterLab Document
+  Close Other JupyterLab Tabs
 
   Add and Run JupyterLab Code Cell  import os
   Add and Run JupyterLab Code Cell  print("Hello World!")
@@ -51,6 +57,3 @@ Can Launch Python3 Smoke Test Notebook
   #Get the text of the last output cell
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
   Should Not Match  ${output}  ERROR*
-
-  Close All JupyterLab Tabs
-  Logout JupyterLab

--- a/tests/Tests/test-jupyterlab-notebook.robot
+++ b/tests/Tests/test-jupyterlab-notebook.robot
@@ -1,8 +1,10 @@
 *** Settings ***
-Resource  ../Resources/ODS.robot
-Library         DebugLibrary
+Resource         ../Resources/ODS.robot
+Resource         ../Resources/Common.robot
+Library          DebugLibrary
 
-Suite Teardown  Stop JupyterLab Notebook Server
+Suite Setup      Begin Web Test
+Suite Teardown   End Web Test
 
 
 *** Variables ***
@@ -11,9 +13,8 @@ Suite Teardown  Stop JupyterLab Notebook Server
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
+  Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
@@ -31,14 +32,13 @@ Can Spawn Notebook
   ${spawner_visible} =  JupyterHub Spawner Is Visible
   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
   Select Notebook Image  s2i-generic-data-science-notebook
-  #This env is required until JupyterLab is the default interface in RHODS
-  Add Spawner Environment Variable  JUPYTER_ENABLE_LAB  true
   Spawn Notebook
 
 Can Launch Python3 Smoke Test Notebook
   [Tags]  Sanity
 
   Wait for JupyterLab Splash Screen
+  Maybe Select Kernel
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
   Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
   Launch a new JupyterLab Document

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -1,7 +1,10 @@
 *** Settings ***
-Resource  ../Resources/ODS.robot
+Resource        ../Resources/ODS.robot
+Resource        ../Resources/Common.robot
 Library         DebugLibrary
 Library         JupyterLibrary
+Suite Setup      Begin Web Test
+Suite Teardown   End Web Test
 
 *** Variables ***
 
@@ -9,7 +12,7 @@ Library         JupyterLibrary
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  #Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait For Condition  return document.title == "Open Data Hub Dashboard"
 
@@ -95,4 +98,9 @@ Can Launch Python3 Smoke Test Notebook
   Should Not Match  ${output}  ERROR*
   Should Be Equal As Strings  ${output}  [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, 0.9116818405511811]
 
-  Logout JupyterLab
+  # Clean up workspace for next run
+  Open With JupyterLab Menu  File  Open from Path…
+  Sleep  1
+  Input Text  xpath=/html/body/div[3]/div/div[1]/input  Untitled.ipynb
+  Click Element  xpath://div[.="Open"]
+  Run Cell And Check For Errors  !rm -rf *

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -14,7 +14,7 @@ Open ODH Dashboard
   [Tags]  Sanity
   #Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Open Data Hub Dashboard"
+  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
 
 Can Launch Jupyterhub
   [Tags]  Sanity
@@ -41,6 +41,8 @@ Can Launch Python3 Smoke Test Notebook
 
   Wait for JupyterLab Splash Screen
 
+
+  # Sometimes we get a modal pop-up upon server spawn asking to select a kernel for the notebooks
   ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
   Run Keyword If  not ${is_kernel_selected}  Click Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
 
@@ -81,6 +83,7 @@ Can Launch Python3 Smoke Test Notebook
   Add and Run JupyterLab Code Cell  !git clone https://github.com/lugi0/minimal-nb-image-test
   # TODO
   # Ensure output cell doesn't contain fatal: ... ?
+  # Should be using the git plugin anyway
 
   #When cloning from inside a notebook cell it takes a while for the folder to appear
   Sleep  10
@@ -101,6 +104,7 @@ Can Launch Python3 Smoke Test Notebook
   Should Be Equal As Strings  ${output}  [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, 0.9116818405511811]
 
   # Clean up workspace for next run
+  # Might make sense to abstract it into a single Keyword
   Open With JupyterLab Menu  File  Open from Path…
   Sleep  1
   Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  Untitled.ipynb

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -63,7 +63,7 @@ Can Launch Python3 Smoke Test Notebook
   Run Cell And Check Output  print("Hello World!")  Hello World!
 
   #Needs to change for RHODS release
-  Run Cell And Check Output  !python --version  Python 3.6.8
+  Run Cell And Check Output  !python --version  Python 3.8.3
   #Run Cell And Check Output  !python --version  Python 3.8.7
 
   Capture Page Screenshot

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -41,12 +41,12 @@ Can Launch Python3 Smoke Test Notebook
 
   Wait for JupyterLab Splash Screen
 
+  ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
+  Run Keyword If  not ${is_kernel_selected}  Click Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
+
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
   Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
   Launch a new JupyterLab Document
-  
-  ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=/html/body/div[3]
-  Run Keyword If  not ${is_kernel_selected}  Click Button  xpath=/html/body/div[3]/div/div[2]/button[2]
 
   Close Other JupyterLab Tabs
 
@@ -79,18 +79,20 @@ Can Launch Python3 Smoke Test Notebook
   #The above doesn't work currently since the git plugin is not available
   #In the minimal image
   Add and Run JupyterLab Code Cell  !git clone https://github.com/lugi0/minimal-nb-image-test
+  # TODO
+  # Ensure output cell doesn't contain fatal: ... ?
 
   #When cloning from inside a notebook cell it takes a while for the folder to appear
   Sleep  10
   Open With JupyterLab Menu  File  Open from Path…
-  Input Text  xpath=/html/body/div[3]/div/div[1]/input  minimal-nb-image-test/minimal-nb.ipynb
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  minimal-nb-image-test/minimal-nb.ipynb
   Click Element  xpath://div[.="Open"]
 
   Wait Until minimal-nb.ipynb JupyterLab Tab Is Selected
   Close Other JupyterLab Tabs
 
   Open With JupyterLab Menu  Run  Run All Cells
-  Wait Until JupyterLab Code Cell Is Not Active
+  Wait Until JupyterLab Code Cell Is Not Active  timeout=300
   JupyterLab Code Cell Error Output Should Not Be Visible
 
   #Get the text of the last output cell
@@ -101,6 +103,8 @@ Can Launch Python3 Smoke Test Notebook
   # Clean up workspace for next run
   Open With JupyterLab Menu  File  Open from Path…
   Sleep  1
-  Input Text  xpath=/html/body/div[3]/div/div[1]/input  Untitled.ipynb
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  Untitled.ipynb
   Click Element  xpath://div[.="Open"]
-  Run Cell And Check For Errors  !rm -rf *
+  Wait Until Untitled.ipynb JupyterLab Tab Is Selected
+  Close Other JupyterLab Tabs
+  Add and Run JupyterLab Code Cell  !rm -rf *

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -1,8 +1,8 @@
 *** Settings ***
-Resource        ../Resources/ODS.robot
-Resource        ../Resources/Common.robot
-Library         DebugLibrary
-Library         JupyterLibrary
+Resource         ../Resources/ODS.robot
+Resource         ../Resources/Common.robot
+Library          DebugLibrary
+Library          JupyterLibrary
 Suite Setup      Begin Web Test
 Suite Teardown   End Web Test
 
@@ -12,9 +12,8 @@ Suite Teardown   End Web Test
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  #Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait For Condition  return document.title == "Red Hat OpenShift Data Science Dashboard"
+  Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
@@ -32,19 +31,16 @@ Can Spawn Notebook
   ${spawner_visible} =  JupyterHub Spawner Is Visible
   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
   Select Notebook Image  s2i-minimal-notebook
-  #This env is required until JupyterLab is the default interface in RHODS
-  Add Spawner Environment Variable  JUPYTER_ENABLE_LAB  true
   Spawn Notebook
 
-Can Launch Python3 Smoke Test Notebook
+Can Execute Minimal Image Test
   [Tags]  Sanity
 
   Wait for JupyterLab Splash Screen
 
 
   # Sometimes we get a modal pop-up upon server spawn asking to select a kernel for the notebooks
-  ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
-  Run Keyword If  not ${is_kernel_selected}  Click Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
+  Maybe Select Kernel
 
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
   Run Keyword If  not ${is_launcher_selected}  Open JupyterLab Launcher
@@ -72,21 +68,12 @@ Can Launch Python3 Smoke Test Notebook
   ##################################################
   # Git clone repo and run existing notebook
   ##################################################
-  #Maybe Open JupyterLab Sidebar  File Browser
-  #Navigate Home In JupyterLab Sidebar
-  #Open With JupyterLab Menu  Git  Clone a Repository
-  #Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/lugi0/minimal-nb-image-test
-  #Click Element  xpath://div[.="CLONE"]
+  Maybe Open JupyterLab Sidebar  File Browser
+  Navigate Home In JupyterLab Sidebar
+  Open With JupyterLab Menu  Git  Clone a Repository
+  Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/lugi0/minimal-nb-image-test
+  Click Element  xpath://div[.="CLONE"]
 
-  #The above doesn't work currently since the git plugin is not available
-  #In the minimal image
-  Add and Run JupyterLab Code Cell  !git clone https://github.com/lugi0/minimal-nb-image-test
-  # TODO
-  # Ensure output cell doesn't contain fatal: ... ?
-  # Should be using the git plugin anyway
-
-  #When cloning from inside a notebook cell it takes a while for the folder to appear
-  Sleep  10
   Open With JupyterLab Menu  File  Open from Path…
   Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  minimal-nb-image-test/minimal-nb.ipynb
   Click Element  xpath://div[.="Open"]
@@ -103,12 +90,3 @@ Can Launch Python3 Smoke Test Notebook
   Should Not Match  ${output}  ERROR*
   Should Be Equal As Strings  ${output}  [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, 0.9116818405511811]
 
-  # Clean up workspace for next run
-  # Might make sense to abstract it into a single Keyword
-  Open With JupyterLab Menu  File  Open from Path…
-  Sleep  1
-  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  Untitled.ipynb
-  Click Element  xpath://div[.="Open"]
-  Wait Until Untitled.ipynb JupyterLab Tab Is Selected
-  Close Other JupyterLab Tabs
-  Add and Run JupyterLab Code Cell  !rm -rf *

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -36,6 +36,8 @@ Can Spawn Notebook
 Can Execute Minimal Image Test
   [Tags]  Sanity
 
+  # We need to send a PR to https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/master/src/JupyterLibrary/clients/jupyterlab/Shell.robot
+  # To increase the timeout here.
   Wait for JupyterLab Splash Screen
 
 

--- a/tests/Tests/test-uninstall.robot
+++ b/tests/Tests/test-uninstall.robot
@@ -16,6 +16,7 @@ Suite Teardown  Close Browser
 
 *** Test Cases ***
 Can Uninstall ODH Operator
+  [Tags]  TBC
   Open Installed Operators
   Uninstall ODH Operator
   ODH Operator Should Be Uninstalled

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -26,9 +26,10 @@ Can Spawn Notebook
    # We need to skip this testcase if the user has an existing pod
    ${spawner_visible} =  JupyterHub Spawner Is Visible
    Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
+   Select Notebook Image  s2i-generic-data-science-notebook
    Select Notebook Image  s2i-minimal-notebook
-   Select Notebook Image  s2i-scipy-notebook
-   Select Notebook Image  s2i-tensorflow-notebook
+   #Select Notebook Image  s2i-scipy-notebook
+   #Select Notebook Image  s2i-tensorflow-notebook
    Select Container Size  Small
    Set Number of required GPUs  9
    Set Number of required GPUs  0

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -31,8 +31,9 @@ Can Spawn Notebook
    Select Notebook Image  s2i-generic-data-science-notebook
    Select Notebook Image  s2i-minimal-notebook
    Select Container Size  Small
-   Set Number of required GPUs  9
-   Set Number of required GPUs  0
+   # Cannot set number of required GPUs on clusters without GPUs anymore
+   #Set Number of required GPUs  9
+   #Set Number of required GPUs  0
    Add Spawner Environment Variable  env_one  one
    Remove Spawner Environment Variable  env_one
    Add Spawner Environment Variable  env_two  two

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -1,6 +1,8 @@
 *** Settings ***
-Resource  ../Resources/ODS.robot
-Library         DebugLibrary
+Library          DebugLibrary
+Resource         ../Resources/ODS.robot
+Resource         ../Resources/Common.robot
+Suite Teardown   End Web Test
 
 *** Variables ***
 
@@ -28,8 +30,6 @@ Can Spawn Notebook
    Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
    Select Notebook Image  s2i-generic-data-science-notebook
    Select Notebook Image  s2i-minimal-notebook
-   #Select Notebook Image  s2i-scipy-notebook
-   #Select Notebook Image  s2i-tensorflow-notebook
    Select Container Size  Small
    Set Number of required GPUs  9
    Set Number of required GPUs  0
@@ -47,9 +47,12 @@ Can Spawn Notebook
    Remove Spawner Environment Variable  env_five
    Remove Spawner Environment Variable  env_six
    Spawn Notebook
+   Wait for JupyterLab Splash Screen
+   Launch a new JupyterLab Document
+   Close Other JupyterLab Tabs
 
 Can Launch Python3
-   [Tags]  Sanity
+   [Tags]  Sanity  TBC
    Launch Python3 JupyterHub
 
 


### PR DESCRIPTION
This PR aims to refactor all suites inside of the `Tests` folder and clean up UI-related code and keywords so that it becomes easier to update in case of breaking changes.
I also propose to use a specific tag to exclude test cases from running, so that we can move away from running `test.robot` by default and instead run all suites in the `Tests` folder. This will enable us to actually test a PR via Jenkins and hit the code that has been committed in the PR. In this WIP I have used `TBC` as a tag (as in, To Be Confirmed if we want to update/maintain these tests, e.g. install/uninstall IMHO should be tested via Pablo's work until the operator is available for install via GUI).
@LaVLaS @vasukulkarni 