### PR TITLE
Use branch "main" when cloning pylero

### DIFF
--- a/utils/scripts/polarion/polarionUpdater.py
+++ b/utils/scripts/polarion/polarionUpdater.py
@@ -66,7 +66,7 @@ def generate_polarion_config(config_template, config_data, testrun_title):
     with open(config_file, 'r') as fh:
         data = yaml.safe_load(fh)
 
-    data["testrun_info"]["polarion-testrun-title"] = testrun_title 
+    data["testrun_info"]["polarion-testrun-title"] = testrun_title
     data["testrun_info"]["polarion-testrun-id"] = testrun_title
 
     with open(config_file, 'w') as yaml_file:
@@ -80,7 +80,7 @@ def main():
 
     # Clone pylero repo
     ret = clone_config_repo(git_repo = PYLERO_REPO,
-                            git_branch = "master",
+                            git_branch = "main",
                             repo_dir = "pylero")
     if not ret:
         sys.exit(1)


### PR DESCRIPTION
The default branch now is "main" instead of "master"
https://github.com/RedHatQE/pylero

Integration with Polarion was failing because of this
https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/rhods-smoke/319/console

![image](https://user-images.githubusercontent.com/66894/149590222-f9818240-0b87-47f5-aa7a-2ab3c1a415fa.png)

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>