### PR TITLE
Add Automated test to cover ODS-272,344 and 501

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ must-gather-results.txt
 .DS_Store
 .idea/
 Results/
+__pycache__/

--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -1,0 +1,10 @@
+from robotlibcore import keyword
+
+
+class Helpers:
+    """Custom keywords written in Python"""
+    @keyword
+    def text_to_list(self, text):
+        rows = text.split('\n')
+        print(rows)
+        return rows

--- a/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
+++ b/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
@@ -1,0 +1,11 @@
+*** Settings ***
+Resource   ../../OCPDashboard/Page.robot
+Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
+
+*** Keywords ***
+Get Build Status
+  [Arguments]  ${namespace}  ${build_search_term}
+  Navigate To Page    Builds    Builds
+  Search Last Item Instance By Title in OpenShift Table  search_term=${build_search_term}  namespace=${namespace}
+  ${build_status}=  Get Text    xpath://tr[@data-id='0-0']/td/*/span[@data-test='status-text']
+  [Return]  ${build_status}

--- a/tests/Resources/Page/OCPDashboard/Page.robot
+++ b/tests/Resources/Page/OCPDashboard/Page.robot
@@ -12,3 +12,21 @@ Open Page
 Page Should Be Open
   [Arguments]  ${url}
   Location Should Contain  ${url}
+
+Select Project By Name
+  [Arguments]  ${project_name}
+  Wait Until Page Contains Element    xpath://div/button[contains(@class, 'co-namespace-dropdown__menu-toggle')]
+  Click Element    xpath://div/button[contains(@class, 'co-namespace-dropdown__menu-toggle')]
+  Wait Until Page Contains Element  xpath://li[contains(@class, 'pf-c-menu__list-item')]
+  Click Element    xpath://li[contains(@class, 'pf-c-menu__list-item')]/*/span[.='${project_name}']
+
+Search Last Item Instance By Title in OpenShift Table
+  [Arguments]  ${search_term}  ${namespace}=All Projects
+  Select Project By Name    ${namespace}
+  Wait Until Page Contains Element    xpath://input[@data-test='name-filter-input']
+  Wait Until Page Contains Element    xpath://a[contains(., "${search_term}")]
+  Clear Element Text    xpath://input[@data-test='name-filter-input']
+  Input Text    xpath://input[@data-test='name-filter-input']    ${search_term}
+  Sleep  2
+  Click Button    xpath://*/th[@data-label='Created']/button  # asc order
+  Click Button    xpath://*/th[@data-label='Created']/button  # desc order

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -1,0 +1,17 @@
+*** Settings ***
+Resource   ../../OCPDashboard/Page.robot
+Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
+Library         ../../../../libs/Helpers.py
+
+*** Keywords ***
+Get Pod Logs
+  [Arguments]  ${namespace}  ${pod_search_term}
+  Navigate To Page    Workloads    Pods
+  Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
+  Click Link    xpath://tr[@data-id='0-0']/td[@id='name']/*/a
+  Click Link    Logs
+  Sleep  2
+  Capture Page Screenshot  logs_page.png
+  ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
+  ${log_rows}=  Text To List  ${logs_text}
+  [Return]  ${log_rows}

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -1,5 +1,8 @@
 *** Settings ***
 Resource  JupyterLabLauncher.robot
+Resource  ../../LoginPage.robot
+Resource  ../../ODH/ODHDashboard/ODHDashboard.robot
+Resource  LoginJupyterHub.robot
 Library  JupyterLibrary
 Library  String
 Library  Collections
@@ -115,6 +118,24 @@ Spawn Notebook With Arguments
       Exit For Loop If  ${spawn_fail} == False
       Click Element  xpath://span[@id='jupyterhub-logo']
    END
+
+Spawn Notebook From Dashboard With Arguments
+  [Arguments]  ${img_displayed_name}  ${img_real_name}  ${retries}=1  ${size}=Small  ${spawner_timeout}=600 seconds  &{envs}
+  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Menu.Navigate To Page    Applications    Enabled
+  Launch JupyterHub From RHODS Dashboard Dropdown
+  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  ${authorization_required} =  Is Service Account Authorization Required
+  Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
+  Fix Spawner Status
+  Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+  Wait Until Page Contains Element  xpath://input[@name="${img_displayed_name}"]
+  Wait Until Element Is Enabled    xpath://input[@name="${img_displayed_name}"]   timeout=600
+  Spawn Notebook With Arguments  retries=${retries}  image=${img_real_name}  size=${size}  spawner_timeout=${spawner_timeout}  &{envs}
+  Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+
 
 Get Spawner Progress Message
    [Documentation]  Get the progress message currently displayed

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -119,10 +119,7 @@ Spawn Notebook With Arguments
       Click Element  xpath://span[@id='jupyterhub-logo']
    END
 
-Spawn Notebook From Dashboard With Arguments
-  [Arguments]  ${img_displayed_name}  ${img_real_name}  ${retries}=1  ${size}=Small  ${spawner_timeout}=600 seconds  &{envs}
-  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+Launch JupyterHub Spawner From Dashboard
   Menu.Navigate To Page    Applications    Enabled
   Launch JupyterHub From RHODS Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
@@ -130,11 +127,6 @@ Spawn Notebook From Dashboard With Arguments
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
   Fix Spawner Status
   Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
-  Wait Until Page Contains Element  xpath://input[@name="${img_displayed_name}"]
-  Wait Until Element Is Enabled    xpath://input[@name="${img_displayed_name}"]   timeout=600
-  Spawn Notebook With Arguments  retries=${retries}  image=${img_real_name}  size=${size}  spawner_timeout=${spawner_timeout}  &{envs}
-  Wait for JupyterLab Splash Screen  timeout=60
-  Maybe Select Kernel
 
 
 Get Spawner Progress Message

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -57,6 +57,9 @@ Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
 Verify User Is Able to Activate Anaconda Commercial Edition
   [Tags]  Sanity  Smoke
   ...     ODS-272  ODS-344  ODS-501
+  [Documentation]  This TC performs the Anaconda CE activation, spawns a JL using the Anaconda image,
+  ...              validate the token, install a library and try to import it.
+  ...              At the end, it stops the JL server and returns to the spawner
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
@@ -74,12 +77,19 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Log  ${val_result}
   Should Be Equal  ${val_result[0]}  ${val_success_msg}
   Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete
-  Spawn Notebook From Dashboard With Arguments   img_displayed_name=Anaconda Commercial Edition  img_real_name=s2i-minimal-notebook-anaconda
-  Sleep  5
+  Go To  ${ODH_DASHBOARD_URL}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Launch JupyterHub Spawner From Dashboard
+  Wait Until Page Contains Element  xpath://input[@name="Anaconda Commercial Edition"]
+  Wait Until Element Is Enabled    xpath://input[@name="Anaconda Commercial Edition"]   timeout=10
+  Spawn Notebook With Arguments  image=s2i-minimal-notebook-anaconda
+  Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+  Sleep  3
   Close Other JupyterLab Tabs
   Capture Page Screenshot  closedtabs.png
   Launch a new JupyterLab Document
-  Sleep  5
+  Sleep  3
   Maybe Select Kernel
   Close Other JupyterLab Tabs
   Run Cell And Check Output    !conda token set ${ANACONDA_CE.ACTIVATION_KEY}    ${token_val_success_msg}

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -118,7 +118,6 @@ Check Anaconda CE Image Build Status
   Navigate To Page    Builds    Builds
   Search Last Item Instance By Title in OpenShift Table  search_term=minimal-notebook-anaconda  namespace=redhat-ods-applications
   ${ace_build_status}=  Get Text    xpath://tr[@data-id='0-0']/td/*/span[@data-test='status-text']
-  Log To Console    \nACE BUILD STATUS: ${ace_build_status}
   Run Keyword If    "${ace_build_status}" == "Failed"
   ...    Fail  the Anaconda image build has failed
   ...  ELSE
@@ -151,6 +150,7 @@ Spawn and Check JupyterLab Using Anaconda CE Image
   Add and Run JupyterLab Code Cell  !conda install -y numpy
   Wait Until JupyterLab Code Cell Is Not Active
   Run Cell And Check For Errors  import numpy as np
+  Capture Page Screenshot  conda_lib_install_result.png
   Maybe Open JupyterLab Sidebar   File Browser
   Fix Spawner Status
   Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -1,8 +1,13 @@
 *** Settings ***
 Resource        ../../../Resources/Page/LoginPage.robot
 Resource        ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+Resource        ../../../Resources/Page/OCPDashboard/Page.robot
+Resource        ../../../Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
+Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Library         SeleniumLibrary
-Library    XML
+Library         XML
+Library         JupyterLibrary
+Library         ../../../../libs/Helpers.py
 Suite Setup     Anaconda Commercial Edition Suite Setup
 Suite Teardown  Anaconda Commercial Edition Suite Teardown
 
@@ -11,7 +16,8 @@ ${anaconda_appname}=  anaconda-ce
 ${anaconda_key_in}=  Anaconda CE Key
 ${invalid_key}=  abcdef-invalidkey
 ${error_msg}=  error\nValidation failed\nError attempting to validate. Please check your entries.
-
+${val_success_msg}=  Validation result: 200
+${token_val_success_msg}=  Success! Your token was validated and Conda has been configured.
 
 *** Test Cases ***
 Verify Anaconda Commercial Edition Is Available In RHODS Dashboard Explore/Enabled Page
@@ -46,6 +52,24 @@ Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
   Capture Page Screenshot  enabletab_anaconda_notpresent.png
   Page Should Not Contain Element  xpath://div[@class="pf-c-card__title"]/span[.="Anaconda Commercial Edition"]
 
+Verify User Is Able to Activate Anaconda Commercial Edition
+  [Tags]  Sanity  Smoke
+  ...     ODS-272  ODS-344  ODS-501
+  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for RHODS Dashboard to Load
+  Enable Anaconda  ${ANACONDA_CE.ACTIVATION_KEY}
+  Wait Until Keyword Succeeds    50  1  Page Should Not Contain Element    xpath://*/div[contains(@class, "bullseye")]
+  Capture Page Screenshot  anaconda_success_activation.png
+  Menu.Navigate To Page    Applications    Enabled
+  Wait Until RHODS Dashboard JupyterHub Is Visible
+  Capture Page Screenshot  enabletab_anaconda_present.png
+  Page Should Contain Element  xpath://div[@class="pf-c-card__title"]/span[.="Anaconda Commercial Edition"]
+  ${val_result}=  Get Anaconda Validator Logs
+  Log  ${val_result}
+  Should Be Equal  ${val_result}  ${val_success_msg}
+  Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete
+  Spawn and Check JupyterLab Using Anaconda CE Image
 
 ** Keywords ***
 Anaconda Commercial Edition Suite Setup
@@ -74,5 +98,61 @@ Check Connect Button Status
 Get Connect Button Status
   ${button_status}=  Get Element Attribute    xpath://*/footer/*[.='Connect']    aria-disabled
   [Return]   ${button_status}
+
+Get Anaconda Validator Logs
+  Go To  ${OCP_CONSOLE_URL}
+  Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
+  Maybe Skip Tour
+  Navigate To Page    Workloads    Pods
+  Search Last Item Instance By Title in OpenShift Table  search_term=anaconda-ce-periodic-validator-job-custom-run  namespace=redhat-ods-applications
+  Click Link    xpath://tr[@data-id='0-0']/td[@id='name']/*/a
+  Click Link    Logs
+  Sleep  2
+  Capture Page Screenshot  logs_page.png
+  ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
+  ${log_rows}=  Text To List  ${logs_text}
+  [Return]  ${log_rows[0]}
+
+Check Anaconda CE Image Build Status
+  [Arguments]  ${target_status}
+  Navigate To Page    Builds    Builds
+  Search Last Item Instance By Title in OpenShift Table  search_term=minimal-notebook-anaconda  namespace=redhat-ods-applications
+  ${ace_build_status}=  Get Text    xpath://tr[@data-id='0-0']/td/*/span[@data-test='status-text']
+  Log To Console    \nACE BUILD STATUS: ${ace_build_status}
+  Run Keyword If    "${ace_build_status}" == "Failed"
+  ...    Fail  the Anaconda image build has failed
+  ...  ELSE
+  ...    Should Be Equal    ${ace_build_status}    ${target_status}
+
+Spawn and Check JupyterLab Using Anaconda CE Image
+  Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Menu.Navigate To Page    Applications    Enabled
+  Launch JupyterHub From RHODS Dashboard Dropdown
+  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  ${authorization_required} =  Is Service Account Authorization Required
+  Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
+  Fix Spawner Status
+  Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+  Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']
+  Wait Until Element Is Enabled    xpath://input[@name='Anaconda Commercial Edition']   timeout=600
+  Spawn Notebook With Arguments  image=s2i-minimal-notebook-anaconda
+  Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+  Sleep  5
+  Close Other JupyterLab Tabs
+  Capture Page Screenshot  closedtabs.png
+  Launch a new JupyterLab Document
+  Sleep  5
+  Maybe Select Kernel
+  Close Other JupyterLab Tabs
+  Run Cell And Check Output    !conda token set ${ANACONDA_CE.ACTIVATION_KEY}    ${token_val_success_msg}
+  Capture Page Screenshot  anaconda_token_val_cell.png
+  Add and Run JupyterLab Code Cell  !conda install -y numpy
+  Wait Until JupyterLab Code Cell Is Not Active
+  Run Cell And Check For Errors  import numpy as np
+  Maybe Open JupyterLab Sidebar   File Browser
+  Fix Spawner Status
+  Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']
 
 


### PR DESCRIPTION
this PR implements the check the use case that includes:
- Anaconda CE activation from Dashboard (with checks on Logs and Build status)
- Spawning of Anaconda CE Image from JH
- Token validation inside JL
- check if it is possible to install and import afterwards a python lib using "conda" pkg manager

It also includes three generic keywords: 
1. Select Project By Name : it select the namespace from UI
2. Search Last Item Instance By Title in OpenShift Table : it search in a OCP table (e.g., Builds) the one passed as argument and sort the table by Desc order (in this way if you need to pick one pod or build which has more instances, you can pick the latest one)
3. Text To List: get a text as input and split it into a list (I used it as support in checking the anaconda pod logs)