### PR TITLE
Update Select Notebook Image to use "tensorflow"

### DIFF
--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -24,7 +24,7 @@ Minimal Tensorflow test
   Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Fix Spawner Status
   # Size needs to change
-  Spawn Notebook With Arguments  image=tensorflow-gpu  size=Small
+  Spawn Notebook With Arguments  image=tensorflow  size=Small
   Wait for JupyterLab Splash Screen  timeout=30
   Maybe Select Kernel
   ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected


### PR DESCRIPTION
This updates the JH Spawner Notebook Image xpath ID to reference `tensorflow` since the `-gpu` was dropped when GPU enablement was bumped from GA

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>