### PR TITLE
Adding sleep after clicking JH link from console to give the page time to load

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
@@ -15,4 +15,5 @@ Launch Jupyterhub
    Input Text  xpath://input[@data-test-id="item-filter"]  jupyterhub
    Wait Until Page Contains  jupyterhub  timeout=15
    Click Element  partial link:https://jupyterhub
+   Sleep  10s
    Switch Window  JupyterHub


### PR DESCRIPTION
Adding sleep after clicking JH link from console to give the page time to load.  It was failing for me consistently on my cluster without the sleep to give it time to load.