### PR TITLE
Added support to execute Robot scipt from mac OS

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -96,6 +96,7 @@ case "$(uname -s)" in
           echo "Not yet supported OS, but shouldn't be hard for you to fix :) "
           echo "Please add the driver, test and submit PR"
           exit 1
+        ;;
 esac
 
 #TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -107,3 +107,35 @@ TEST_ARTIFACT_DIR=$(mktemp -d -p ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d
 ./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}
 
 esac
+
+case "$(uname -s)" in
+Darwin)
+         echo "MACOS"
+         echo "setting driver  to $currentpath/Drivers/MACOS"
+         PATH=$PATH:$currentpath/drivers/MACOS
+         export PATH=$PATH
+         echo $PATH
+
+
+#TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test
+VENV_ROOT=${currentpath}/venv
+#setup virtualenv
+python3 -m venv ${VENV_ROOT}
+source ${VENV_ROOT}/bin/activate
+
+if [[ ${SKIP_PIP_INSTALL} -eq 0 ]]; then
+  ${VENV_ROOT}/bin/pip install -r requirements.txt
+fi
+
+#Create a unique directory to store the output for current test run
+if [[ ! -d "${TEST_ARTIFACT_DIR}" ]]; then
+  mkdir ${TEST_ARTIFACT_DIR}
+fi
+
+#TODO: Configure the "tmp_dir" creation so that we can have a "latest" link
+TEST_ARTIFACT_DIR=$(mktemp -d  ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
+
+#run tests
+./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}
+
+esac

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -115,10 +115,11 @@ if [[ ! -d "${TEST_ARTIFACT_DIR}" ]]; then
 fi
 case "$(uname -s)" in
     Darwin)
-        TEST_ARTIFACT_DIR=$(mktemp -d  ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
+        TEST_ARTIFACT_DIR=$(mktemp -d  ${TEST_ARTIFACT_DIR} -t ${TEST_ARTIFACT_DIR}/ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
          ;;
     Linux)
         TEST_ARTIFACT_DIR=$(mktemp -d -p ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
         ;;
 esac
+
 ./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -64,58 +64,39 @@ fi
 
 currentpath=`pwd`
 case "$(uname -s)" in
-Linux)
-   case "$(lsb_release --id --short)" in
-   "Fedora"|"CentOS")
-         ## Bootstrap script to setup drivers ##
-         echo "setting driver  to $currentpath/Drivers/fedora"
-         PATH=$PATH:$currentpath/drivers/fedora
-         export PATH=$PATH
-         echo $PATH
-    ;;
-    "Ubuntu")
-         echo "Not yet supported, but shouldn't be hard for you to fix :) "
-         echo "Please add the driver, test and submit PR"
-         exit 1
-    ;;
-    "openSUSE project"|"SUSE LINUX"|"openSUSE")
-         echo "Not yet supported, but shouldn't be hard for you to fix :) "
-         echo "Please add the driver, test and submit PR"
-         exit 1
-    ;;
-    esac
-
-#TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test
-VENV_ROOT=${currentpath}/venv
-#setup virtualenv
-python3 -m venv ${VENV_ROOT}
-source ${VENV_ROOT}/bin/activate
-
-if [[ ${SKIP_PIP_INSTALL} -eq 0 ]]; then
-  ${VENV_ROOT}/bin/pip install -r requirements.txt
-fi
-
-#Create a unique directory to store the output for current test run
-if [[ ! -d "${TEST_ARTIFACT_DIR}" ]]; then
-  mkdir ${TEST_ARTIFACT_DIR}
-fi
-
-#TODO: Configure the "tmp_dir" creation so that we can have a "latest" link
-TEST_ARTIFACT_DIR=$(mktemp -d -p ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
-
-#run tests
-./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}
-
-esac
-
-case "$(uname -s)" in
-Darwin)
+    Darwin5)
          echo "MACOS"
          echo "setting driver  to $currentpath/Drivers/MACOS"
          PATH=$PATH:$currentpath/drivers/MACOS
          export PATH=$PATH
-         echo $PATH
-
+         echo "$PATH"
+         ;;
+    Linux)
+       case "$(lsb_release --id --short)" in
+       "Fedora"|"CentOS")
+             ## Bootstrap script to setup drivers ##
+             echo "setting driver  to $currentpath/Drivers/fedora"
+             PATH=$PATH:$currentpath/drivers/fedora
+             export PATH=$PATH
+             echo $PATH
+        ;;
+        "Ubuntu")
+             echo "Not yet supported, but shouldn't be hard for you to fix :) "
+             echo "Please add the driver, test and submit PR"
+             exit 1
+        ;;
+        "openSUSE project"|"SUSE LINUX"|"openSUSE")
+             echo "Not yet supported, but shouldn't be hard for you to fix :) "
+             echo "Please add the driver, test and submit PR"
+             exit 1
+        ;;
+        esac
+        ;;
+      * )
+          echo "Not yet supported OS, but shouldn't be hard for you to fix :) "
+          echo "Please add the driver, test and submit PR"
+          exit 1
+esac
 
 #TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test
 VENV_ROOT=${currentpath}/venv
@@ -131,11 +112,12 @@ fi
 if [[ ! -d "${TEST_ARTIFACT_DIR}" ]]; then
   mkdir ${TEST_ARTIFACT_DIR}
 fi
-
-#TODO: Configure the "tmp_dir" creation so that we can have a "latest" link
-TEST_ARTIFACT_DIR=$(mktemp -d  ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
-
-#run tests
-./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}
-
+case "$(uname -s)" in
+    Darwin)
+        TEST_ARTIFACT_DIR=$(mktemp -d  ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
+         ;;
+    Linux)
+        TEST_ARTIFACT_DIR=$(mktemp -d -p ${TEST_ARTIFACT_DIR} -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
+        ;;
 esac
+./venv/bin/robot -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -64,7 +64,7 @@ fi
 
 currentpath=`pwd`
 case "$(uname -s)" in
-    Darwin5)
+    Darwin)
          echo "MACOS"
          echo "setting driver  to $currentpath/Drivers/MACOS"
          PATH=$PATH:$currentpath/drivers/MACOS


### PR DESCRIPTION
Signed-off-by: tarukumar <takumar@redhat.com>

Added support to execute the "run_reboot_test.sh" script to support MAC OS(Darwin). Added another block for mac os. Earlier script was not supported on mac OS due to below reason:

1. kernel name for mac os different 
2. mktemp in mac os doesn't support "-p". 

