### PR TITLE
Catch ValueError exception in GTE keyword on invalid SemVer

### DIFF
--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -12,8 +12,14 @@ class Helpers:
 
     @keyword
     def gte(self, version, target):
-        version=VersionInfo.parse(version)
-        target=VersionInfo.parse(target)
-        #version=tuple(version.translate(str.maketrans('', '', string.punctuation)))
-        #target=tuple(target.translate(str.maketrans('', '', string.punctuation)))
-        return version>=target
+        """ Returns True if the SemVer version >= target
+            and otherwise False including if an exception is thrown """
+        try:
+            version=VersionInfo.parse(version)
+            target=VersionInfo.parse(target)
+            #version=tuple(version.translate(str.maketrans('', '', string.punctuation)))
+            #target=tuple(target.translate(str.maketrans('', '', string.punctuation)))
+            return version>=target
+        except ValueError:
+            # Returning False on exception as a workaround for when an null (or invalid) semver version is passed
+            return False


### PR DESCRIPTION
Catch the ValueError exception thrown by the `GTE` keyword when the `version` argument is invalid or null.

Signed-off-by: Landon LaSmith <LLaSmith@redhat.com>