### PR TITLE
remove wait for JL splash page and kernel popup from RHOSAK test

### DIFF
--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -89,8 +89,6 @@ Verify User Is Able to Produce and Consume Events
   ...                                   KAFKA_PASSWORD=${kafka_client_secret}  KAFKA_TOPIC=${topic_name_test}
   ...                                   KAFKA_CONSUMER_GROUP=${consumer_group_test}
   Spawn Notebook With Arguments  image=s2i-generic-data-science-notebook  envs=&{notebook_envs}
-  Wait for JupyterLab Splash Screen  timeout=60
-  Maybe Select Kernel
   ## clone JL notebooks from git and run
   Clone Git Repository  REPO_URL=${GIT_REPO_NOTEBOOKS}
   Open Consumer Notebook  dir_path=${NOTEBOOK_DIR_PATH}  filename=${NOTEBOOK_CONS_FILENAME}


### PR DESCRIPTION
To integrate the changes from #172, this PR removes two lines for ODS-248 because those got integrated in the Jupyter keyword `Spawn Notebook With Arguments`

Signed-off-by: bdattoma <bdattoma@redhat.com>