### PR TITLE
add keyword to open sidebar before clicking on root folder icon

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -181,6 +181,7 @@ Fix Spawner Status
          ${JL_visible} =  JupyterLab Is Visible
          IF  ${JL_visible}==True
             Maybe Close Popup
+            Maybe Open JupyterLab Sidebar   File Browser
             Click Element  xpath://span[@title="/opt/app-root/src"]
             Open With JupyterLab Menu  File  New  Notebook
             Sleep  1

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -181,8 +181,7 @@ Fix Spawner Status
          ${JL_visible} =  JupyterLab Is Visible
          IF  ${JL_visible}==True
             Maybe Close Popup
-            Maybe Open JupyterLab Sidebar   File Browser
-            Click Element  xpath://span[@title="/opt/app-root/src"]
+            Navigate Home (Root folder) In JupyterLab Sidebar File Browser
             Open With JupyterLab Menu  File  New  Notebook
             Sleep  1
             Maybe Close Popup


### PR DESCRIPTION
I noticed that the keyword "Fix Spawner Status" fails if the right sidebar (file browser) is closed. It is due to this line of code: 
`Click Element  xpath://span[@title="/opt/app-root/src"]`
If the file browser is closed, the above line of code fails because the searched element is not displayed