### PR TITLE
enhancement of some keywords to fix anaconda TC

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
+++ b/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
@@ -7,5 +7,5 @@ Get Build Status
   [Arguments]  ${namespace}  ${build_search_term}
   Navigate To Page    Builds    Builds
   Search Last Item Instance By Title in OpenShift Table  search_term=${build_search_term}  namespace=${namespace}
-  ${build_status}=  Get Text    xpath://tr[@data-id='0-0']/td/*/span[@data-test='status-text']
+  ${build_status}=  Get Text    xpath://tr[@data-key='0-0']/td/span/span[@data-test='status-text']
   [Return]  ${build_status}

--- a/tests/Resources/Page/OCPDashboard/Page.robot
+++ b/tests/Resources/Page/OCPDashboard/Page.robot
@@ -13,12 +13,22 @@ Page Should Be Open
   [Arguments]  ${url}
   Location Should Contain  ${url}
 
+Maybe Click Show Default Project Button
+  ${switch_button}=  Run Keyword And Return Status    Page Should Contain Element    xpath=//input[@data-test='showSystemSwitch']
+  IF    ${switch_button} == True
+     ${switch_status}=  Get Element Attribute    xpath=//input[@data-test='showSystemSwitch']    data-checked-state
+     IF    '${switch_status}' == 'false'
+          Click Element    xpath=//input[@data-test='showSystemSwitch']
+     END
+  END
+
 Select Project By Name
   [Arguments]  ${project_name}
-  Wait Until Page Contains Element    xpath://div/button[contains(@class, 'co-namespace-dropdown__menu-toggle')]
-  Click Element    xpath://div/button[contains(@class, 'co-namespace-dropdown__menu-toggle')]
-  Wait Until Page Contains Element  xpath://li[contains(@class, 'pf-c-menu__list-item')]
-  Click Element    xpath://li[contains(@class, 'pf-c-menu__list-item')]/*/span[.='${project_name}']
+  Wait Until Page Contains Element    xpath://div[@data-test-id='namespace-bar-dropdown']/div/div/button
+  Click Element    xpath://div[@data-test-id='namespace-bar-dropdown']/div/div/button
+  Wait Until Page Contains Element  xpath://div[@data-test-id='namespace-bar-dropdown']//li
+  Maybe Click Show Default Project Button
+  Click Element    xpath://div[@data-test-id='namespace-bar-dropdown']//li//*[text()='${project_name}']
 
 Search Last Item Instance By Title in OpenShift Table
   [Arguments]  ${search_term}  ${namespace}=All Projects

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -1,17 +1,18 @@
 *** Settings ***
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
-Library         ../../../../libs/Helpers.py
+Library    ../../../../libs/Helpers.py
 
 *** Keywords ***
 Get Pod Logs Manual Version
   [Arguments]  ${namespace}  ${pod_search_term}
   Navigate To Page    Workloads    Pods
   Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
-  Click Link    xpath://tr[@data-key='0-0']/td[@id='name']/span/a
+  Click Link    xpath://tr[@data-key='0-0']/td/span/a
   Click Link    Logs
   Sleep  2
   Capture Page Screenshot  logs_page.png
   ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
   ${log_rows}=  Text To List  ${logs_text}
+
   [Return]  ${log_rows}

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -4,11 +4,11 @@ Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 Library         ../../../../libs/Helpers.py
 
 *** Keywords ***
-Get Pod Logs
+Get Pod Logs Manual Version
   [Arguments]  ${namespace}  ${pod_search_term}
   Navigate To Page    Workloads    Pods
   Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
-  Click Link    xpath://tr[@data-id='0-0']/td[@id='name']/*/a
+  Click Link    xpath://tr[@data-key='0-0']/td[@id='name']/span/a
   Click Link    Logs
   Sleep  2
   Capture Page Screenshot  logs_page.png

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -4,7 +4,7 @@ Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 Library    ../../../../libs/Helpers.py
 
 *** Keywords ***
-Get Pod Logs Manual Version
+Get Pod Logs From UI
   [Arguments]  ${namespace}  ${pod_search_term}
   Navigate To Page    Workloads    Pods
   Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
@@ -14,5 +14,4 @@ Get Pod Logs Manual Version
   Capture Page Screenshot  logs_page.png
   ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
   ${log_rows}=  Text To List  ${logs_text}
-
   [Return]  ${log_rows}

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -225,7 +225,7 @@ Login Via Button
    Wait Until Page Contains  Log in with
 
 Maybe Handle Server Not Running Page
-  ${SNR_visible} =  Run Keyword and Return Status   Wait Until Page Contains    Server not running  timeout=10
+  ${SNR_visible} =  Run Keyword and Return Status   Wait Until Page Contains    Server not running  timeout=15
   IF  ${SNR_visible}==True
          Handle Server Not Running
   END

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -3,6 +3,7 @@ Resource  JupyterLabLauncher.robot
 Resource  ../../LoginPage.robot
 Resource  ../../ODH/ODHDashboard/ODHDashboard.robot
 Resource  LoginJupyterHub.robot
+Resource  JupyterLabSidebar.robot
 Resource  ../../OCPDashboard/InstalledOperators/InstalledOperators.robot
 Library   JupyterLibrary
 Library   String

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -223,3 +223,9 @@ Login Via Button
    ...  Keyword.
    Click Element  xpath://a[@id='login']
    Wait Until Page Contains  Log in with
+
+Maybe Handle Server Not Running Page
+  ${SNR_visible} =  Run Keyword and Return Status   Wait Until Page Contains    Server not running  timeout=10
+  IF  ${SNR_visible}==True
+         Handle Server Not Running
+  END

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -141,7 +141,7 @@ Get Spawner Event Log
    [Return] @{event_elements}
 
 Server Not Running Is Visible
-   ${SNR_visible} =  Run Keyword and Return Status  Page Should Contain  Server not running
+   ${SNR_visible} =  Run Keyword and Return Status  Wait Until Page Contains    Server not running  timeout=15
    [return]  ${SNR_visible}
 
 Handle Server Not Running
@@ -226,7 +226,7 @@ Login Via Button
    Wait Until Page Contains  Log in with
 
 Maybe Handle Server Not Running Page
-  ${SNR_visible} =  Run Keyword And Return Status    Wait Until Keyword Succeeds    15    1    Server Not Running Is Visible
+  ${SNR_visible} =  Server Not Running Is Visible
   IF  ${SNR_visible}==True
          Handle Server Not Running
   END

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -192,6 +192,7 @@ Fix Spawner Status
             Maybe Close Popup
             Stop JupyterLab Notebook Server
             Handle Start My Server
+            Maybe Handle Server Not Running Page
          END
       END
    END
@@ -225,7 +226,7 @@ Login Via Button
    Wait Until Page Contains  Log in with
 
 Maybe Handle Server Not Running Page
-  ${SNR_visible} =  Run Keyword and Return Status   Wait Until Page Contains    Server not running  timeout=15
+  ${SNR_visible} =  Run Keyword And Return Status    Wait Until Keyword Succeeds    15    1    Server Not Running Is Visible
   IF  ${SNR_visible}==True
          Handle Server Not Running
   END

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -80,6 +80,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Go To  ${ODH_DASHBOARD_URL}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Launch JupyterHub Spawner From Dashboard
+  Maybe Handle Server Not Running Page
   Wait Until Page Contains Element  xpath://input[@name="Anaconda Commercial Edition"]
   Wait Until Element Is Enabled    xpath://input[@name="Anaconda Commercial Edition"]   timeout=10
   Spawn Notebook With Arguments  image=s2i-minimal-notebook-anaconda
@@ -102,6 +103,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Capture Page Screenshot  conda_lib_install_result.png
   Maybe Open JupyterLab Sidebar   File Browser
   Fix Spawner Status  # used to close the server and go back to Spawner
+  Maybe Handle Server Not Running Page
   Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']  timeout=15
 
 ** Keywords ***
@@ -139,5 +141,4 @@ Check Anaconda CE Image Build Status
   ...    Fail  the Anaconda image build has failed
   ...  ELSE
   ...    Should Be Equal    ${ace_build_status}    ${target_status}
-
 

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -73,7 +73,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Go To  ${OCP_CONSOLE_URL}
   Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
   Maybe Skip Tour
-  ${val_result}=  Get Pod Logs  namespace=redhat-ods-applications  pod_search_term=anaconda-ce-periodic-validator-job-custom-run
+  ${val_result}=  Get Pod Logs Manual Version  namespace=redhat-ods-applications  pod_search_term=anaconda-ce-periodic-validator-job-custom-run
   Log  ${val_result}
   Should Be Equal  ${val_result[0]}  ${val_success_msg}
   Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -73,7 +73,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Go To  ${OCP_CONSOLE_URL}
   Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
   Maybe Skip Tour
-  ${val_result}=  Get Pod Logs Manual Version  namespace=redhat-ods-applications  pod_search_term=anaconda-ce-periodic-validator-job-custom-run
+  ${val_result}=  Get Pod Logs From UI  namespace=redhat-ods-applications  pod_search_term=anaconda-ce-periodic-validator-job-custom-run
   Log  ${val_result}
   Should Be Equal  ${val_result[0]}  ${val_success_msg}
   Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -102,7 +102,7 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Capture Page Screenshot  conda_lib_install_result.png
   Maybe Open JupyterLab Sidebar   File Browser
   Fix Spawner Status  # used to close the server and go back to Spawner
-  Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']
+  Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']  timeout=15
 
 ** Keywords ***
 Anaconda Commercial Edition Suite Setup

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -80,7 +80,6 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Go To  ${ODH_DASHBOARD_URL}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Launch JupyterHub Spawner From Dashboard
-  Maybe Handle Server Not Running Page
   Wait Until Page Contains Element  xpath://input[@name="Anaconda Commercial Edition"]
   Wait Until Element Is Enabled    xpath://input[@name="Anaconda Commercial Edition"]   timeout=10
   Spawn Notebook With Arguments  image=s2i-minimal-notebook-anaconda
@@ -103,10 +102,10 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Capture Page Screenshot  conda_lib_install_result.png
   Maybe Open JupyterLab Sidebar   File Browser
   Fix Spawner Status  # used to close the server and go back to Spawner
-  Maybe Handle Server Not Running Page
   Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']  timeout=15
 
-** Keywords ***
+
+*** Keywords ***
 Anaconda Commercial Edition Suite Setup
   Set Library Search Order  SeleniumLibrary
 
@@ -141,4 +140,5 @@ Check Anaconda CE Image Build Status
   ...    Fail  the Anaconda image build has failed
   ...  ELSE
   ...    Should Be Equal    ${ace_build_status}    ${target_status}
+
 


### PR DESCRIPTION
This PR implements two improvements to the "Select Project By Name" and "Get Pod Logs Manual Version" keyword:
1. compatibility with OCP 4.8 for both the keywords
2. enable the "show default projects" in OCP 4.9 if not already selected (select project by name)
3. change name (old name: Get Pod Logs) to avoid conflict with OpenshiftCLI lib
4. New keyword to handle "Server not running" page (which is intermittent) after "Fix Spawner Status" in Ananconda TC 
5. Add a missing resource import in JupyterSpawnerHub.robot

Moreover, it makes the TC using it compatible with OCP 4.8 (e.g., Anaconda TCs)