### PR TITLE
[WIP] ODS-518 test

### DIFF
--- a/test-variables.yml.example
+++ b/test-variables.yml.example
@@ -3,6 +3,7 @@ BROWSER:
   # List of Chrome options - https://peter.sh/experiments/chromium-command-line-switches/
   # --disable-dev-shm-usage  and --no-sandbox are required for running chromedriver in a container
   OPTIONS: add_argument("--ignore-certificate-errors");add_argument("window-size=1920,1024");add_argument("--disable-dev-shm-usage");add_argument("--no-sandbox")
+OSD_CLUSTERMGMT_URL: "https://console.redhat.com/openshift/details/s/SoMeClUsTeRiDhAsH"
 OCP_CONSOLE_URL: "http://console-openshift-console.apps.my-cluster.test.redhat.com/"
 ODH_DASHBOARD_URL: "http://odh-dashboard-opendatahub.apps.my-cluster.test.redhat.com/"
 TEST_USER:
@@ -13,6 +14,9 @@ OCP_ADMIN_USER:
   AUTH_TYPE: "kube:admin"
   USERNAME: kubeadmin
   PASSWORD: abc123XYZ!
+RED_HAT_USER:
+  USERNAME: rhuser-with-subscription@redhat.com
+  PASSWORD: red-hat-account-password
 S3:
   AWS_ACCESS_KEY_ID: ID-value
   AWS_SECRET_ACCESS_KEY: Secret-Key

--- a/tests/Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
+++ b/tests/Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
@@ -13,6 +13,9 @@ Open OperatorHub
 Install ODH Operator
     Install Operator    opendatahub
 
+Install RHODS Operator
+    Install Operator    rhods
+
 Open OCP Console
     Open Page    ${OCP_CONSOLE_URL}
 
@@ -24,3 +27,6 @@ OperatorHub Should Be Open
 
 ODH Operator Should Be Installed
     Operator Should Be Installed    Open Data Hub Operator
+
+RHODS Operator Should Be installed
+    Operator Should Be Installed    Red Hat OpenShift Data Science

--- a/tests/Resources/Page/OSD/ClusterManagement/ClusterManagement.resource
+++ b/tests/Resources/Page/OSD/ClusterManagement/ClusterManagement.resource
@@ -1,0 +1,3 @@
+*** Settings ***
+Resource  LoginOSD.robot
+Resource  InstallAddon.robot

--- a/tests/Resources/Page/OSD/ClusterManagement/InstallAddon.robot
+++ b/tests/Resources/Page/OSD/ClusterManagement/InstallAddon.robot
@@ -1,0 +1,50 @@
+*** Settings ***
+Resource   ../../Components/Components.resource
+Resource   LoginOSD.robot
+
+
+*** Keywords ***
+Open ClusterManagement
+    [Arguments]  ${osd_user_name}  ${osd_user_password}
+    Open OSD Cluster Manager
+    Login To OSD  ${osd_user_name}  ${osd_user_password}
+
+Open AddOns Tab
+  ${addonstab} =  Set Variable  ${OSD_CLUSTERMGMT_URL}#addOns
+  Go To  ${addonstab}
+
+Install RHODS Operator From AddOns
+  [Arguments]  ${notification-email-list}
+  Wait Until Page Contains  Red Hat OpenShift Data Science
+  Click Element  //div[contains(text(), "Red Hat OpenShift Data Science")]
+  ${addon_already_installed} =  Run Keyword And Return Status  Check if Selected AddOn Installed  Red Hat OpenShift Data Science
+  Run Keyword If  not ${addon_already_installed}  Install Selected AddOn  Red Hat OpenShift Data Science  ${notification-email-list}
+
+Install Selected AddOn
+  [Arguments]  ${addon}  ${notification-email-list}
+  Wait Until Page Contains  Install
+  Click Install
+  Add Notification Email  ${notification-email-list}
+  #This is technically different as its type is *submit*, not *button*
+  Complete Operator Install
+
+Check if Selected AddOn Installed
+  [Arguments]  ${addon}
+  Wait Until Page Contains  ${addon}
+  ${installed_status} =   Run Keyword And Return Status  Element Should Be Visible  //span[contains(text(), "Installed")]
+  [Return]  ${installed_status}
+
+Complete Operator Install
+    # Click the Second "Install" Button (first/only one found under a footer tag)
+    Wait Until Element is Visible    //footer//*[text()='Install']
+    Click Element    //footer//*[text()='Install']
+    Verify No Errors Installing
+
+Add Notification Email
+  [Arguments]  ${notification-email-list}
+  Wait Until Element is Visible  id=field-addon-notification-email  timeout=15seconds
+  Input Text  id=field-addon-notification-email  ${notification-email-list}
+
+Verify No Errors Installing
+  Sleep  60
+  Page Should Not Contain  Error adding add-ons

--- a/tests/Resources/Page/OSD/ClusterManagement/LoginOSD.robot
+++ b/tests/Resources/Page/OSD/ClusterManagement/LoginOSD.robot
@@ -1,0 +1,20 @@
+*** Settings ***
+Library  Dialogs
+
+*** Keywords ***
+Open OSD Cluster Manager
+    Open Browser    ${OSD_CLUSTERMGMT_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+
+Login To OSD
+  [Arguments]  ${osd_user_name}  ${osd_user_password}
+  # Give the login prompt time to render after browser opens
+  Wait Until Page Contains  Red Hat login or email
+  Input Text  id=username-verification  ${osd_user_name}
+  Click Element  id=login-show-step2
+  Wait Until Page Contains  Password
+  Sleep  1  # Wait out silly animation
+  Input Text  id=password  ${osd_user_password}
+  Click Element  id=rh-password-verification-submit-button
+  # FIXME: replace this sleep for something more efficient, considering that this method is used for
+  # authentication in OpenShift Console, but also RHODS dashboard and other places
+  Sleep  5

--- a/tests/Tests/200__monitor_and_manage/210__alerts/test-set-notifier-email.robot
+++ b/tests/Tests/200__monitor_and_manage/210__alerts/test-set-notifier-email.robot
@@ -1,0 +1,74 @@
+*** Settings ***
+Documentation     Check if notifications emails list parameter is properly set after RHODS installation
+Resource          ../../../Resources/ODS.robot
+Resource          ../../../Resources/Common.robot
+Resource          ../../../Resources/Page/OCPDashboard/OCPDashboard.resource
+Resource          ../../../Resources/Page/OSD/ClusterManagement/ClusterManagement.resource
+Library           DebugLibrary
+Library           SeleniumLibrary
+Library           Process
+Library           yaml
+Library           Collections
+Test Setup        Set Library Search Order  SeleniumLibrary
+Test Teardown     End Web Test
+
+
+*** Variables ***
+#${MOCK_EMAIL_ADDRESS}  dummyEmail@redhat.com   # Look into this, as the capital 'E' is not allowed by some input validation RegEx.
+${MOCK_EMAIL_ADDRESS}  dummyemail@redhat.com
+${OPERATOR_NAMESPACE}  redhat-ods-operator
+${PARAMETER_SECRET_NAME}  addon-managed-odh-parameters
+${MONITORING_NAMESPACE}  redhat-ods-monitoring
+${ALERTMANAGER_CM}        alertmanager
+${ALERTMANAGER_CFG_NAME}  alertmanager.yml
+
+*** Test Cases ***
+Can Install RHODS Operator With custom notification emails list
+  [Tags]  TBC  ODS-518
+  Open ClusterManagement  ${RED_HAT_USER.USERNAME}  ${RED_HAT_USER.PASSWORD}
+  Open Addons Tab
+  Install RHODS Operator From AddOns  ${MOCK_EMAIL_ADDRESS}
+  Wait Until Page Does Not Contain  Installing  timeout=1800
+  Sleep  10
+
+Verify RHODS notification emails list Secret properly set
+  [Tags]  Smoke  Sanity  ODS-518
+  [Documentation]  Check if the addon-managed-odh-parameters Secret has a properly set notification-emails value
+  ...              Note: in order to run this, user must be logged into openshift console via oc
+  ${email_list}=  Run  oc get secret -n ${OPERATOR_NAMESPACE} -o go-template --template='{{ index .data "notification-email" | base64decode }}' ${PARAMETER_SECRET_NAME}
+  Should Not Contain  ${email_list}  "error:"
+  Should Be Equal  ${email_list}  ${MOCK_EMAIL_ADDRESS}
+
+Verify RHODS notification emails list Secret matches value set in installation
+  [Tags]  Smoke  Sanity  ODS-518
+  [Documentation]  Check if the addon-managed-odh-parameters Secret has a properly set notification-emails value
+  ...              Note: in order to run this, user must be logged into openshift console via oc
+  ${email_list}=  Run  oc get secret -n ${OPERATOR_NAMESPACE} -o go-template --template='{{ index .data "notification-email" | base64decode }}' ${PARAMETER_SECRET_NAME}
+  Should Be Equal  ${email_list}  ${MOCK_EMAIL_ADDRESS}
+
+Verify RHODS alertmanger reciever set correctly with email list
+  [Tags]  Smoke  Sanity  ODS-518
+  [Documentation]  Retreive, parse, and verify that the Mock email address used in RHODS installation is correctly set in the AlertManager Config file.
+  ${am_cfg}   Run   oc get cm -n ${MONITORING_NAMESPACE} -o go-template --template='{{ index .data "${ALERTMANAGER_CFG_NAME}" }}' ${ALERTMANAGER_CM}
+  Should Not Contain    ${am_cfg}    "error:"
+  ${loaded_cfg}=   yaml.Safe Load  ${am_cfg}
+  @{receivers}=      Set Variable  ${loaded_cfg}[receivers]
+  FOR   ${rcv}   IN   @{receivers}
+    Run keyword if  'email_configs' in ${rcv}  Find Email Recipients In Configs  ${rcv}
+  END
+
+*** Keywords ***
+Find Email Recipients In Configs
+  [Arguments]  ${rcv}
+  @{email_configs}=   Set Variable  ${rcv}[email_configs]
+  ${found} =   Set Variable  ${false}
+
+  FOR  ${cfg}  IN  @{email_configs}
+    ${cfg_dict}=  Convert To Dictionary  ${cfg}
+    IF  'to' in ${cfg_dict}
+      IF  "${cfg_dict}[to]" == "${MOCK_EMAIL_ADDRESS}"
+        ${found} =  Set Variable  ${true}
+      END
+    END
+  END
+  Should Be True  ${found}


### PR DESCRIPTION
Robot Framework test for ODS-518: Verify the emails provided during installation of RHODS is properly set in the alertmanager and operator Secret

WIP Items:
- Operator installation is through the add-ons tab, not OperatorHub as most other tests. this introduces some unique problems:
  - Test requires Red Hat Account with access to the cluster management page (cloud.redhat.com/openshift)
  - Test requires the Cluster's management URL to be specified in the test-variables.yaml file (not sure if Jenkins can provide this)
  - Test requires the tester to be logged in to the cluster via oc on console (and has admin access)