### PR TITLE
Open RHODS apps using hyperlink instead of dropdown

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -15,7 +15,12 @@ Begin Web Test
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -122,7 +122,12 @@ Spawn Notebook With Arguments
 
 Launch JupyterHub Spawner From Dashboard
   Menu.Navigate To Page    Applications    Enabled
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -87,7 +87,12 @@ Run Jupyter Notebook For 5 Minutes
 ##TODO: This is a copy of "Iterative Image Test" keyword from image-iteration.robob. We have to refactor the code not to duplicate this method
 Iterative Image Test
   [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Page Should Not Contain    403 : Forbidden
   ${authorization_required} =  Is Service Account Authorization Required
@@ -116,7 +121,12 @@ CleanUp JupyterHub
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Page Should Not Contain    403 : Forbidden
   ${authorization_required} =  Is Service Account Authorization Required

--- a/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
@@ -53,7 +53,12 @@ Clean Up Files And End Web Test
 
 Iterative Image Test
     [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -41,7 +41,12 @@ Iterative Testing Clustering
 *** Keywords ***
 Iterative Image Test
     [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -20,7 +20,12 @@ Test User Not In JH Access Groups
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ldap-noaccess1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login Verify Access Level  ldap-noaccess1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  none
 
 Test User In JH Admin Group
@@ -30,7 +35,12 @@ Test User In JH Admin Group
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ldap-admin1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login Verify Access Level  ldap-admin1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  admin
 
 Test User In JH Users Group
@@ -40,5 +50,10 @@ Test User In JH Users Group
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ldap-user1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     Login Verify Access Level  ldap-user1  ${TEST_USER.PASSWORD}  ${AUTH_TYPE}  user

--- a/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
+++ b/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
@@ -13,7 +13,12 @@ Launch JupyterLab
   [Tags]  Sanity
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -18,7 +18,12 @@ Minimal PyTorch test
   ...     PLACEHOLDER  #category tags
   ...     PLACEHOLDER  #Polarion tags
   Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -19,7 +19,12 @@ Minimal Tensorflow test
   ...     PLACEHOLDER  #Category tags
   ...     PLACEHOLDER  #Polarion tags
   Wait for RHODS Dashboard to Load
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   Run Keyword If  ${authorization_required}  Authorize jupyterhub service account

--- a/tests/Tests/500__jupyterhub/special-user-testing.robot
+++ b/tests/Tests/500__jupyterhub/special-user-testing.robot
@@ -22,7 +22,12 @@ Test Special Usernames
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Launch JupyterHub From RHODS Dashboard Dropdown
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+    IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+    ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+    END
     FOR  ${char}  IN  @{CHARS}
         Login Verify Logout  ldap-special${char}  ${TEST_USER.PASSWORD}  ldap-provider-qe
     END

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
@@ -17,7 +17,12 @@ Open RHODS Dashboard
 
 Can Launch Jupyterhub
   [Tags]  Tier2
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
 
 Can Login to Jupyterhub
   [Tags]  Tier2

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
@@ -17,7 +17,12 @@ Open RHODS Dashboard
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
@@ -19,7 +19,12 @@ Open RHODS Dashboard
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test-minimal-image.robot
+++ b/tests/Tests/500__jupyterhub/test-minimal-image.robot
@@ -11,13 +11,17 @@ Suite Teardown   End Web Test
 
 *** Variables ***
 
-
 *** Test Cases ***
 Open RHODS Dashboard
   Wait for RHODS Dashboard to Load
 
 Can Launch Jupyterhub
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
 
 Can Login to Jupyterhub
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}

--- a/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
+++ b/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
@@ -17,7 +17,12 @@ Open RHODS Dashboard
 
 Can Launch Jupyterhub
   [Tags]  Sanity
-  Launch JupyterHub From RHODS Dashboard Dropdown
+  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+  IF  ${version-check}==True
+    Launch JupyterHub From RHODS Dashboard Link
+  ELSE
+    Launch JupyterHub From RHODS Dashboard Dropdown
+  END
 
 Can Login to Jupyterhub
   [Tags]  Sanity

--- a/tests/Tests/500__jupyterhub/test.robot
+++ b/tests/Tests/500__jupyterhub/test.robot
@@ -25,7 +25,12 @@ Can Launch Jupyterhub
    Launch Jupyterhub via App
    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
    Wait for RHODS Dashboard to Load
-   Launch JupyterHub From RHODS Dashboard Dropdown
+   ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
+   IF  ${version-check}==True
+      Launch JupyterHub From RHODS Dashboard Link
+   ELSE
+      Launch JupyterHub From RHODS Dashboard Dropdown
+   END
 
 Can Login to Jupyterhub
    [Tags]  Sanity  Smoke  ODS-936


### PR DESCRIPTION
The PR #168 in odh-dashboard https://github.com/red-hat-data-services/odh-dashboard/pull/168 removed the option to open JupyterHub (and other RHODS apps) from the dropdown menu.

From 1.4.0-2 version, use the "Launch ${dashboard_app} From RHODS Dashboard Link" instead of "Launch ${dashboard_app} From RHODS Dashboard Dropdown" option.