### PR TITLE
Add robotframework-lsp dependency in requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,1 @@
+robotframework-lsp


### PR DESCRIPTION
It is a requirement for running PyCharm's Robot Framework Language Server Plugin

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>