### PR TITLE
Add Keyword to fix spawner status

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -1,10 +1,22 @@
 *** Settings ***
 Library   JupyterLibrary
 Resource  Page/ODH/JupyterHub/JupyterLabLauncher.robot
+Resource  Page/ODH/JupyterHub/JupyterHubSpawner.robot
 
 *** Keywords ***
 Begin Web Test
+    [Documentation]  This keyword should be used as a Suite Setup; it will log in to the
+    ...              ODH dashboard, checking that the spawner is in a ready state before 
+    ...              handing control over to the test suites.
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+    Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Wait for ODH Dashboard to Load
+    Launch JupyterHub From ODH Dashboard Dropdown
+    Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    ${authorization_required} =  Is Service Account Authorization Required
+    Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
+    Fix Spawner Status
+    Go To  ${ODH_DASHBOARD_URL}
 
 End Web Test
     ${server} =  Run Keyword and Return Status  Page Should Contain Element  //div[@id='jp-top-panel']//div[contains(@class, 'p-MenuBar-itemLabel')][text() = 'File']

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -108,3 +108,7 @@ Clean Up Server
   Wait Until Untitled.ipynb JupyterLab Tab Is Selected
   Close Other JupyterLab Tabs
   Add and Run JupyterLab Code Cell  !rm -rf *
+
+JupyterLab Is Visible
+  ${spawner_visible} =  Run Keyword and Return Status  Wait Until Element Is Visible  xpath:${JL_TABBAR_CONTENT_XPATH}  timeout=20
+  [return]  ${spawner_visible}

--- a/tests/Tests/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/test-jupyterlab-git-notebook.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource         ../Resources/ODS.robot
 Resource         ../Resources/Common.robot
+Resource         ../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Library          DebugLibrary
 Suite Setup      Begin Web Test
 Suite Teardown   End Web Test
@@ -11,7 +12,6 @@ Suite Teardown   End Web Test
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
@@ -26,9 +26,7 @@ Can Login to Jupyterhub
 
 Can Spawn Notebook
   [Tags]  Sanity
-  # We need to skip this testcase if the user has an existing pod
-  ${spawner_visible} =  JupyterHub Spawner Is Visible
-  Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
+  Fix Spawner Status
   Select Notebook Image  s2i-generic-data-science-notebook
   Spawn Notebook
 

--- a/tests/Tests/test-jupyterlab-notebook.robot
+++ b/tests/Tests/test-jupyterlab-notebook.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource         ../Resources/ODS.robot
 Resource         ../Resources/Common.robot
+Resource         ../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Library          DebugLibrary
 
 Suite Setup      Begin Web Test
@@ -13,7 +14,6 @@ Suite Teardown   End Web Test
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
@@ -29,8 +29,7 @@ Can Login to Jupyterhub
 Can Spawn Notebook
   [Tags]  Sanity
   # We need to skip this testcase if the user has an existing pod
-  ${spawner_visible} =  JupyterHub Spawner Is Visible
-  Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
+  Fix Spawner Status
   Select Notebook Image  s2i-generic-data-science-notebook
   Spawn Notebook
 

--- a/tests/Tests/test-minimal-image.robot
+++ b/tests/Tests/test-minimal-image.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Resource         ../Resources/ODS.robot
 Resource         ../Resources/Common.robot
+Resource         ../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Library          DebugLibrary
 Library          JupyterLibrary
 Suite Setup      Begin Web Test
@@ -12,7 +13,6 @@ Suite Teardown   End Web Test
 *** Test Cases ***
 Open ODH Dashboard
   [Tags]  Sanity
-  Login To ODH Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for ODH Dashboard to Load
 
 Can Launch Jupyterhub
@@ -27,9 +27,7 @@ Can Login to Jupyterhub
 
 Can Spawn Notebook
   [Tags]  Sanity
-  # We need to skip this testcase if the user has an existing pod
-  ${spawner_visible} =  JupyterHub Spawner Is Visible
-  Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
+  Fix Spawner Status
   Select Notebook Image  s2i-minimal-notebook
   Spawn Notebook
 

--- a/tests/Tests/test.robot
+++ b/tests/Tests/test.robot
@@ -2,6 +2,7 @@
 Library          DebugLibrary
 Resource         ../Resources/ODS.robot
 Resource         ../Resources/Common.robot
+Resource         ../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Suite Teardown   End Web Test
 
 *** Variables ***
@@ -25,9 +26,7 @@ Can Login to Jupyterhub
 
 Can Spawn Notebook
    [Tags]  Sanity
-   # We need to skip this testcase if the user has an existing pod
-   ${spawner_visible} =  JupyterHub Spawner Is Visible
-   Skip If  ${spawner_visible}!=True  The user has an existing notebook pod running
+   Fix Spawner Status
    Select Notebook Image  s2i-generic-data-science-notebook
    Select Notebook Image  s2i-minimal-notebook
    Select Container Size  Small


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

Sometimes the spawner page will be in an undesirable state. That happened this morning and caused a Sanity run failure (https://opendatascience-jenkins-csb-rhods.apps.ocp4.prod.psi.redhat.com/job/rhods-sanity/96/).

This PR adds a keyword to deal with such states, and integrates it both in the Suite Setup (so that before kicking off any tests we ensure we are in the correct state) and during execution of the test suites we currently have.

I've tested this to the best of my ability and it seems to handle all "bad" states that I know of, but getting to these reliably is not easy (or, at the very least, not easy for me). It would be nice if before merging everyone could try running this PR locally to ensure that it works for everyone and on every cluster. If you can, also try to force a bad state for the spawner (e.g. "Server not running", "Server is stopping" etc.).