### PR TITLE
Automate test case to Enable and Delete a Kafka Stream (ods 242)

### DIFF
--- a/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -28,3 +28,24 @@ Maybe Skip RHOSAK Tour
    ${tour_modal} =  Run Keyword And Return Status  Page Should Contain Element  xpath=//button[text()='Take tour']
    Run Keyword If  ${tour_modal}  Click Button    Not now
 
+Maybe Agree RH Terms and Conditions
+  ${agree_required}=  Run Keyword And Return Status  Page Should Contain  Red Hat Terms and Conditions
+  IF    ${agree_required} == True
+    Wait Until Page Contains Element    xpath=//div[@class='checkbox terms-decision']
+    Select Checkbox    xpath=//input[contains(@id, 'checkbox-term')]
+    Checkbox Should Be Selected  xpath=//input[contains(@id, 'checkbox-term')]
+    Click Button  Submit
+  END
+
+Maybe Accept Cookie Policy
+  ${cookie_required}=  Run Keyword And Return Status  Page Should Contain  We use cookies on this site
+  IF    ${cookie_required} == True
+    Select Frame    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
+    Wait Until Page Contains Element    xpath=//a[contains(@class, 'required')]  timeout=10
+    Click Link    xpath=//a[contains(@class, 'required')]
+    Wait Until Page Contains Element    xpath=//a[contains(@class, 'close')]  timeout=10
+    Click Link    xpath=//a[contains(@class, 'close')]
+    Wait Until Page Does Not Contain    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
+    Unselect Frame
+    Capture Page Screenshot  cookieaccepted.png
+  END

--- a/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -13,6 +13,7 @@ Wait For HCC Splash Page
 
 Login to HCC
   [Arguments]  ${username}  ${password}
+  Sleep  5
   ${login-required} =  Is SSO Login Page Visible
   IF    ${login-required} == True
     Wait Until Element is Visible  xpath://input[@id="username-verification"]  timeout=5
@@ -23,6 +24,7 @@ Login to HCC
     Click Button    Log in
   END
   Run Keyword And Continue On Failure    Wait For HCC Splash Page
+  Maybe Handle Something Went Wrong Page
 
 Maybe Skip RHOSAK Tour
    ${tour_modal} =  Run Keyword And Return Status  Page Should Contain Element  xpath=//button[text()='Take tour']
@@ -48,4 +50,28 @@ Maybe Accept Cookie Policy
     Wait Until Page Does Not Contain    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
     Unselect Frame
     Capture Page Screenshot  cookieaccepted.png
+  END
+
+Search Item By Name and Owner in RHOSAK Table
+  [Arguments]  ${name_search_term}  ${owner_search_term}
+  Wait Until Page Contains Element    xpath://input[@id='filterText']
+  Clear Element Text    xpath://input[@id='filterText']
+  Input Text    xpath://input[@id='filterText']    ${name_search_term}
+  Click Button    xpath=//button[@aria-label='Search instances']
+  Click Button  xpath=//button[contains(@id, 'pf-select-toggle-id')]
+  Wait Until Page Contains Element    xpath=//button[text()='Owner']
+  Click Button  xpath=//button[text()='Owner']
+  Wait Until Page Contains Element    xpath://input[@id='filterOwners']  # needed because unpredictable refreshes
+  Clear Element Text    xpath://input[@id='filterOwners']
+  Input Text    xpath://input[@id='filterOwners']    ${owner_search_term}
+  Click Button    xpath=//button[@aria-label='Search owners']
+  Sleep  1
+  Click Button    xpath://th[@data-label='Time created']/button
+  Click Button    xpath://th[@data-label='Time created']/button
+
+Maybe Handle Something Went Wrong Page
+  ${sww_required}=  Run Keyword And Return Status  Page Should Contain  Something went wrong
+  IF    ${sww_required} == True
+    Capture Page Screenshot  somethingwentwrong_kafka.png
+    Reload Page
   END

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -47,13 +47,15 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Sleep  5
   Wait Until Page Contains    Create Kafka instance
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
+  Capture Page Screenshot  newly_created_stream.png
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
   Delete Kafka Stream Instance  stream_name=${stream_name_test}  stream_owner=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
-  Delete    kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
+  Capture Page Screenshot  after deleting_stream.png
+  OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
 
-** Keywords ***
+*** Keywords ***
 Kafka Suite Setup
   Set Library Search Order  SeleniumLibrary
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -19,6 +19,7 @@ Verify RHOSAK Is Available In RHODS Dashboard Explore Page
   Verify Service Provides "Get Started" Button In The Explore Page    ${rhosak_displayed_appname}
   Verify Service Provides "Enable" Button In The Explore Page    ${rhosak_displayed_appname}
 
+
 Verify User Can Enable RHOSAK from Dashboard Explore Page
   [Tags]  Sanity  Smoke
   ...     ODS-392
@@ -30,6 +31,25 @@ Verify User Can Enable RHOSAK from Dashboard Explore Page
   Login to HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
   Maybe Skip RHOSAK Tour
   Wait Until Page Contains    Kafka Instances
+  Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
+
+Verify User Is Able to Create a Kafka Stream
+  [Tags]  Sanity  Smoke
+  ...     ODS-392-ext
+  Enable RHOSAK
+  Verify Service Is Enabled  ${rhosak_displayed_appname}
+  Launch OpenShift Streams for Apache Kafka From RHODS Dashboard Link
+  Login to HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
+  Maybe Skip RHOSAK Tour
+  Sleep  5
+  Wait Until Page Contains    Create Kafka instance
+  Click Button  Create Kafka instance
+  Sleep  5
+  Maybe Accept Cookie Policy
+  Sleep  5
+  Maybe Agree RH Terms and Conditions
+  Sleep    5
+  # insert kafka stream data and wait until it is ready to use!
   Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
 
 ** Keywords ***
@@ -54,4 +74,3 @@ Enable RHOSAK
   Wait Until Page Contains Element    xpath://div[contains(@id, 'pf-modal-part')]
   Click Button    xpath://footer/button[text()='Enable']
   Wait Until Page Contains Element   xpath://div[@class='pf-c-alert pf-m-success']
-

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -11,6 +11,9 @@ Test Setup      Kafka Test Setup
 *** Variables ***
 ${rhosak_real_appname}=  rhosak
 ${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
+${stream_name_test}=  qe-test-stream
+${stream_region_test}=  us-east-1
+${cloud_provider_test}=  Amazon Web Services
 
 *** Test Cases ***
 Verify RHOSAK Is Available In RHODS Dashboard Explore Page
@@ -33,9 +36,9 @@ Verify User Can Enable RHOSAK from Dashboard Explore Page
   Wait Until Page Contains    Kafka Instances
   Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
 
-Verify User Is Able to Create a Kafka Stream
+Verify User Is Able to Create And Delete a Kafka Stream
   [Tags]  Sanity  Smoke
-  ...     ODS-392-ext
+  ...     ODS-242
   Enable RHOSAK
   Verify Service Is Enabled  ${rhosak_displayed_appname}
   Launch OpenShift Streams for Apache Kafka From RHODS Dashboard Link
@@ -43,14 +46,13 @@ Verify User Is Able to Create a Kafka Stream
   Maybe Skip RHOSAK Tour
   Sleep  5
   Wait Until Page Contains    Create Kafka instance
-  Click Button  Create Kafka instance
-  Sleep  5
-  Maybe Accept Cookie Policy
-  Sleep  5
-  Maybe Agree RH Terms and Conditions
-  Sleep    5
-  # insert kafka stream data and wait until it is ready to use!
+  Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
+  Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+  Delete Kafka Stream Instance  stream_name=${stream_name_test}  stream_owner=${SSO.USERNAME}
+  Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
+
 
 ** Keywords ***
 Kafka Suite Setup
@@ -74,3 +76,42 @@ Enable RHOSAK
   Wait Until Page Contains Element    xpath://div[contains(@id, 'pf-modal-part')]
   Click Button    xpath://footer/button[text()='Enable']
   Wait Until Page Contains Element   xpath://div[@class='pf-c-alert pf-m-success']
+
+Check Stream Status
+  [Arguments]  ${target_status}
+  ${status}=  Get Text    xpath://tr[@tabindex='0']/td[@data-label='Status']
+  Should Be Equal    ${status}    ${target_status}
+
+Check Stream Creation
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+
+
+Create Kafka Stream Instance
+  [Arguments]  ${stream_name}  ${stream_region}  ${cloud_provider}
+  Click Button  Create Kafka instance
+  Sleep  5
+  Maybe Accept Cookie Policy
+  Sleep  5
+  Maybe Agree RH Terms and Conditions
+  Wait Until Page Contains Element    xpath=//div[@id='modalCreateKafka']  timeout=10
+  ${warn_msg}=  Run Keyword And Return Status    Page Should Not Contain    To deploy a new instance, delete your existing one first
+  IF    ${warn_msg} == ${False}
+     Log  level=WARN  message=The next keywords are going to fail because you cannot create more than one stream at a time.
+  END
+  Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
+  Click Element    xpath=//div[text()='${cloud_provider}']
+  Select From List By Value    id:cloud-region-select   ${stream_region}
+  Click Button    Create instance
+  Capture Page Screenshot  form.png
+  Sleep    2
+
+Delete Kafka Stream Instance
+  [Arguments]  ${stream_name}  ${stream_owner}
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
+  Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
+  Input Text    id:name__input   ${stream_name}
+  Click Button    Delete
+
+

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -51,8 +51,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
   Delete Kafka Stream Instance  stream_name=${stream_name_test}  stream_owner=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
-  Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
-
+  Delete    kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
 
 ** Keywords ***
 Kafka Suite Setup

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -37,7 +37,7 @@ Verify User Can Enable RHOSAK from Dashboard Explore Page
   Delete Configmap    name=rhosak-validation-result  namespace=redhat-ods-applications
 
 Verify User Is Able to Create And Delete a Kafka Stream
-  [Tags]  Sanity  Smoke
+  [Tags]  Sanity
   ...     ODS-242
   Enable RHOSAK
   Verify Service Is Enabled  ${rhosak_displayed_appname}


### PR DESCRIPTION
The following PR wants to cover ODS-242 for testing the creation of a Kafka Stream starting from the Dashboard. It extends ODS-242 to include the deletion of the stream