### PR TITLE
Automation of RHOSAK UseCase

### DIFF
--- a/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -75,3 +75,9 @@ Maybe Handle Something Went Wrong Page
     Capture Page Screenshot  somethingwentwrong_kafka.png
     Reload Page
   END
+
+Wait Until Page Contains HCC Generic Modal
+  Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
+
+Wait Until Page Does Not Contains HCC Generic Modal
+  Wait Until Page Does Not Contain Element    xpath=//div[contains(@id, 'pf-modal-part')]

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -30,8 +30,8 @@ Create Kafka Stream Instance
   Wait Until Page Does Not Contain Element    xpath=//div[@id='modalCreateKafka']  timeout=10
 
 Check Stream Status
-  [Arguments]  ${target_status}
-  ${status}=  Get Text    xpath://tr[@tabindex='0']/td[@data-label='Status']
+  [Arguments]  ${target_status}  ${target_stream}
+  ${status}=  Get Text    xpath=//tr[td[@data-label='Name' and *[text()='${target_stream}']]]/td[@data-label='Status']
   Should Be Equal    ${status}    ${target_status}
 
 Check Stream Creation
@@ -47,8 +47,10 @@ Delete Kafka Stream Instance
   Wait Until Element Is Enabled    xpath=//button[text()='Delete']
   Capture Page Screenshot  3.png
   Click Button    Delete
+  Wait Until Page Does Not Contain Element    xpath=//div[@class='pf-l-bullseye']
+  Sleep  3
   Wait Until Page Contains    Create Kafka instance
-  Wait Until Keyword Succeeds    300  1  Page Should Not Contain    xpath=//tr/td[@data-label='Name' and //*[text()='${stream_name}']]
+  Wait Until Keyword Succeeds    300  1  Page Should Not Contain Element    xpath=//tr/td[@data-label='Name' and (text()='${stream_name}' or *[text()='${stream_name}'])]
   # Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
 
 Create Topic
@@ -169,7 +171,7 @@ Delete Stream Topic
   Wait Until Page Does Not Contains HCC Generic Modal
   Capture Page Screenshot  deleting_after_modal.png
   Wait Until Page Contains    Create topic
-  Wait Until Keyword Succeeds    300  1  Page Should Not Contain    xpath=//tr/td[@data-label='Name' and *[text()='${topic_to_delete}']]
+  Wait Until Keyword Succeeds    300  1  Page Should Not Contain Element    xpath=//tr/td[@data-label='Name' and *[text()='${topic_to_delete}']]
   Capture Page Screenshot  deletion_topic.png
 
 Delete Service Account By Client ID
@@ -179,7 +181,7 @@ Delete Service Account By Client ID
   Click Button  Delete
   Wait Until Page Does Not Contains HCC Generic Modal
   Wait Until Page Contains    Create service account
-  Wait Until Keyword Succeeds    300  1  Page Should Not Contain    xpath=//tr[td[@data-label='Client ID' and text()='${client_id_delete}']]
+  Wait Until Keyword Succeeds    300  1  Page Should Not Contain Element    xpath=//tr/td[@data-label='Client ID' and text()='${client_id_delete}']
 
 
 Clean Up RHOSAK

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -186,6 +186,8 @@ Delete Service Account By Client ID
 
 Clean Up RHOSAK
   [Arguments]  ${stream_to_delete}  ${topic_to_delete}  ${sa_clientid_to_delete}
+  OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
+  Switch Window  title:Red Hat OpenShift Streams for Apache Kafka
   Menu.Navigate To Page    Streams for Apache Kafka   Kafka Instances
   Enter Stream  stream_name=${stream_to_delete}
   Enter Stream Topics Section
@@ -197,6 +199,3 @@ Clean Up RHOSAK
   Capture Page Screenshot  after deleting_stream.png
   Click Link  Service Accounts
   Delete Service Account By Client ID  client_id_delete=${sa_clientid_to_delete}
-  OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
-
-

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -18,7 +18,7 @@ Create Kafka Stream Instance
   END
   Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
   Click Element    xpath=//div[text()='${cloud_provider}']
-  Select From List By Value    id:cloud-region-select   ${stream_region}
+  Select From List By Value    id:form-cloud-region-option   ${stream_region}
   Click Button    Create instance
   Capture Page Screenshot  form.png
 

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -2,6 +2,9 @@
 Library         SeleniumLibrary
 Resource        HCCLogin.robot
 
+*** Variables ***
+${PERMISSION_GRID_XPATH_PREFIX}=  table[@aria-label='permission.table.table.permission_list_table']/tbody
+${PERMISSION_GRID_BUTTON_XPATH_PREFIX}=  div/ul[@class='pf-c-select__menu']/li
 
 *** Keywords ***
 Create Kafka Stream Instance
@@ -119,5 +122,6 @@ Assign Permissions To ServiceAccount in RHOSAK
       Click Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button[text()='${permissionvalue}']
 
       Click Button    Save
-      Wait Until Page Contains Element  xpath=//button[text()='Manage access']
+      Wait Until Page Does Not Contain Element   xpath=//div[(@id='manage-permissions-modal')]
+      # Wait Until Page Contains Element  xpath=//button[text()='Manage access']
   END

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -32,7 +32,6 @@ Create Kafka Stream Instance
 Check Stream Status
   [Arguments]  ${target_status}  ${target_stream}
   ${status}=  Get Text    xpath=//tr[td[@data-label='Name' and (text()='${target_stream}' or *[text()='${target_stream}'])]]/td[@data-label='Status']
-  #${status}=  Get Text    xpath=//tr[td[@data-label='Name' and *[text()='${target_stream}']]]/td[@data-label='Status']
   Should Be Equal    ${status}    ${target_status}
 
 Check Stream Creation

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -19,7 +19,7 @@ Create Kafka Stream Instance
   Wait Until Page Contains Element    xpath=//div[@id='modalCreateKafka']  timeout=10
   ${warn_msg}=  Run Keyword And Return Status    Page Should Not Contain    To deploy a new instance, delete your existing one first
   IF    ${warn_msg} == ${False}
-     Log  level=WARN  message=The next keywords are going to fail because you cannot create more than one stream at a time.
+     Log  level=ERROR  message=The next keywords are going to fail because you cannot create more than one stream at a time.
   END
   Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
   Click Element    xpath=//div[text()='${cloud_provider}']

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -31,7 +31,8 @@ Create Kafka Stream Instance
 
 Check Stream Status
   [Arguments]  ${target_status}  ${target_stream}
-  ${status}=  Get Text    xpath=//tr[td[@data-label='Name' and *[text()='${target_stream}']]]/td[@data-label='Status']
+  ${status}=  Get Text    xpath=//tr[td[@data-label='Name' and (text()='${target_stream}' or *[text()='${target_stream}'])]]/td[@data-label='Status']
+  #${status}=  Get Text    xpath=//tr[td[@data-label='Name' and *[text()='${target_stream}']]]/td[@data-label='Status']
   Should Be Equal    ${status}    ${target_status}
 
 Check Stream Creation

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -1,0 +1,123 @@
+*** Settings ***
+Library         SeleniumLibrary
+Resource        HCCLogin.robot
+
+
+*** Keywords ***
+Create Kafka Stream Instance
+  [Arguments]  ${stream_name}  ${stream_region}  ${cloud_provider}
+  Click Button  Create Kafka instance
+  Sleep  5
+  Maybe Accept Cookie Policy
+  Sleep  5
+  Maybe Agree RH Terms and Conditions
+  Wait Until Page Contains Element    xpath=//div[@id='modalCreateKafka']  timeout=10
+  ${warn_msg}=  Run Keyword And Return Status    Page Should Not Contain    To deploy a new instance, delete your existing one first
+  IF    ${warn_msg} == ${False}
+     Log  level=WARN  message=The next keywords are going to fail because you cannot create more than one stream at a time.
+  END
+  Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
+  Click Element    xpath=//div[text()='${cloud_provider}']
+  Select From List By Value    id:cloud-region-select   ${stream_region}
+  Click Button    Create instance
+  Capture Page Screenshot  form.png
+
+Check Stream Status
+  [Arguments]  ${target_status}
+  ${status}=  Get Text    xpath://tr[@tabindex='0']/td[@data-label='Status']
+  Should Be Equal    ${status}    ${target_status}
+
+Check Stream Creation
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+
+Delete Kafka Stream Instance
+  [Arguments]  ${stream_name}  ${stream_owner}
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
+  Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
+  Input Text    id:name__input   ${stream_name}
+  Click Button    Delete
+
+Create Topic
+  [Arguments]  ${topic_name_to_create}
+  Click Button  Create topic
+  Wait For HCC Splash Page
+  Input Text  name:step-topic-name  ${topic_name_to_create}
+  Click Button   Next
+  Wait Until Page Contains Element  xpath=//h2[text()='Partitions']
+  Click Button   Next
+  Wait Until Page Contains Element  xpath=//h2[text()='Message retention']
+  Click Button   Next
+  Wait Until Page Contains Element    xpath=//button[text()='Finish']
+  Click Button   Finish
+  Wait For HCC Splash Page
+
+Click ${action} Submenu From Actions Menu
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
+
+Create Service Account From Connection Menu
+  [Arguments]  ${sa_description}
+  # Set Log Level    NONE
+  Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  Click Button  xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  Wait Until Page Contains Element    xpath=//div[@id='modalCreateSAccount']
+  Input Text  xpath=//input[@id='text-input-short-description']  ${sa_description}
+  Click Button  Create
+  Wait Until Page Contains  Credentials successfully generated
+  ${kafka_client_id}=  Get Element Attribute  xpath=//input[@aria-label='Client ID']  value
+  ${kafka_client_secret}=  Get Element Attribute  xpath=//input[@aria-label='Client secret']  value
+  &{service_account_creds}=  Create Dictionary  kafka_client_id=${kafka_client_id}  kafka_client_secret=${kafka_client_secret}
+  Select Checkbox    xpath=//input[@class='pf-c-check__input']
+  Wait Until Element Is Enabled    xpath=//button[@data-testid='modalCredentials-buttonClose']
+  Click Button  xpath=//button[@data-testid='modalCredentials-buttonClose']
+  Wait Until Element Is Not Visible    xpath=//div[@class='pf-l-bullseye']
+  [Return]  &{service_account_creds}
+
+Assign Permissions To ServiceAccount in RHOSAK
+  [Arguments]  ${sa_client_id}  ${sa_to_assign}  ${topic_to_assign}  ${cg_to_assign}
+
+  &{topic_read_permissions}=  Create Dictionary  resource_name=Topic  search_type=Is  name_text=${topic_to_assign}  permissions_value=Read
+  &{topic_write_permissions}=  Create Dictionary  resource_name=Topic  search_type=Is  name_text=${topic_to_assign}  permissions_value=Write
+  &{cg_permissions}=  Create Dictionary  resource_name=Consumer group  search_type=Is  name_text=${cg_to_assign}  permissions_value=Read
+  &{permissions_grid}=  Create Dictionary  row1=&{topic_read_permissions}  row2=&{topic_write_permissions}  row3=&{cg_permissions}
+
+  ${permissions_items}     Get Dictionary Items   ${permissions_grid}
+
+  FOR    ${index}    ${row_n}   ${resource_dict}  IN ENUMERATE    @{permissions_items}  start=1
+      Click Button  Manage access
+      Wait Until Page Contains Element  xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//input[@aria-label='Select an account']
+      Sleep  1
+      Input Text  xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//input[@aria-label='Select an account']   ${sa_to_assign}
+      Click Element   xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//div[@class='pf-c-select__menu']/li/button/span[text()='${sa_client_id}']
+      Wait Until Element Is Enabled  xpath=//button[text()='Next']
+      Click Button  Next
+      Wait Until Page Contains  Assign permissions
+
+      ${resource}=  Set Variable  ${resource_dict}[resource_name]
+      ${searchtype}=  Set Variable  ${resource_dict}[search_type]
+      ${nametext}=  Set Variable  ${resource_dict}[name_text]
+      ${permissionvalue}=  Set Variable  ${resource_dict}[permissions_value]
+
+      ${index}=  Set Variable  1
+      Click Element  xpath=//${PERMISSION_GRID_XPATH_PREFIX}/tr[${index}]/td[@data-label='Resource']//button[@aria-label='Options menu']
+      Wait Until Page Contains Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button[text()='${resource}']
+      Click Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button[text()='${resource}']
+
+      Click Element  xpath=//${PERMISSION_GRID_XPATH_PREFIX}/tr[${index}]/td[@data-key='1']//button[@aria-label='Options menu']
+      Wait Until Page Contains Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button/span[text()='${searchtype}']
+      Click Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button/span[text()='${searchtype}']
+
+      Input Text  xpath=//${PERMISSION_GRID_XPATH_PREFIX}/tr[${index}]//input[@aria-label='permission.manage_permissions_dialog.assign_permissions.resource_name_aria']  ${nametext}
+
+      Click Element  xpath=//${PERMISSION_GRID_XPATH_PREFIX}/tr[${index}]/td[@data-key='4']/div[contains(@class, 'f-u-display-flex')]/div//button[@aria-label='Options menu']
+      Click Element  xpath=//${PERMISSION_GRID_XPATH_PREFIX}/tr[${index}]/td[@data-key='4']/div[contains(@class, 'f-u-display-flex')]/div//button[@aria-label='Options menu']
+      Wait Until Page Contains Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button[text()='${permissionvalue}']
+      Click Element  xpath=//${PERMISSION_GRID_BUTTON_XPATH_PREFIX}/button[text()='${permissionvalue}']
+
+      Click Button    Save
+      Wait Until Page Contains Element  xpath=//button[text()='Manage access']
+  END

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -51,7 +51,6 @@ Delete Kafka Stream Instance
   Sleep  3
   Wait Until Page Contains    Create Kafka instance
   Wait Until Keyword Succeeds    300  1  Page Should Not Contain Element    xpath=//tr/td[@data-label='Name' and (text()='${stream_name}' or *[text()='${stream_name}'])]
-  # Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
 
 Create Topic
   [Arguments]  ${topic_name_to_create}
@@ -67,16 +66,8 @@ Create Topic
   Click Button   Finish
   Wait For HCC Splash Page
 
-Click ${action} Submenu From Actions Menu
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
-
 Create Service Account From Connection Menu
   [Arguments]  ${sa_description}
-  # Set Log Level    NONE
-  ###Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
   Wait Until Element Is Visible    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
   Click Button  xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
   Wait Until Page Contains Element    xpath=//div[@id='modalCreateSAccount']
@@ -135,7 +126,6 @@ Assign Permissions To ServiceAccount in RHOSAK
 
       Click Button    Save
       Wait Until Page Does Not Contain Element   xpath=//div[(@id='manage-permissions-modal')]
-      # Wait Until Page Contains Element  xpath=//button[text()='Manage access']
   END
 
 Enter Stream

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -35,10 +35,8 @@ Check Stream Creation
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
 
 Delete Kafka Stream Instance
-  [Arguments]  ${stream_name}  ${stream_owner}
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
+  [Arguments]  ${stream_name}
+  Click From Actions Menu  search_col=Name  search_value=${stream_name}  action=Delete
   Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
   Input Text    id:name__input   ${stream_name}
   Click Button    Delete
@@ -66,7 +64,8 @@ Click ${action} Submenu From Actions Menu
 Create Service Account From Connection Menu
   [Arguments]  ${sa_description}
   # Set Log Level    NONE
-  Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  ###Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  Wait Until Element Is Visible    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
   Click Button  xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
   Wait Until Page Contains Element    xpath=//div[@id='modalCreateSAccount']
   Input Text  xpath=//input[@id='text-input-short-description']  ${sa_description}
@@ -126,3 +125,26 @@ Assign Permissions To ServiceAccount in RHOSAK
       Wait Until Page Does Not Contain Element   xpath=//div[(@id='manage-permissions-modal')]
       # Wait Until Page Contains Element  xpath=//button[text()='Manage access']
   END
+
+Enter Stream
+  [Arguments]  ${stream_name}
+  Wait Until Page Contains Element  xpath=//a[text()='${stream_name}']
+  Click Link    xpath=//a[text()='${stream_name}']
+  Wait For HCC Splash Page
+
+Enter Stream ${sec_title} Section
+  Click Button    xpath=//button[@aria-label='${sec_title}']
+  Wait For HCC Splash Page
+
+Click From Actions Menu
+  [Arguments]  ${search_col}  ${search_value}  ${action}
+  ${SEARCH_ROW_PATH}=  Set Variable  //tr/td[@data-label='${search_col}' and //*[text()='${search_value}']]
+  ${SIDE_BUTTON_PATH}=  Set Variable  ${SEARCH_ROW_PATH}/../td[contains(@class, 'pf-c-table__action')]
+  ${ACTION_MENU_PATH}=  Set Variable  ${SIDE_BUTTON_PATH}//button[@aria-label='Actions']
+  ${TARGET_ACTION_PATH}=  Set Variable  ${SIDE_BUTTON_PATH}//button[text()='${action}']
+  Wait Until Page Contains Element    xpath=${ACTION_MENU_PATH}
+  Click Button    xpath=${ACTION_MENU_PATH}
+  Wait Until Page Contains Element    xpath=${TARGET_ACTION_PATH}
+  Click Button    xpath=${TARGET_ACTION_PATH}
+
+

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -21,6 +21,7 @@ Create Kafka Stream Instance
   END
   Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
   Click Element    xpath=//div[text()='${cloud_provider}']
+  Click Element    id:form-cloud-region-option
   Select From List By Value    id:form-cloud-region-option   ${stream_region}
   Click Button    Create instance
   Capture Page Screenshot  form.png

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.resource
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.resource
@@ -1,0 +1,9 @@
+*** Settings ***
+Resource        ../ODHDashboard/ODHDashboard.robot
+Resource        ../../Components/Menu.robot
+Resource        ../../HybridCloudConsole/HCCLogin.robot
+Resource        ../../HybridCloudConsole/Rhosak.robot
+Resource        ../JupyterHub/LoginJupyterHub.robot
+Resource        ../JupyterHub/JupyterHubSpawner.robot
+Resource        ../JupyterHub/JupyterLabSidebar.robot
+Resource        Rhosak.robot

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.robot
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Library         SeleniumLibrary
+Library         ../../../../libs/Helpers.py
+Resource        ../JupyterHub/JupyterLabLauncher.robot
+Resource        ../../Components/Components.resource
+
+
+*** Keywords ***
+Check Consumer and Producer Output Equality
+  [Arguments]  ${producer_text}  ${consumer_text}
+  ${producer_output_list}=  Text To List  text=${producer_text}
+  ${consumer_output_list}=  Text To List  text=${consumer_text}
+  Should Be Equal    ${producer_output_list}    ${consumer_output_list}[1:]
+
+Load Kafka Notebooks From Git
+  [Arguments]  ${git_repo_http}
+  Open With JupyterLab Menu  File  New  Notebook
+  Sleep  1
+  Maybe Select Kernel
+  Sleep  3
+  Close Other JupyterLab Tabs
+  Clone Git Repository  REPO_URL=${git_repo_http}
+  Sleep  5
+
+Open Producer Notebook
+  [Arguments]  ${dir_path}  ${filename}
+  # open producer
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  ${dir_path}/${filename}
+  Click Element  xpath://div[.="Open"]
+  Wait Until ${filename} JupyterLab Tab Is Selected
+
+Open Consumer Notebook
+  [Arguments]  ${dir_path}  ${filename}
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  ${dir_path}/${filename}
+  Click Element  xpath://div[.="Open"]
+  Wait Until ${filename} JupyterLab Tab Is Selected
+
+Enable RHOSAK
+  Menu.Navigate To Page    Applications    Explore
+  Wait Until Page Contains    ${rhosak_displayed_appname}  timeout=30
+  Click Element     xpath://*[@id='${rhosak_real_appname}']
+  Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}   timeout=10   error=${rhosak_real_appname} does not have sidebar with information in the Explore page of ODS Dashboard
+  Page Should Contain Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}   message=${rhosak_real_appname} does not have a "Enable" button in ODS Dashboard
+  Click Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}
+  Wait Until Page Contains Element    xpath://div[contains(@id, 'pf-modal-part')]
+  Click Button    xpath://footer/button[text()='Enable']
+  Wait Until Page Contains Element   xpath://div[@class='pf-c-alert pf-m-success']

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.robot
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.robot
@@ -12,16 +12,6 @@ Check Consumer and Producer Output Equality
   ${consumer_output_list}=  Text To List  text=${consumer_text}
   Should Be Equal    ${producer_output_list}    ${consumer_output_list}[1:]
 
-Load Kafka Notebooks From Git
-  [Arguments]  ${git_repo_http}
-  Open With JupyterLab Menu  File  New  Notebook
-  Sleep  1
-  Maybe Select Kernel
-  Sleep  3
-  Close Other JupyterLab Tabs
-  Clone Git Repository  REPO_URL=${git_repo_http}
-  Sleep  5
-
 Open Producer Notebook
   [Arguments]  ${dir_path}  ${filename}
   # open producer

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.robot
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.robot
@@ -14,7 +14,6 @@ Check Consumer and Producer Output Equality
 
 Open Producer Notebook
   [Arguments]  ${dir_path}  ${filename}
-  # open producer
   Open With JupyterLab Menu  File  Open from Path…
   Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  ${dir_path}/${filename}
   Click Element  xpath://div[.="Open"]

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -328,7 +328,8 @@ Wait Until JupyterLab Code Cell Is Not Active In a Given Tab
   ...              This assumes that there is only one cell currently active and it is the currently selected cell
   ...              It works when there are multiple notebook tabs opened
   [Arguments]  ${tab_id_to_wait}  ${timeout}=120seconds
-  Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
+  Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[@aria-label="notebook content"]/div[1]/div[contains(@class, p-Cell-inputWrapper)]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
+  #Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
 
 Get Selected Tab ID
   ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
@@ -337,7 +338,8 @@ Get Selected Tab ID
 
 Get JupyterLab Code Output In a Given Tab
    [Arguments]  ${tab_id_to_read}
-   ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
+   ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]/div[@aria-label="notebook content"]/div[1]/div[contains(@class, jp-Cell-outputWrapper)]/div[contains(@class,"jp-Cell-outputArea")]//div[contains(@class,"jp-RenderedText")])[last()]
+   # ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
    [Return]  ${outputtext}
 
 Select ${filename} Tab

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -329,7 +329,6 @@ Wait Until JupyterLab Code Cell Is Not Active In a Given Tab
   ...              It works when there are multiple notebook tabs opened
   [Arguments]  ${tab_id_to_wait}  ${timeout}=120seconds
   Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[@aria-label="notebook content"]/div[1]/div[contains(@class, p-Cell-inputWrapper)]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
-  #Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
 
 Get Selected Tab ID
   ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
@@ -339,7 +338,6 @@ Get Selected Tab ID
 Get JupyterLab Code Output In a Given Tab
    [Arguments]  ${tab_id_to_read}
    ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]/div[@aria-label="notebook content"]/div[1]/div[contains(@class, jp-Cell-outputWrapper)]/div[contains(@class,"jp-Cell-outputArea")]//div[contains(@class,"jp-RenderedText")])[last()]
-   # ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
    [Return]  ${outputtext}
 
 Select ${filename} Tab

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -322,3 +322,23 @@ Run Current JupyterLab Code Cell MOD
     ${run icon} =    Get JupyterLab Icon XPath    run
     Click Element    xpath://div[@aria-labelledby="${tab-id}"]/div[1]//${run icon}
     Sleep    0.5s
+
+Wait Until JupyterLab Code Cell Is Not Active In a Given Tab
+  [Documentation]  Waits until the current cell no longer has an active prompt "[*]:".
+  ...              This assumes that there is only one cell currently active and it is the currently selected cell
+  ...              It works when there are multiple notebook tabs opened
+  [Arguments]  ${tab_id_to_wait}  ${timeout}=120seconds
+  Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
+
+Get Selected Tab ID
+  ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
+  ${tab-id} =    Get Element Attribute    ${active-nb-tab}    id
+  [Return]  ${tab-id}
+
+Get JupyterLab Code Output In a Given Tab
+   [Arguments]  ${tab_id_to_read}
+   ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
+   [Return]  ${outputtext}
+
+Select ${filename} Tab
+  Click Element    xpath:${JL_TABBAR_CONTENT_XPATH}/li/div[.="${filename}"]

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -7,16 +7,9 @@ Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
 Library         SeleniumLibrary
 Library         OpenShiftCLI
+Library    ../../../../libs/Helpers.py
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
-Test Setup      Kafka Test Setup
-
-*** Variables ***
-${rhosak_real_appname}=  rhosak
-${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
-${stream_name_test}=  qe-test-stream
-${stream_region_test}=  us-east-1
-${cloud_provider_test}=  Amazon Web Services
 
 
 *** Variables ***

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -2,6 +2,7 @@
 Library         SeleniumLibrary
 Library         OpenShiftCLI
 Resource        ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+Resource        ../../../Resources/Page/Components/Menu.robot
 Resource        ../../../Resources/Page/HybridCloudConsole/HCCLogin.robot
 Resource        ../../../Resources/Page/HybridCloudConsole/Rhosak.robot
 Resource        ../../../Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
@@ -61,7 +62,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Capture Page Screenshot  newly_created_stream.png
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
-  Delete Kafka Stream Instance  stream_name=${stream_name_test}  stream_owner=${SSO.USERNAME}
+  Delete Kafka Stream Instance  stream_name=${stream_name_test}
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Capture Page Screenshot  after deleting_stream.png
   OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
@@ -82,7 +83,6 @@ Verify User Is Able to Produce and Consume Events
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
   ## Create service account
-  # Click Connection Submenu From Actions Menu
   Click From Actions Menu  search_col=Name  search_value=${stream_name_test}  action=Connection
   Wait Until Page Contains Element  xpath=//input[@aria-label="Bootstrap server"]
   ${bootstrap_server}=  Get Element Attribute    xpath=//input[@aria-label="Bootstrap server"]  value
@@ -127,7 +127,10 @@ Verify User Is Able to Produce and Consume Events
   Check Consumer and Producer Output Equality  producer_text=${producer_output}  consumer_text=${consumer_output}
   Capture Page Screenshot  consumer_run.png
   Fix Spawner Status
-
+  Switch Window  title:Red Hat OpenShift Streams for Apache Kafka
+  Clean Up RHOSAK  stream_to_delete=${stream_name_test}
+  ...              topic_to_delete=${topic_name_test}
+  ...              sa_clientid_to_delete=${kafka_sa_creds}[kafka_client_id]
 
 
 *** Keywords ***

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -106,7 +106,7 @@ Verify User Is Able to Produce and Consume Events
   Open Consumer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_CONS_FILENAME}
   ${cons_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
-  Sleep  0.2
+  Sleep  1
   Open Producer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_PROD_FILENAME}
   ${prod_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -149,21 +149,18 @@ Assign Permissions To ServiceAccount in RHOSAK
   [Arguments]  ${sa_client_id}  ${sa_to_assign}
   Click Button  Manage access
   Wait Until Page Contains Element  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']
-  # /*/input[aria-label='Select an account']
-  Click Element   xpath=//div[@id='manage-permissions-modal']/form//div[contains(@class, 'pf-m-typeahead')]
-  # Click Element   xpath=//div[@id='manage-permissions-modal']/form//button[@aria-label='Options menu']
-  Execute JavaScript    document.querySelectorAll('[aria-label="Select an account"]').value="${sa_to_assign}";
+  # Click Element   xpath=//div[@id='manage-permissions-modal']/form//div[contains(@class, 'pf-m-typeahead')]
   # Input Text  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']   ${sa_to_assign}
-  Sleep  10
-  # Click Element  xpath=//div[@id='manage-permissions-modal']/form//li/button/span[text()='${sa_client_id}']
-  # # Click Element  xpath=//input[@arial-label='Select an account']
-  # Wait Until Element Is Enabled  xpath=//button[text()='Next']
-  # Click Button  Next
-  # Wait Until Page Contains  Assign permissions
-  # Click Element  xpath=//button[@aria-label='Options menu']
-  # Wait Until Page Contains Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
-  # Click Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
-  # Click Button  Add
+  Input Text  xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//input[@aria-label='Select an account']   ${sa_to_assign}
+  Sleep  1
+  Click Element   xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//li/button/span[text()='${sa_client_id}']
+  Wait Until Element Is Enabled  xpath=//button[text()='Next']
+  Click Button  Next
+  Wait Until Page Contains  Assign permissions
+  Click Element  xpath=//button[@aria-label='Options menu']
+  Wait Until Page Contains Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
+  Click Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
+  Click Button  Add
 
 
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -54,7 +54,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
   Capture Page Screenshot  newly_created_stream.png
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
-  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
   Delete Kafka Stream Instance  stream_name=${stream_name_test}
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Capture Page Screenshot  after deleting_stream.png
@@ -73,7 +73,7 @@ Verify User Is Able to Produce and Consume Events
   ## Create kafka stream
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
-  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
   ## Create service account
   Click From Actions Menu  search_col=Name  search_value=${stream_name_test}  action=Connection
   Wait Until Page Contains Element  xpath=//input[@aria-label="Bootstrap server"]
@@ -124,6 +124,7 @@ Verify User Is Able to Produce and Consume Events
   Clean Up RHOSAK  stream_to_delete=${stream_name_test}
   ...              topic_to_delete=${topic_name_test}
   ...              sa_clientid_to_delete=${kafka_sa_creds}[kafka_client_id]
+
 
 *** Keywords ***
 Kafka Suite Setup

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -59,7 +59,6 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Capture Page Screenshot  after deleting_stream.png
   OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
-  Delete    kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
 
 Verify User Is Able to Produce and Consume Events
   [Tags]  Sanity  Smoke

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -11,7 +11,7 @@ Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
 Resource        ../../../Resources/Page/ODH/AiApps/Rhosak.robot
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
-Test Setup      Kafka Test Setup
+#Test Setup      Kafka Test Setup
 
 *** Variables ***
 ${rhosak_real_appname}=  rhosak
@@ -110,7 +110,7 @@ Verify User Is Able to Produce and Consume Events
   Wait for JupyterLab Splash Screen  timeout=60
   Maybe Select Kernel
   ## clone JL notebooks from git and run
-  Load Kafka Notebooks From Git  git_repo_http=${GIT_REPO_NOTEBOOKS}
+  Clone Git Repository  REPO_URL=${GIT_REPO_NOTEBOOKS}
   Open Consumer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_CONS_FILENAME}
   ${cons_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
@@ -131,7 +131,6 @@ Verify User Is Able to Produce and Consume Events
   Clean Up RHOSAK  stream_to_delete=${stream_name_test}
   ...              topic_to_delete=${topic_name_test}
   ...              sa_clientid_to_delete=${kafka_sa_creds}[kafka_client_id]
-
 
 *** Keywords ***
 Kafka Suite Setup

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -57,7 +57,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
   Capture Page Screenshot  newly_created_stream.png
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
-  Wait Until Keyword Succeeds    300  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
+  Wait Until Keyword Succeeds    450  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
   Delete Kafka Stream Instance  stream_name=${stream_name_test}
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Capture Page Screenshot  after deleting_stream.png
@@ -79,7 +79,7 @@ Verify User Is Able to Produce and Consume Events
   ## Create kafka stream
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
-  Wait Until Keyword Succeeds    300  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
+  Wait Until Keyword Succeeds    450  1  Check Stream Status  target_status=Ready  target_stream=${stream_name_test}
   ## Create service account
   Click From Actions Menu  search_col=Name  search_value=${stream_name_test}  action=Connection
   Wait Until Page Contains Element  xpath=//input[@aria-label="Bootstrap server"]

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -9,12 +9,12 @@ Test Setup      Kafka Test Setup
 *** Variables ***
 ${rhosak_real_appname}=  rhosak
 ${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
-${stream_name_test}=  qe-stream-autotest
-${stream_region_test}=  us-east-1
-${cloud_provider_test}=  Amazon Web Services
-${service_account_test}=  qe-sa-autotest
-${topic_name_test}=   qe-topic-autotest
-${consumer_group_test}=  qe-cg-autotest
+${stream_name_test}=  ${RHOSAK_CONFIG_TEST.STREAM_NAME}
+${stream_region_test}=  ${RHOSAK_CONFIG_TEST.STREAM_REGION}
+${cloud_provider_test}=  ${RHOSAK_CONFIG_TEST.CLOUD_PROVIDER}
+${service_account_test}=  ${RHOSAK_CONFIG_TEST.SERVICE_ACCOUNT}
+${topic_name_test}=   ${RHOSAK_CONFIG_TEST.TOPIC_NAME}
+${consumer_group_test}=  ${RHOSAK_CONFIG_TEST.CONSUMER_GROUP}
 ${GIT_REPO_NOTEBOOKS}=  https://github.com/bdattoma/notebook-examples.git
 ${NOTEBOOK_DIR_PATH}=   notebook-examples/kafka-sasl-plain
 ${NOTEBOOK_CONS_FILENAME}=   2_kafka_consumer_print.ipynb

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -1,26 +1,32 @@
 *** Settings ***
-Resource        ../../../Resources/Page/LoginPage.robot
+Library         SeleniumLibrary
+Library         OpenShiftCLI
 Resource        ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource        ../../../Resources/Page/HybridCloudConsole/HCCLogin.robot
+Resource        ../../../Resources/Page/HybridCloudConsole/Rhosak.robot
 Resource        ../../../Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
 Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
-Library         SeleniumLibrary
-Library         OpenShiftCLI
-Library    ../../../../libs/Helpers.py
+Resource        ../../../Resources/Page/ODH/AiApps/Rhosak.robot
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
-
+Test Setup      Kafka Test Setup
 
 *** Variables ***
 ${rhosak_real_appname}=  rhosak
 ${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
-${stream_name_test}=  qe-stream-test
+${stream_name_test}=  qe-stream-autotest
 ${stream_region_test}=  us-east-1
 ${cloud_provider_test}=  Amazon Web Services
-${service_account_test}=  qe-sa-test2
-${topic_name_test}=   qe-topic-test2
-${consumer_group_test}=  qe-cg-test2
+${service_account_test}=  qe-sa-autotest
+${topic_name_test}=   qe-topic-autotest
+${consumer_group_test}=  qe-cg-autotest
+${PERMISSION_GRID_XPATH_PREFIX}=  table[@aria-label='permission.table.table.permission_list_table']/tbody
+${PERMISSION_GRID_BUTTON_XPATH_PREFIX}=  div/ul[@class='pf-c-select__menu']/li
+${GIT_REPO_NOTEBOOKS}=  https://github.com/bdattoma/notebook-examples.git
+${NOTEBOOK_DIR_PATH}=   notebook-examples/kafka-sasl-plain
+${NOTEBOOK_CONS_FILENAME}=   2_kafka_consumer_print.ipynb
+${NOTEBOOK_PROD_FILENAME}=   1_kafka_producer.ipynb
 
 *** Test Cases ***
 Verify RHOSAK Is Available In RHODS Dashboard Explore Page
@@ -66,13 +72,13 @@ Verify User Is Able to Create And Delete a Kafka Stream
 Verify User Is Able to Produce and Consume Events
   [Tags]  Sanity  Smoke
   ...     ODS-242-ext
-
-  # test setup -
-  Open Browser  https://jupyterhub-redhat-ods-applications.apps.ods-qe-tc.agbe.s1.devshift.org/user/ldap-admin9/lab  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  # Wait for JupyterLab Splash Screen  timeout=60
-  Maybe Select Kernel
-
+  Enable RHOSAK
+  Verify Service Is Enabled  ${rhosak_displayed_appname}
+  Launch OpenShift Streams for Apache Kafka From RHODS Dashboard Link
+  Login to HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
+  Maybe Skip RHOSAK Tour
+  Sleep  5
+  Wait Until Page Contains    Create Kafka instance
   ## Create kafka stream
   Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
@@ -90,149 +96,44 @@ Verify User Is Able to Produce and Consume Events
   Wait For HCC Splash Page
   Create Topic  topic_name_to_create=${topic_name_test}
   Page Should Contain Element    xpath=//a[text()='${topic_name_test}']
+  ## Assign permissions to SA
+  Click Button    xpath=//button[@aria-label='Access']
+  Wait For HCC Splash Page
+  Assign Permissions To ServiceAccount in RHOSAK  sa_client_id=${kafka_sa_creds}[kafka_client_id]  sa_to_assign=${service_account_test}
+  ...                                             topic_to_assign=${topic_name_test}  cg_to_assign=${consumer_group_test}
 
-
-  ## Assign permissions
   ## Spawn a notebook with env variables
-
-  Sleep  3
-  # Load Kafka Notebooks From Git
-  Open Consumer notebook
+  Switch Window  url:${ODH_DASHBOARD_URL}
+  Wait for RHODS Dashboard to Load
+  Launch JupyterHub Spawner From Dashboard
+  Wait Until Page Contains Element  xpath://input[@name="Standard Data Science"]
+  &{notebook_envs}=  Create Dictionary  KAFKA_BOOTSTRAP_SERVER=${bootstrap_server}  KAFKA_USERNAME=${kafka_sa_creds}[kafka_client_id]
+  ...                                   KAFKA_PASSWORD=${kafka_sa_creds}[kafka_client_secret]  KAFKA_TOPIC=${topic_name_test}
+  ...                                   KAFKA_CONSUMER_GROUP=${consumer_group_test}
+  Spawn Notebook With Arguments  image=s2i-generic-data-science-notebook  envs=&{notebook_envs}
+  Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+  ## clone JL notebooks from git and run
+  Load Kafka Notebooks From Git  git_repo_http=${GIT_REPO_NOTEBOOKS}
+  Open Consumer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_CONS_FILENAME}
   ${cons_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
-  Open Producer notebook
+  Open Producer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_PROD_FILENAME}
   ${prod_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
   Wait Until JupyterLab Code Cell Is Not Active In a Given Tab  tab_id_to_wait=${prod_tab_id}
   Capture Page Screenshot  cell_not_active.png
   ${producer_output} =  Get JupyterLab Code Output In a Given Tab  tab_id_to_read=${prod_tab_id}
   Capture Page Screenshot  producer_run.png
-  Select 2_kafka_consumer_print.ipynb Tab
+  Select ${NOTEBOOK_CONS_FILENAME} Tab
   Sleep  3
   ${consumer_output} =  Get JupyterLab Code Output In a Given Tab  tab_id_to_read=${cons_tab_id}
   Check Consumer and Producer Output Equality  producer_text=${producer_output}  consumer_text=${consumer_output}
-  Sleep  3
   Capture Page Screenshot  consumer_run.png
-  #############END DRAFT CODE##############
-  # Launch JupyterHub Spawner From Dashboard
-  #Wait Until Page Contains Element  xpath://input[@name="Standard Data Science"]
-  #Spawn Notebook With Arguments  image=s2i-generic-data-science-notebook
-  #Wait for JupyterLab Splash Screen  timeout=60
-  #Maybe Select Kernel
-  #Load Kafka Notebooks From Git
-  #Open Producer notebook
-  #Open With JupyterLab Menu  Run  Run All Cells
+  Fix Spawner Status
 
 
-
-Verify Permission Assignment
-  [Tags]  access
-  Open Browser  https://console.redhat.com/application-services/streams/kafkas/c6j2losoj920eaqq5gf0/acls  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  # Open Browser  https://console.redhat.com/application-services/streams/kafkas  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login to HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
-  # Maybe Skip RHOSAK Tour
-  # Sleep  5
-  # Wait Until Page Contains    Create Kafka instance
-  # Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
-  # Wait Until Page Contains Element  xpath=//a[text()='${stream_name_test}']
-  # Click Link    xpath=//a[text()='${stream_name_test}']
-  # Wait For HCC Splash Page
-  # Click Button    xpath=//button[@aria-label='Access']
-  # Wait For HCC Splash Page
-  Sleep  3
-  Assign Permissions To ServiceAccount in RHOSAK  sa_client_id=srvc-acct-898640c2-50a6-48bc-984c-6e72e8a93cbe  sa_to_assign=${service_account_test}
-
-
-
-** Keywords ***
-Assign Permissions To ServiceAccount in RHOSAK
-  [Arguments]  ${sa_client_id}  ${sa_to_assign}
-  Click Button  Manage access
-  Wait Until Page Contains Element  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']
-  # Click Element   xpath=//div[@id='manage-permissions-modal']/form//div[contains(@class, 'pf-m-typeahead')]
-  # Input Text  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']   ${sa_to_assign}
-  Input Text  xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//input[@aria-label='Select an account']   ${sa_to_assign}
-  Sleep  1
-  Click Element   xpath=//div[(@id='manage-permissions-modal') and (@class='pf-c-modal-box__body')]/form//li/button/span[text()='${sa_client_id}']
-  Wait Until Element Is Enabled  xpath=//button[text()='Next']
-  Click Button  Next
-  Wait Until Page Contains  Assign permissions
-  Click Element  xpath=//button[@aria-label='Options menu']
-  Wait Until Page Contains Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
-  Click Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
-  Click Button  Add
-
-
-
-
-Wait Until JupyterLab Code Cell Is Not Active In a Given Tab
-  [Documentation]  Waits until the current cell no longer has an active prompt "[*]:".
-  ...              This assumes that there is only one cell currently active and it is the currently selected cell
-  ...              It works when there are multiple notebook tabs opened
-  [Arguments]  ${tab_id_to_wait}  ${timeout}=120seconds
-  Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
-
-Get Selected Tab ID
-  ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
-  ${tab-id} =    Get Element Attribute    ${active-nb-tab}    id
-  [Return]  ${tab-id}
-
-Get JupyterLab Code Output In a Given Tab
-   [Arguments]  ${tab_id_to_read}
-   ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
-   [Return]  ${outputtext}
-
-Select ${filename} Tab
-  Click Element    xpath:${JL_TABBAR_CONTENT_XPATH}/li/div[.="${filename}"]
-
-Check Consumer and Producer Output Equality
-  [Arguments]  ${producer_text}  ${consumer_text}
-  ${producer_output_list}=  Text To List  text=${producer_text}
-  ${consumer_output_list}=  Text To List  text=${consumer_text}
-  Should Be Equal    ${producer_output_list}    ${consumer_output_list}[1:]
-
-Kafka Test Setup MOD
-  Open Browser  https://jupyterhub-redhat-ods-applications.apps.ods-qe-tc.agbe.s1.devshift.org/user/ldap-admin9/lab  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  # Wait for JupyterLab Splash Screen  timeout=60
-  Maybe Select Kernel
-
-Launch JupyterHub Spawner From Dashboard MOD
-  Menu.Navigate To Page    Applications    Enabled
-  Launch JupyterHub From RHODS Dashboard Dropdown
-  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  # ${authorization_required} =  Is Service Account Authorization Required
-  # Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
-  # Fix Spawner Status
-  Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
-
-Load Kafka Notebooks From Git
-  Open With JupyterLab Menu  File  New  Notebook
-  Sleep  1
-  Maybe Select Kernel
-  Sleep  3
-  Close Other JupyterLab Tabs
-  Navigate Home (Root folder) In JupyterLab Sidebar File Browser
-  Open With JupyterLab Menu  Git  Clone a Repository
-  Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/bdattoma/notebook-examples.git
-  Click Element  xpath://div[.="CLONE"]
-  Sleep  5
-
-Open Producer notebook
-  # open producer
-  Open With JupyterLab Menu  File  Open from Path…
-  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  notebook-examples/kafka-sasl-plain/1_kafka_producer.ipynb
-  Click Element  xpath://div[.="Open"]
-  Wait Until 1_kafka_producer.ipynb JupyterLab Tab Is Selected
-
-Open Consumer notebook
-  # open consumer
-  Open With JupyterLab Menu  File  Open from Path…
-  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  notebook-examples/kafka-sasl-plain/2_kafka_consumer_print.ipynb
-  Click Element  xpath://div[.="Open"]
-  Wait Until 2_kafka_consumer_print.ipynb JupyterLab Tab Is Selected
-
-
+*** Keywords ***
 Kafka Suite Setup
   Set Library Search Order  SeleniumLibrary
 
@@ -244,89 +145,16 @@ Kafka Test Setup
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
 
-Enable RHOSAK
-  Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    ${rhosak_displayed_appname}  timeout=30
-  Click Element     xpath://*[@id='${rhosak_real_appname}']
-  Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}   timeout=10   error=${rhosak_real_appname} does not have sidebar with information in the Explore page of ODS Dashboard
-  Page Should Contain Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}   message=${rhosak_real_appname} does not have a "Enable" button in ODS Dashboard
-  Click Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}
-  Wait Until Page Contains Element    xpath://div[contains(@id, 'pf-modal-part')]
-  Click Button    xpath://footer/button[text()='Enable']
-  Wait Until Page Contains Element   xpath://div[@class='pf-c-alert pf-m-success']
-
-Check Stream Status
-  [Arguments]  ${target_status}
-  ${status}=  Get Text    xpath://tr[@tabindex='0']/td[@data-label='Status']
-  Should Be Equal    ${status}    ${target_status}
-
-Check Stream Creation
-  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
 
 
-Create Kafka Stream Instance
-  [Arguments]  ${stream_name}  ${stream_region}  ${cloud_provider}
-  Click Button  Create Kafka instance
-  Sleep  5
-  Maybe Accept Cookie Policy
-  Sleep  5
-  Maybe Agree RH Terms and Conditions
-  Wait Until Page Contains Element    xpath=//div[@id='modalCreateKafka']  timeout=10
-  ${warn_msg}=  Run Keyword And Return Status    Page Should Not Contain    To deploy a new instance, delete your existing one first
-  IF    ${warn_msg} == ${False}
-     Log  level=WARN  message=The next keywords are going to fail because you cannot create more than one stream at a time.
-  END
-  Input Text    xpath=//input[@id='form-instance-name']    ${stream_name}
-  Click Element    xpath=//div[text()='${cloud_provider}']
-  Select From List By Value    id:form-cloud-region-option   ${stream_region}
-  Click Button    Create instance
-  Capture Page Screenshot  form.png
-  Sleep    2
 
-Delete Kafka Stream Instance
-  [Arguments]  ${stream_name}  ${stream_owner}
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='Delete']
-  Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
-  Input Text    id:name__input   ${stream_name}
-  Click Button    Delete
 
-Click ${action} Submenu From Actions Menu
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
-  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
-  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
 
-Create Service Account From Connection Menu
-  [Arguments]  ${sa_description}
-  # Set Log Level    NONE
-  Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
-  Click Button  xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
-  Wait Until Page Contains Element    xpath=//div[@id='modalCreateSAccount']
-  Input Text  xpath=//input[@id='text-input-short-description']  ${sa_description}
-  Click Button  Create
-  Wait Until Page Contains  Credentials successfully generated
-  ${kafka_client_id}=  Get Element Attribute  xpath=//input[@aria-label='Client ID']  value
-  ${kafka_client_secret}=  Get Element Attribute  xpath=//input[@aria-label='Client secret']  value
-  &{service_account_creds}=  Create Dictionary  kafka_client_id=${kafka_client_id}  kafka_client_secret=${kafka_client_secret}
-  Select Checkbox    xpath=//input[@class='pf-c-check__input']
-  Wait Until Element Is Enabled    xpath=//button[@data-testid='modalCredentials-buttonClose']
-  [Return]  &{service_account_creds}
 
-Create Topic
-  [Arguments]  ${topic_name_to_create}
-  Click Button  Create topic
-  Wait For HCC Splash Page
-  Input Text  name:step-topic-name  ${topic_name_to_create}
-  Click Button   Next
-  Wait Until Page Contains Element  xpath=//h2[text()='Partitions']
-  Click Button   Next
-  Wait Until Page Contains Element  xpath=//h2[text()='Message retention']
-  Click Button   Next
-  Wait Until Page Contains Element    xpath=//button[text()='Finish']
-  Click Button   Finish
-  Wait For HCC Splash Page
+
+
+
+
 
 
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -21,8 +21,6 @@ ${cloud_provider_test}=  Amazon Web Services
 ${service_account_test}=  qe-sa-autotest
 ${topic_name_test}=   qe-topic-autotest
 ${consumer_group_test}=  qe-cg-autotest
-${PERMISSION_GRID_XPATH_PREFIX}=  table[@aria-label='permission.table.table.permission_list_table']/tbody
-${PERMISSION_GRID_BUTTON_XPATH_PREFIX}=  div/ul[@class='pf-c-select__menu']/li
 ${GIT_REPO_NOTEBOOKS}=  https://github.com/bdattoma/notebook-examples.git
 ${NOTEBOOK_DIR_PATH}=   notebook-examples/kafka-sasl-plain
 ${NOTEBOOK_CONS_FILENAME}=   2_kafka_consumer_print.ipynb

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -15,9 +15,12 @@ Suite Teardown  Kafka Suite Teardown
 *** Variables ***
 ${rhosak_real_appname}=  rhosak
 ${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
-${stream_name_test}=  qe-test-stream
+${stream_name_test}=  qe-stream-test
 ${stream_region_test}=  us-east-1
 ${cloud_provider_test}=  Amazon Web Services
+${service_account_test}=  qe-sa-test2
+${topic_name_test}=   qe-topic-test2
+${consumer_group_test}=  qe-cg-test2
 
 *** Test Cases ***
 Verify RHOSAK Is Available In RHODS Dashboard Explore Page
@@ -58,8 +61,181 @@ Verify User Is Able to Create And Delete a Kafka Stream
   Wait Until Keyword Succeeds    300  1  Page Should Contain    No results found
   Capture Page Screenshot  after deleting_stream.png
   OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
+  Delete    kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
 
-*** Keywords ***
+Verify User Is Able to Produce and Consume Events
+  [Tags]  Sanity  Smoke
+  ...     ODS-242-ext
+
+  # test setup -
+  Open Browser  https://jupyterhub-redhat-ods-applications.apps.ods-qe-tc.agbe.s1.devshift.org/user/ldap-admin9/lab  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  # Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+
+  ## Create kafka stream
+  Create Kafka Stream Instance  stream_name=${stream_name_test}  stream_region=${stream_region_test}  cloud_provider=${cloud_provider_test}
+  Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
+  Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
+  ## Create service account
+  Click Connection Submenu From Actions Menu
+  Wait Until Page Contains Element  xpath=//input[@aria-label="Bootstrap server"]
+  ${bootstrap_server}=  Get Element Attribute    xpath=//input[@aria-label="Bootstrap server"]  value
+  ${kafka_sa_creds}=  Create Service Account From Connection Menu  sa_description=${service_account_test}
+  ## Create topic
+  Wait Until Page Contains Element  xpath=//a[text()='${stream_name_test}']
+  Click Link    xpath=//a[text()='${stream_name_test}']
+  Wait For HCC Splash Page
+  Click Button    xpath=//button[@aria-label='Topics']
+  Wait For HCC Splash Page
+  Create Topic  topic_name_to_create=${topic_name_test}
+  Page Should Contain Element    xpath=//a[text()='${topic_name_test}']
+
+
+  ## Assign permissions
+  ## Spawn a notebook with env variables
+
+  Sleep  3
+  # Load Kafka Notebooks From Git
+  Open Consumer notebook
+  ${cons_tab_id} =    Get Selected Tab ID
+  Open With JupyterLab Menu  Run  Run All Cells
+  Open Producer notebook
+  ${prod_tab_id} =    Get Selected Tab ID
+  Open With JupyterLab Menu  Run  Run All Cells
+  Wait Until JupyterLab Code Cell Is Not Active In a Given Tab  tab_id_to_wait=${prod_tab_id}
+  Capture Page Screenshot  cell_not_active.png
+  ${producer_output} =  Get JupyterLab Code Output In a Given Tab  tab_id_to_read=${prod_tab_id}
+  Capture Page Screenshot  producer_run.png
+  Select 2_kafka_consumer_print.ipynb Tab
+  Sleep  3
+  ${consumer_output} =  Get JupyterLab Code Output In a Given Tab  tab_id_to_read=${cons_tab_id}
+  Check Consumer and Producer Output Equality  producer_text=${producer_output}  consumer_text=${consumer_output}
+  Sleep  3
+  Capture Page Screenshot  consumer_run.png
+  #############END DRAFT CODE##############
+  # Launch JupyterHub Spawner From Dashboard
+  #Wait Until Page Contains Element  xpath://input[@name="Standard Data Science"]
+  #Spawn Notebook With Arguments  image=s2i-generic-data-science-notebook
+  #Wait for JupyterLab Splash Screen  timeout=60
+  #Maybe Select Kernel
+  #Load Kafka Notebooks From Git
+  #Open Producer notebook
+  #Open With JupyterLab Menu  Run  Run All Cells
+
+
+
+Verify Permission Assignment
+  [Tags]  access
+  Open Browser  https://console.redhat.com/application-services/streams/kafkas/c6j2losoj920eaqq5gf0/acls  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  # Open Browser  https://console.redhat.com/application-services/streams/kafkas  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login to HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
+  # Maybe Skip RHOSAK Tour
+  # Sleep  5
+  # Wait Until Page Contains    Create Kafka instance
+  # Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
+  # Wait Until Page Contains Element  xpath=//a[text()='${stream_name_test}']
+  # Click Link    xpath=//a[text()='${stream_name_test}']
+  # Wait For HCC Splash Page
+  # Click Button    xpath=//button[@aria-label='Access']
+  # Wait For HCC Splash Page
+  Sleep  3
+  Assign Permissions To ServiceAccount in RHOSAK  sa_client_id=srvc-acct-898640c2-50a6-48bc-984c-6e72e8a93cbe  sa_to_assign=${service_account_test}
+
+
+
+** Keywords ***
+Assign Permissions To ServiceAccount in RHOSAK
+  [Arguments]  ${sa_client_id}  ${sa_to_assign}
+  Click Button  Manage access
+  Wait Until Page Contains Element  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']
+  # /*/input[aria-label='Select an account']
+  Click Element   xpath=//div[@id='manage-permissions-modal']/form//div[contains(@class, 'pf-m-typeahead')]
+  # Click Element   xpath=//div[@id='manage-permissions-modal']/form//button[@aria-label='Options menu']
+  Execute JavaScript    document.querySelectorAll('[aria-label="Select an account"]').value="${sa_to_assign}";
+  # Input Text  xpath=//div[@id='manage-permissions-modal']/form//input[@aria-label='Select an account']   ${sa_to_assign}
+  Sleep  10
+  # Click Element  xpath=//div[@id='manage-permissions-modal']/form//li/button/span[text()='${sa_client_id}']
+  # # Click Element  xpath=//input[@arial-label='Select an account']
+  # Wait Until Element Is Enabled  xpath=//button[text()='Next']
+  # Click Button  Next
+  # Wait Until Page Contains  Assign permissions
+  # Click Element  xpath=//button[@aria-label='Options menu']
+  # Wait Until Page Contains Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
+  # Click Element  xpath=//div/ul[@class='pf-c-select__menu']/li/button[text()='Topic']
+  # Click Button  Add
+
+
+
+
+Wait Until JupyterLab Code Cell Is Not Active In a Given Tab
+  [Documentation]  Waits until the current cell no longer has an active prompt "[*]:".
+  ...              This assumes that there is only one cell currently active and it is the currently selected cell
+  ...              It works when there are multiple notebook tabs opened
+  [Arguments]  ${tab_id_to_wait}  ${timeout}=120seconds
+  Wait Until Element Is Not Visible  //div[@aria-labelledby="${tab_id_to_wait}"]/div[2]/div[1]/div[2]/div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]   ${timeout}
+
+Get Selected Tab ID
+  ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
+  ${tab-id} =    Get Element Attribute    ${active-nb-tab}    id
+  [Return]  ${tab-id}
+
+Get JupyterLab Code Output In a Given Tab
+   [Arguments]  ${tab_id_to_read}
+   ${outputtext}=  Get Text  (//div[@aria-labelledby="${tab_id_to_read}"]//div[2]/div[1]/div[3]/div[contains(@class,"jp-Cell-outputArea")]/div/div[contains(@class,"jp-RenderedText")])[last()]
+   [Return]  ${outputtext}
+
+Select ${filename} Tab
+  Click Element    xpath:${JL_TABBAR_CONTENT_XPATH}/li/div[.="${filename}"]
+
+Check Consumer and Producer Output Equality
+  [Arguments]  ${producer_text}  ${consumer_text}
+  ${producer_output_list}=  Text To List  text=${producer_text}
+  ${consumer_output_list}=  Text To List  text=${consumer_text}
+  Should Be Equal    ${producer_output_list}    ${consumer_output_list}[1:]
+
+Kafka Test Setup MOD
+  Open Browser  https://jupyterhub-redhat-ods-applications.apps.ods-qe-tc.agbe.s1.devshift.org/user/ldap-admin9/lab  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  # Wait for JupyterLab Splash Screen  timeout=60
+  Maybe Select Kernel
+
+Launch JupyterHub Spawner From Dashboard MOD
+  Menu.Navigate To Page    Applications    Enabled
+  Launch JupyterHub From RHODS Dashboard Dropdown
+  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+  # ${authorization_required} =  Is Service Account Authorization Required
+  # Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
+  # Fix Spawner Status
+  Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+
+Load Kafka Notebooks From Git
+  Open With JupyterLab Menu  File  New  Notebook
+  Sleep  1
+  Maybe Select Kernel
+  Sleep  3
+  Close Other JupyterLab Tabs
+  Navigate Home (Root folder) In JupyterLab Sidebar File Browser
+  Open With JupyterLab Menu  Git  Clone a Repository
+  Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/bdattoma/notebook-examples.git
+  Click Element  xpath://div[.="CLONE"]
+  Sleep  5
+
+Open Producer notebook
+  # open producer
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  notebook-examples/kafka-sasl-plain/1_kafka_producer.ipynb
+  Click Element  xpath://div[.="Open"]
+  Wait Until 1_kafka_producer.ipynb JupyterLab Tab Is Selected
+
+Open Consumer notebook
+  # open consumer
+  Open With JupyterLab Menu  File  Open from Path…
+  Input Text  xpath=//input[@placeholder="/path/relative/to/jlab/root"]  notebook-examples/kafka-sasl-plain/2_kafka_consumer_print.ipynb
+  Click Element  xpath://div[.="Open"]
+  Wait Until 2_kafka_consumer_print.ipynb JupyterLab Tab Is Selected
+
+
 Kafka Suite Setup
   Set Library Search Order  SeleniumLibrary
 
@@ -118,5 +294,47 @@ Delete Kafka Stream Instance
   Wait Until Page Contains Element    xpath=//div[contains(@id, 'pf-modal-part')]
   Input Text    id:name__input   ${stream_name}
   Click Button    Delete
+
+Click ${action} Submenu From Actions Menu
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/button[@aria-label='Actions']
+  Wait Until Page Contains Element    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
+  Click Button    xpath=//tr[@tabindex='0']/td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[text()='${action}']
+
+Create Service Account From Connection Menu
+  [Arguments]  ${sa_description}
+  # Set Log Level    NONE
+  Wait Until Page Contains Element    xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  Click Button  xpath=//section[contains(@id, 'pf-tab-section-connection')]/div/button[text()='Create service account']
+  Wait Until Page Contains Element    xpath=//div[@id='modalCreateSAccount']
+  Input Text  xpath=//input[@id='text-input-short-description']  ${sa_description}
+  Click Button  Create
+  Wait Until Page Contains  Credentials successfully generated
+  ${kafka_client_id}=  Get Element Attribute  xpath=//input[@aria-label='Client ID']  value
+  ${kafka_client_secret}=  Get Element Attribute  xpath=//input[@aria-label='Client secret']  value
+  &{service_account_creds}=  Create Dictionary  kafka_client_id=${kafka_client_id}  kafka_client_secret=${kafka_client_secret}
+  Select Checkbox    xpath=//input[@class='pf-c-check__input']
+  Wait Until Element Is Enabled    xpath=//button[@data-testid='modalCredentials-buttonClose']
+  [Return]  &{service_account_creds}
+
+Create Topic
+  [Arguments]  ${topic_name_to_create}
+  Click Button  Create topic
+  Wait For HCC Splash Page
+  Input Text  name:step-topic-name  ${topic_name_to_create}
+  Click Button   Next
+  Wait Until Page Contains Element  xpath=//h2[text()='Partitions']
+  Click Button   Next
+  Wait Until Page Contains Element  xpath=//h2[text()='Message retention']
+  Click Button   Next
+  Wait Until Page Contains Element    xpath=//button[text()='Finish']
+  Click Button   Finish
+  Wait For HCC Splash Page
+
+
+
+
+
+
 
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -128,10 +128,6 @@ Verify User Is Able to Produce and Consume Events
   Check Consumer and Producer Output Equality  producer_text=${producer_output}  consumer_text=${consumer_output}
   Capture Page Screenshot  consumer_run.png
   Fix Spawner Status
-  ### Switch Window  title:Red Hat OpenShift Streams for Apache Kafka
-  ### Clean Up RHOSAK  stream_to_delete=${stream_name_test}
-  ### ...              topic_to_delete=${topic_name_test}
-  ### ...              sa_clientid_to_delete=${kafka_sa_creds}[kafka_client_id]
 
 
 *** Keywords ***

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -11,7 +11,7 @@ Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
 Resource        ../../../Resources/Page/ODH/AiApps/Rhosak.robot
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
-#Test Setup      Kafka Test Setup
+Test Setup      Kafka Test Setup
 
 *** Variables ***
 ${rhosak_real_appname}=  rhosak

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -2,11 +2,22 @@
 Resource        ../../../Resources/Page/LoginPage.robot
 Resource        ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource        ../../../Resources/Page/HybridCloudConsole/HCCLogin.robot
+Resource        ../../../Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
+Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
 Library         SeleniumLibrary
 Library         OpenShiftCLI
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
 Test Setup      Kafka Test Setup
+
+*** Variables ***
+${rhosak_real_appname}=  rhosak
+${rhosak_displayed_appname}=  OpenShift Streams for Apache Kafka
+${stream_name_test}=  qe-test-stream
+${stream_region_test}=  us-east-1
+${cloud_provider_test}=  Amazon Web Services
+
 
 *** Variables ***
 ${rhosak_real_appname}=  rhosak

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -82,21 +82,19 @@ Verify User Is Able to Produce and Consume Events
   Search Item By Name and Owner in RHOSAK Table  name_search_term=${stream_name_test}  owner_search_term=${SSO.USERNAME}
   Wait Until Keyword Succeeds    300  1  Check Stream Status  Ready
   ## Create service account
-  Click Connection Submenu From Actions Menu
+  # Click Connection Submenu From Actions Menu
+  Click From Actions Menu  search_col=Name  search_value=${stream_name_test}  action=Connection
   Wait Until Page Contains Element  xpath=//input[@aria-label="Bootstrap server"]
   ${bootstrap_server}=  Get Element Attribute    xpath=//input[@aria-label="Bootstrap server"]  value
   ${kafka_sa_creds}=  Create Service Account From Connection Menu  sa_description=${service_account_test}
   ## Create topic
-  Wait Until Page Contains Element  xpath=//a[text()='${stream_name_test}']
-  Click Link    xpath=//a[text()='${stream_name_test}']
-  Wait For HCC Splash Page
-  Click Button    xpath=//button[@aria-label='Topics']
-  Wait For HCC Splash Page
+  Enter Stream  stream_name=${stream_name_test}
+  Enter Stream Topics Section
+  # Wait For HCC Splash Page
   Create Topic  topic_name_to_create=${topic_name_test}
   Page Should Contain Element    xpath=//a[text()='${topic_name_test}']
   ## Assign permissions to SA
-  Click Button    xpath=//button[@aria-label='Access']
-  Wait For HCC Splash Page
+  Enter Stream Access Section
   Assign Permissions To ServiceAccount in RHOSAK  sa_client_id=${kafka_sa_creds}[kafka_client_id]  sa_to_assign=${service_account_test}
   ...                                             topic_to_assign=${topic_name_test}  cg_to_assign=${consumer_group_test}
 
@@ -131,6 +129,7 @@ Verify User Is Able to Produce and Consume Events
   Fix Spawner Status
 
 
+
 *** Keywords ***
 Kafka Suite Setup
   Set Library Search Order  SeleniumLibrary
@@ -142,6 +141,12 @@ Kafka Test Setup
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
+
+
+
+
+
+
 
 
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -1,14 +1,7 @@
 *** Settings ***
 Library         SeleniumLibrary
 Library         OpenShiftCLI
-Resource        ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
-Resource        ../../../Resources/Page/Components/Menu.robot
-Resource        ../../../Resources/Page/HybridCloudConsole/HCCLogin.robot
-Resource        ../../../Resources/Page/HybridCloudConsole/Rhosak.robot
-Resource        ../../../Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
-Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
-Resource        ../../../Resources/Page/ODH/JupyterHub/JupyterLabSidebar.robot
-Resource        ../../../Resources/Page/ODH/AiApps/Rhosak.robot
+Resource        ../../../Resources/Page/ODH/AiApps/Rhosak.resource
 Suite Setup     Kafka Suite Setup
 Suite Teardown  Kafka Suite Teardown
 Test Setup      Kafka Test Setup

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -64,7 +64,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
   OpenShiftCLI.Delete      kind=ConfigMap  name=rhosak-validation-result  namespace=redhat-ods-applications
 
 Verify User Is Able to Produce and Consume Events
-  [Tags]  Sanity  Smoke
+  [Tags]  Sanity  Tier2
   ...     ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-241  ODS-239
   [Teardown]  Clean Up RHOSAK    stream_to_delete=${stream_name_test}
   ...                            topic_to_delete=${topic_name_test}

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -101,7 +101,7 @@ Verify User Is Able to Produce and Consume Events
   ...                                             topic_to_assign=${topic_name_test}  cg_to_assign=${consumer_group_test}
 
   ## Spawn a notebook with env variables
-  Switch Window  url:${ODH_DASHBOARD_URL}
+  Switch Window  title:Red Hat OpenShift Data Science Dashboard
   Wait for RHODS Dashboard to Load
   Launch JupyterHub Spawner From Dashboard
   Wait Until Page Contains Element  xpath://input[@name="Standard Data Science"]

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -71,7 +71,7 @@ Verify User Is Able to Create And Delete a Kafka Stream
 
 Verify User Is Able to Produce and Consume Events
   [Tags]  Sanity  Smoke
-  ...     ODS-242-ext
+  ...     ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-241  ODS-239
   Enable RHOSAK
   Verify Service Is Enabled  ${rhosak_displayed_appname}
   Launch OpenShift Streams for Apache Kafka From RHODS Dashboard Link

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -107,6 +107,7 @@ Verify User Is Able to Produce and Consume Events
   Open Consumer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_CONS_FILENAME}
   ${cons_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
+  Sleep  0.2
   Open Producer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_PROD_FILENAME}
   ${prod_tab_id} =    Get Selected Tab ID
   Open With JupyterLab Menu  Run  Run All Cells
@@ -136,28 +137,3 @@ Kafka Test Setup
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This PR wants to automate this set of Polarion IDs: ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-241  ODS-239.
It follows the entire use case of RHOSAK as described in the QuickStart and as reported in the Polarion TCs:
1. enable rhosak from dashboard
2. connect to HybridCloudConsole 
3. create a Kafka stream
4. configure the stream (topic, service account and permissions)
5. run Kafka Producer and Consumer python code in JypyterLab to check if the communication with the stream is working.

The clean up code (remove rhosak, streams and configuration) is included as Test Teardown

It also brings some common keywords to JupyterLabLauncher.robot to handle different open notebook tabs.
