### PR TITLE
Add prefix to RequestLibrary.Get & Fix PVC alert error

### DIFF
--- a/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
+++ b/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
@@ -7,7 +7,7 @@ Library        RequestsLibrary
 Run Query
   [Arguments]  ${pm_url}  ${pm_token}  ${pm_query}
   ${pm_headers}=       Create Dictionary  Authorization=Bearer ${pm_token}
-  ${resp}=       GET   url=${pm_url}/api/v1/query?query=${pm_query}   headers=${pm_headers}   verify=${False}
+  ${resp}=       RequestsLibrary.GET   url=${pm_url}/api/v1/query?query=${pm_query}   headers=${pm_headers}   verify=${False}
   Status Should Be    200    ${resp}
   Log To Console    ${resp.json()}
   [Return]   ${resp}
@@ -15,7 +15,7 @@ Run Query
 Get Rules
   [Arguments]  ${pm_url}  ${pm_token}  ${rule_type}
   ${pm_headers}=       Create Dictionary  Authorization=Bearer ${pm_token}
-  ${resp}=       GET   url=${pm_url}/api/v1/rules?type=${rule_type}   headers=${pm_headers}   verify=${False}
+  ${resp}=       RequestsLibrary.GET   url=${pm_url}/api/v1/rules?type=${rule_type}   headers=${pm_headers}   verify=${False}
   Status Should Be    200    ${resp}
   [Return]  ${resp.json()}
 

--- a/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
@@ -7,7 +7,6 @@ Resource         ../../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Library          DebugLibrary
 Library          SeleniumLibrary
 Library          JupyterLibrary
-Test Teardown   End Web Test
 
 *** Variables ***
 ${rule_group}=  RHODS-PVC-Usage
@@ -20,10 +19,11 @@ ${notebook_clean}=  /ods-ci-notebooks-main/notebooks/200__monitor_and_manage/203
 
 *** Test Cases ***
 Verify alert RHODS-PVC-Usage is fired when user notebook pvc usage is above 90 Percent
-  [Tags]  Sanity  ODS-516 
+  [Tags]  Sanity  ODS-516
   Set Up Alert Test  ${notebook_90}
   Sleep  320
   Prometheus.Alert Should Be Firing  ${RHODS_PROMETHEUS_URL}  ${RHODS_PROMETHEUS_TOKEN}  ${rule_group}  ${alert_90}
+  [Teardown]  Clean Up Files And End Web Test
 
 Verify alert RHODS-PVC-Usage is fired when user notebook pvc usage is 100 Percent
   [Tags]  Sanity  ODS-517

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -14,7 +14,7 @@ Dashboard Test Teardown
 
 Get HTTP Status Code
     [Arguments]  ${link_to_check}
-    ${response}=    GET  ${link_to_check}   expected_status=any
+    ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any
     Run Keyword And Continue On Failure  Status Should Be  200
     [Return]  ${response.status_code}
 


### PR DESCRIPTION
- Add prefix to RequestLibrary.Get to avoid keyword conflicts
- Update Teardown in PVC alert error to avoid keyword conflicts
Note: differences in PVC size between RHODS 1.2.0 and 1.3.0 are now handled in the [test notebook itself ](https://github.com/redhat-rhods-qe/ods-ci-notebooks-main/blob/main/notebooks/200__monitor_and_manage/203__alerts/notebook-pvc-usage/fill-notebook-pvc-over-90.ipynb)


Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>