### PR TITLE
Fix billing metrics tests (datapoints found error) and disable checking removed prometheus rule

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Monitoring/Metrics.robot
+++ b/tests/Resources/Page/OCPDashboard/Monitoring/Metrics.robot
@@ -11,9 +11,7 @@ Verify Page Loaded
   Wait Until Page Contains Element  ${METRICS_QUERY_TEXTAREA}  timeout=20
 
 Verify Query Results Contain Data
-  Page Should Not Contain   No datapoints found.
-  Wait Until Page Contains Element  ${METRICS_QUERY_RESULTS_TABLE_ROW1_VALUE_ELEMENT}  timeout=20
-  Page Should Contain Element    ${METRICS_QUERY_RESULTS_TABLE_ROW1_VALUE_ELEMENT}   "Query results don't contain data"
+  Wait Until Page Contains Element  ${METRICS_QUERY_RESULTS_TABLE_ROW1_VALUE_ELEMENT}  timeout=20  error="Query results don't contain data"
   ${metrics_query_result_row1_value} =   Get Text  ${METRICS_QUERY_RESULTS_TABLE_ROW1_VALUE_ELEMENT}
   Should Be True    '${metrics_query_result_row1_value}' != ''   "Query results don't contain data"
   Should Be True    '${metrics_query_result_row1_value}' != 'None'   "Query results don't contain data"
@@ -23,10 +21,21 @@ Verify Query Results Dont Contain Data
   Should Be True   not ${metrics_query_results_contain_data}
 
 Run Query
-  [Arguments]  ${query}
+  [Arguments]  ${query}  ${retry-attempts}=10
+  Wait Until Page Contains Element    ${METRICS_QUERY_TEXTAREA}  timeout=30
   Input Text   ${METRICS_QUERY_TEXTAREA}  ${query}
-  Press Keys   ${METRICS_QUERY_TEXTAREA}    ENTER
-  Wait Until Page Does Not Contain    No query entered  timeout=20
+
+  ${end-range}=   Evaluate    ${retry-attempts} + 1
+  FOR    ${counter}    IN RANGE    1    ${end-range}
+      Press Keys   ${METRICS_QUERY_TEXTAREA}    ENTER
+      Sleep  5  reason=Wait for query results
+      ${metrics_query_results_contain_data} =  Run Keyword and Return Status   Verify Query Results Contain Data
+      Capture Page Screenshot
+      Exit For Loop If   ${metrics_query_results_contain_data}
+      Exit For Loop If   ${counter} == ${retry-attempts}
+      Sleep  60  reason=Wait until metrics are available
+  END
+
 
 Get Query Results
   ${metrics_query_results_contain_data} =  Run Keyword and Return Status   Verify Query Results Contain Data

--- a/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -3,7 +3,7 @@ Resource    ../../../Resources/ODS.robot
 
 *** Variables ***
 
-@{RECORD_GROUPS}  Availability Metrics  SLOs - JupyterHub  SLOs - JupyterHub DB  SLOs - ODH Dashboard  SLOs - RHODS Operator  SLOs - Traefik Proxy  Usage Metrics
+@{RECORD_GROUPS}  Availability Metrics  SLOs - JupyterHub  SLOs - ODH Dashboard  SLOs - RHODS Operator  SLOs - Traefik Proxy  Usage Metrics
 
 @{ALERT_GROUPS}  Builds  DeadManSnitch  RHODS-PVC-Usage  SLOs-haproxy_backend_http_responses_total  SLOs-probe_success
 


### PR DESCRIPTION
Sometimes, when we run a metrics query in OpenShift Monitoring, we get "no datapoints found" as a result. If we wait a few minutes and run the same query we get the result.

This PR adds retries to the "Run Query" keyword to avoid having this issue and also makes the Test Suite Teardown more reliable

This PR also fixes test ODS-510 after the rule _SLOs - JupyterHub DB_ was removed in build 1.1.1-41
