### PR TITLE
Drop .z check from python version

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -119,6 +119,17 @@ Run Cell And Check Output
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
   Should Match  ${output}  ${expected_output}
 
+Python Version Check
+  [Arguments]  ${expected_version}=3.8
+  Add and Run JupyterLab Code Cell in Active Notebook  !python --version
+  Wait Until JupyterLab Code Cell Is Not Active
+  #Get the text of the last output cell
+  ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
+  #start is inclusive, end exclusive, get x.y from Python x.y.z string
+  ${output} =  Fetch From Right  ${output}  ${SPACE}
+  ${vers} =  Get Substring  ${output}  0  3
+  Should Match  ${vers}  ${expected_version}
+
 Maybe Select Kernel
   ${is_kernel_selected} =  Run Keyword And Return Status  Page Should Not Contain Element  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]
   Run Keyword If  not ${is_kernel_selected}  Click Button  xpath=//div[@class="jp-Dialog-buttonLabel"][.="Select"]/..
@@ -139,6 +150,7 @@ Clean Up Server
   Click Element  xpath://div[.="Open"]
   Maybe Close Popup
   Wait Until Untitled.ipynb JupyterLab Tab Is Selected
+  Sleep  5
   Add and Run JupyterLab Code Cell in Active Notebook  !rm -rf *
 
 

--- a/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -54,7 +54,7 @@ Iterative Image Test
     Close Other JupyterLab Tabs
     Sleep  5
     Run Cell And Check Output  print("Hello World!")  Hello World!
-    Run Keyword And Continue On Failure  Run Cell And Check Output  !python --version  Python 3.8.8
+    Python Version Check
     Capture Page Screenshot
     JupyterLab Code Cell Error Output Should Not Be Visible
     #This ensures all workloads are run even if one (or more) fails

--- a/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -38,7 +38,7 @@ Verify Installed Python Version in PyTorch
   [Tags]  Regression
   ...     PLACEHOLDER  #category tags
   ...     ODS-217  #Polarion tags
-  Run Keyword And Continue On Failure  Run Cell And Check Output  !python --version  Python 3.8.8
+  Python Version Check
 
 Verify Installed Libraries in PyTorch
   [Tags]  Regression

--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -38,7 +38,7 @@ Verify Installed Python Version in Tensorflow
   [Tags]  Regression
   ...     PLACEHOLDER  #category tags
   ...     ODS-206  #Polarion tags
-  Run Keyword And Continue On Failure  Run Cell And Check Output  !python --version  Python 3.8.8
+  Python Version Check
 
 Verify Installed Libraries in Tensorflow
   [Tags]  Regression

--- a/tests/Tests/500__jupyterhub/test-minimal-image.robot
+++ b/tests/Tests/500__jupyterhub/test-minimal-image.robot
@@ -52,7 +52,7 @@ Can Launch Python3 Smoke Test Notebook
 
   Add and Run JupyterLab Code Cell in Active Notebook  import os
   Run Cell And Check Output  print("Hello World!")  Hello World!
-  Run Keyword And Continue On Failure  Run Cell And Check Output  !python --version  Python 3.8.8
+  Python Version Check
 
   Capture Page Screenshot
   JupyterLab Code Cell Error Output Should Not Be Visible


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

Removing the .z version check until we have a way to dinamically get the x.y.z version from imagestream metadata