### PR TITLE
remove logout keyword from Jupyterlab Git Notebook test case

### DIFF
--- a/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
@@ -85,4 +85,4 @@ Can Run Flask Test Notebook
   Wait Until JupyterLab Code Cell Is Not Active
 
   Close JupyterLab Selected Tab
-  Logout JupyterLab
+ 

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
@@ -86,5 +86,3 @@ Can Launch Python3 Smoke Test Notebook
   #Get the text of the last output cell
   ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
   Should Not Match  ${output}  ERROR*
-
-  Logout JupyterLab


### PR DESCRIPTION
this PR should fix the JS error we face in one of the JupyterLab TC, which was reported by @lugi0 