### PR TITLE
to handle the failure occurs for smoke

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -11,7 +11,7 @@ Get Pod Logs From UI
   Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
   Click Link    xpath://tr[@data-key='0-0']/td/span/a
   Click Link    Logs
-  Sleep  2
+  Sleep  4
   Capture Page Screenshot  logs_page.png
   ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
   ${log_rows}=  Text To List  ${logs_text}


### PR DESCRIPTION
Signed-off-by: tarukumar <takumar@redhat.com>

While running the [smoke]( https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/rhods-smoke/313/console) Arthy observed that  "Verify User Is Able to Activate Anaconda Commercial Edition" TC is getting failed. After going the Robot logs it looks like logs took more time than 2 second to get stream/appear in the log panel. Increase time to 4 sec to handle the case for now.

PS: I think this is  one off case and we can handle this in better way bu using other keyword like "Wait Until Keyword Succeeds" or something. We should avoid wherever possible to not hard code the wait/sleep time. We can do it in refactoring