### PR TITLE
Fix PVC alert test teardown

### DIFF
--- a/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/203__alerts.robot
@@ -43,7 +43,8 @@ Set Up Alert Test
 
 Clean Up Files And End Web Test
     [Documentation]  We delete the notebook files using the new -and expererimental- "Clean Up User Notebook" because "End Web Test" doesn't work well when disk is 100% filled
-    Close All JupyterLab Tabs
+    Open With JupyterLab Menu  File  Close All Tabs
+    Maybe Close Popup
     Navigate Home (Root folder) In JupyterLab Sidebar File Browser
     Delete Folder In User Notebook  ${OCP_ADMIN_USER.USERNAME}  ${TEST_USER.USERNAME}  ods-ci-notebooks-main
     Maybe Close Popup


### PR DESCRIPTION
Replace the "Close All JupyterLab Tabs" keyword, as is not working well on RHODS 1.4.0

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>