### PR TITLE
RHODS/ODH keywords compatibility changes

### DIFF
--- a/test-variables.yml.example
+++ b/test-variables.yml.example
@@ -19,3 +19,6 @@ OCP_ADMIN_USER:
 S3:
   AWS_ACCESS_KEY_ID: ID-value
   AWS_SECRET_ACCESS_KEY: Secret-Key
+
+# If you want to test ODH, set this variable to 'ODH'
+ODS_PROJECT: RHODS

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -3,6 +3,7 @@ Library   SeleniumLibrary
 Library   JupyterLibrary
 Resource  Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource  Page/ODH/JupyterHub/JupyterHubSpawner.robot
+Resource  ${ODS_PROJECT}Variables.resource
 
 *** Keywords ***
 Begin Web Test
@@ -13,9 +14,9 @@ Begin Web Test
     Set Library Search Order  SeleniumLibrary
 
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Resources/ODHVariables.resource
+++ b/tests/Resources/ODHVariables.resource
@@ -1,0 +1,3 @@
+//Put the ODH specific variables here
+*** Variables ***
+${ODH_DASHBOARD_TITLE}                                Open Data Hub Dashboard

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -121,7 +121,7 @@ Spawn Notebook With Arguments
 
 Launch JupyterHub Spawner From Dashboard
   Menu.Navigate To Page    Applications    Enabled
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -13,7 +13,7 @@ Authorize rhods-dashboard service account
   Checkbox Should Be Selected  user:info
   Click Element  approve
 
-Login To RHODS Dashboard
+Login To Main Dashboard
    [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
    #Wait Until Page Contains  Log in with
    ${oauth_prompt_visible} =  Is OpenShift OAuth Login Prompt Visible
@@ -23,22 +23,21 @@ Login To RHODS Dashboard
    ${authorize_service_account} =  Is rhods-dashboard Service Account Authorization Required
    Run Keyword If  ${authorize_service_account}  Authorize rhods-dashboard service account
 
-Wait for RHODS Dashboard to Load
-  [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science Dashboard"
-  Wait For Condition  return document.title == ${dashboard_title}  timeout=15
+Wait for ${ods_project} Dashboard to Load
+  Wait For Condition  return document.title == "${${ods_project}_DASHBOARD_TITLE}"  timeout=15
 
-Wait Until RHODS Dashboard ${dashboard_app} Is Visible
+Wait Until Main Dashboard ${dashboard_app} Is Visible
   # Ideally the timeout would be an arg but Robot does not allow "normal" and "embedded" arguments
   # Setting timeout to 30seconds since anything beyond that should be flagged as a UI bug
   Wait Until Element is Visible  xpath://div[@class="pf-c-card__title" and .="${dashboard_app}"]  30seconds
 
-Launch ${dashboard_app} From RHODS Dashboard Link
-  Wait Until RHODS Dashboard ${dashboard_app} Is Visible
+Launch ${dashboard_app} From ${ods_project} Dashboard Link
+  Wait Until Main Dashboard ${dashboard_app} Is Visible
   Click Link  xpath://div[@class="pf-c-card__title" and .="${dashboard_app}"]/../div[contains(@class,"pf-c-card__footer")]/a
   Switch Window  NEW
 
-Launch ${dashboard_app} From RHODS Dashboard Dropdown
-  Wait Until RHODS Dashboard ${dashboard_app} Is Visible
+Launch ${dashboard_app} From ${ods_project} Dashboard Dropdown
+  Wait Until Main Dashboard ${dashboard_app} Is Visible
   Click Button  xpath://div[@class="pf-c-card__title" and .="${dashboard_app}"]/..//button[contains(@class,pf-c-dropdown__toggle)]
   Click Link  xpath://div[@class="pf-c-card__title" and .="${dashboard_app}"]/..//a[.="Launch"]
   Switch Window  NEW

--- a/tests/Resources/RHODSVariables.resource
+++ b/tests/Resources/RHODSVariables.resource
@@ -1,0 +1,3 @@
+// Put the RHODS specific varibles here
+*** Variables ***
+${RHODS_DASHBOARD_TITLE}                              Red Hat OpenShift Data Science Dashboard

--- a/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -79,15 +79,15 @@ Verify Previus CPU Usage Is Greater Than Zero
 ## TODO: Add this keyword with the other JupyterHub stuff
 Run Jupyter Notebook For 5 Minutes
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Iterative Image Test  s2i-generic-data-science-notebook  https://github.com/lugi0/minimal-nb-image-test  minimal-nb-image-test/minimal-nb.ipynb
 
 
 ##TODO: This is a copy of "Iterative Image Test" keyword from image-iteration.robob. We have to refactor the code not to duplicate this method
 Iterative Image Test
   [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Page Should Not Contain    403 : Forbidden
   ${authorization_required} =  Is Service Account Authorization Required
@@ -114,9 +114,9 @@ Iterative Image Test
 
 CleanUp JupyterHub
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Page Should Not Contain    403 : Forbidden
   ${authorization_required} =  Is Service Account Authorization Required

--- a/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
@@ -37,8 +37,8 @@ Set Up Alert Test
     [Arguments]  ${NOTEBOOK_PATH}
     Set Library Search Order  SeleniumLibrary
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
     Iterative Image Test  s2i-generic-data-science-notebook  ${notebook_repo_url}  ${NOTEBOOK_PATH}
     Capture Page Screenshot
 
@@ -54,7 +54,7 @@ Clean Up Files And End Web Test
 
 Iterative Image Test
     [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -24,8 +24,8 @@ Verify Resource Link Http status code
     [Tags]  Sanity
     ...     ODS-531
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
     Click Link    Resources
     Sleep  5
     ${link_elements}=  Get WebElements    //a[@class="odh-card__footer__link" and not(starts-with(@href, '#'))]

--- a/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -18,10 +18,10 @@ Suite Teardown   End Web Test
 ${python_dict}  {'classifiers':[${generic-1}, ${minimal-1}], 'clustering':[${generic-2}, ${generic-3}, ${minimal-2}, ${minimal-3}]}
 
 *** Test Cases ***
-Open RHODS Dashboard
+Open Main Dashboard
   [Tags]  Sanity
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Iterative Testing Classifiers
   [Tags]  Sanity  POLARION-ID-Classifiers
@@ -40,7 +40,7 @@ Iterative Testing Clustering
 *** Keywords ***
 Iterative Image Test
     [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -18,9 +18,9 @@ Test User Not In JH Access Groups
     ...     PLACEHOLDER  #Category tags
     ...     ODS-503
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ldap-noaccess1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Login To Main Dashboard  ldap-noaccess1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login Verify Access Level  ldap-noaccess1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  none
 
 Test User In JH Admin Group
@@ -28,9 +28,9 @@ Test User In JH Admin Group
     ...     PLACEHOLDER  #Category tags
     ...     ODS-503
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ldap-admin1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Login To Main Dashboard  ldap-admin1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login Verify Access Level  ldap-admin1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  admin
 
 Test User In JH Users Group
@@ -38,7 +38,7 @@ Test User In JH Users Group
     ...     PLACEHOLDER  #Category tags
     ...     ODS-503
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ldap-user1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Login To Main Dashboard  ldap-user1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     Login Verify Access Level  ldap-user1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  user

--- a/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
+++ b/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
@@ -11,9 +11,9 @@ Suite Teardown   End Web Test
 *** Test Cases ***
 Launch JupyterLab
   [Tags]  Sanity
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -17,8 +17,8 @@ Minimal PyTorch test
   [Tags]  Regression
   ...     PLACEHOLDER  #category tags
   ...     PLACEHOLDER  #Polarion tags
-  Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Wait for ${ODS_PROJECT} Dashboard to Load
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -18,8 +18,8 @@ Minimal Tensorflow test
   [Tags]  Regression
   ...     PLACEHOLDER  #Category tags
   ...     PLACEHOLDER  #Polarion tags
-  Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Wait for ${ODS_PROJECT} Dashboard to Load
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/special-user-testing.robot
+++ b/tests/Tests/500__jupyterhub/special-user-testing.robot
@@ -20,9 +20,9 @@ Test Special Usernames
     ...     PLACEHOLDER  #Category tags
     ...     ODS-257
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Wait for ${ODS_PROJECT} Dashboard to Load
+    Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
     FOR  ${char}  IN  @{CHARS}
         Login Verify Logout  ldap-special${char}  ${TEST_USER.PASSWORD}  ldap-provider-qe
     END

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
@@ -11,13 +11,13 @@ Suite Teardown   End Web Test
 
 
 *** Test Cases ***
-Open RHODS Dashboard
+Open Main Dashboard
   [Tags]  Tier2
-  Wait for RHODS Dashboard to Load
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Tier2
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
   [Tags]  Tier2

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
@@ -11,13 +11,13 @@ Suite Teardown   End Web Test
 
 
 *** Test Cases ***
-Open RHODS Dashboard
+Open Main Dashboard
   [Tags]  Sanity
-  Wait for RHODS Dashboard to Load
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
@@ -13,13 +13,13 @@ Suite Teardown   End Web Test
 
 
 *** Test Cases ***
-Open RHODS Dashboard
+Open Main Dashboard
   [Tags]  Sanity
-  Wait for RHODS Dashboard to Load
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test-minimal-image.robot
+++ b/tests/Tests/500__jupyterhub/test-minimal-image.robot
@@ -13,11 +13,11 @@ Suite Teardown   End Web Test
 
 
 *** Test Cases ***
-Open RHODS Dashboard
-  Wait for RHODS Dashboard to Load
+Open Main Dashboard
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Can Launch Jupyterhub
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}

--- a/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
+++ b/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
@@ -11,13 +11,13 @@ Suite Teardown   End Web Test
 
 
 *** Test Cases ***
-Open RHODS Dashboard
+Open Main Dashboard
   [Tags]  Sanity
-  Wait for RHODS Dashboard to Load
+  Wait for ${ODS_PROJECT} Dashboard to Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test.robot
+++ b/tests/Tests/500__jupyterhub/test.robot
@@ -23,9 +23,9 @@ Can Launch Jupyterhub
    [Tags]  Sanity  Smoke  ODS-129
    #This keyword will work with accounts that are not cluster admins.
    Launch Jupyterhub via App
-   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-   Wait for RHODS Dashboard to Load
-   Launch JupyterHub From RHODS Dashboard Dropdown
+   Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+   Wait for ${ODS_PROJECT} Dashboard to Load
+   Launch JupyterHub From ${ODS_PROJECT} Dashboard Dropdown
 
 Can Login to Jupyterhub
    [Tags]  Sanity  Smoke  ODS-128

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -25,8 +25,8 @@ ${token_val_success_msg}=  Success! Your token was validated and Conda has been 
 Verify Anaconda Commercial Edition Is Available In RHODS Dashboard Explore/Enabled Page
   [Tags]  ODS-262  Smoke  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Verify Service Is Available In The Explore Page    Anaconda Commercial Edition
   Verify Service Provides "Get Started" Button In The Explore Page    Anaconda Commercial Edition
   ${status}       Run keyword and Return Status         Verify Service Provides "Enable" Button In The Explore Page    Anaconda Commercial Edition
@@ -41,8 +41,8 @@ Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
   [Tags]  Smoke  Sanity
   ...     ODS-310  ODS-367
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Enable Anaconda  ${invalid_key}
   Wait Until Keyword Succeeds    30  1  Check Connect Button Status  false
   Capture Page Screenshot  anaconda_failed_activation.png
@@ -50,7 +50,7 @@ Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
   Should Be Equal  ${text}  ${error_msg}
   Click Button    Cancel
   Menu.Navigate To Page    Applications    Enabled
-  Wait Until RHODS Dashboard JupyterHub Is Visible
+  Wait Until Main Dashboard JupyterHub Is Visible
   Capture Page Screenshot  enabletab_anaconda_notpresent.png
   Page Should Not Contain Element  xpath://div[@class="pf-c-card__title"]/span[.="Anaconda Commercial Edition"]
 
@@ -61,13 +61,13 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   ...              validate the token, install a library and try to import it.
   ...              At the end, it stops the JL server and returns to the spawner
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Enable Anaconda  ${ANACONDA_CE.ACTIVATION_KEY}
   Wait Until Keyword Succeeds    50  1  Page Should Not Contain Element    xpath://*/div[contains(@class, "bullseye")]
   Capture Page Screenshot  anaconda_success_activation.png
   Menu.Navigate To Page    Applications    Enabled
-  Wait Until RHODS Dashboard JupyterHub Is Visible
+  Wait Until Main Dashboard JupyterHub Is Visible
   Capture Page Screenshot  enabletab_anaconda_present.png
   Page Should Contain Element  xpath://div[@class="pf-c-card__title"]/span[.="Anaconda Commercial Edition"]
   Go To  ${OCP_CONSOLE_URL}
@@ -78,7 +78,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Should Be Equal  ${val_result[0]}  ${val_success_msg}
   Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete
   Go To  ${ODH_DASHBOARD_URL}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Launch JupyterHub Spawner From Dashboard
   Wait Until Page Contains Element  xpath://input[@name="Anaconda Commercial Edition"]
   Wait Until Element Is Enabled    xpath://input[@name="Anaconda Commercial Edition"]   timeout=10

--- a/tests/Tests/600__ai_apps/610__ibm_watson_studio/610__ibm_watson_studio.robot
+++ b/tests/Tests/600__ai_apps/610__ibm_watson_studio/610__ibm_watson_studio.robot
@@ -9,8 +9,8 @@ Suite Teardown  IBM Watson Studio Suite Teardown
 Verify IBM Watson Studio Is Available In RHODS Dashboard Explore Page
   [Tags]  ODS-267  Smoke  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Verify Service Is Available In The Explore Page    IBM Watson Studio
   Verify Service Provides "Get Started" Button In The Explore Page    IBM Watson Studio
 

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -9,8 +9,8 @@ Suite Teardown  RHOAM Suite Teardown
 Verify RHOAM Is Available In RHODS Dashboard Explore Page
   [Tags]  ODS-271  Smoke  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Verify Service Is Available In The Explore Page    OpenShift API Management
   Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
 

--- a/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -9,8 +9,8 @@ Suite Teardown  OpenVino Suite Teardown
 Verify OpenVino Is Available In RHODS Dashboard Explore Page
   [Tags]  ODS-258  Smoke  Sanity
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Login To Main Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  Wait for ${ODS_PROJECT} Dashboard to Load
   Verify Service Is Available In The Explore Page    OpenVINO
   Verify Service Provides "Get Started" Button In The Explore Page    OpenVINO
 


### PR DESCRIPTION
The idea was to created two separate resource files [ODH|RHODS]Variables.resource, each file will contain platform specific variables. The tester can switch between these two files just by setting the ODS_PROJECT variable, which is in the main variable file `test-variables.yml.` I adjusted the keyword for controlling the main dashboard title, because it's the only conflicting keyword I could find so far but if more conflicting stuff will occur it can be easily handled.