### PR TITLE
Add "Clean Up User Notebook" keyword

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         "pygments",
         "requests",
         "robotframework-requests",
+        "escapism",
     ],
     zip_safe=True,
     include_package_data=True,

--- a/tests/Resources/Page/ODH/JupyterHub/jupyter-helper.py
+++ b/tests/Resources/Page/ODH/JupyterHub/jupyter-helper.py
@@ -1,0 +1,10 @@
+import string
+import escapism
+
+
+def get_safe_username(username):
+    # Calculates safe usernames using JupyterHub algorithm (e.g. ldap-user1 > ldap-2duser1)
+    # Kubespawner example:
+    #  https://github.com/jupyterhub/kubespawner/blob/251a0b65ffaff72e722446d5b9aac738ad6923d1/kubespawner/spawner.py#L1709
+    safe_chars = set(string.ascii_lowercase + string.digits)
+    return escapism.escape(username, safe=safe_chars, escape_char='-').lower()


### PR DESCRIPTION
This keyword deletes all files and folders in a user's notebook PVC (excluding hidden files and folders).

It will be useful to fix test teardown in ODS-517 in PR #102, as regular "Clean Up Server" fails
to do the job because the PVC is full for that test.

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>