### PR TITLE
Add pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,11 @@
 - [ ] Commits are squashed in a cohesive manner and have meaningful messages (see [how](https://cbea.ms/git-commit))
 - [ ] The robocop analyser doesn't detect any issues in the test suites modified by this PR (see [check-code-style](https://github.com/red-hat-data-services/ods-ci/blob/master/docs/check-code-style.md))
 - [ ] Code is formatted following the _[ODS-CI RobotFramework Style Guide](https://docs.google.com/document/d/11ZJOPI1uq-0Wl6a2V8fkAv_TQhfzp9t_IjXAheaJxmQ/edit?usp=sharing)_
+- [ ] Jira Link(s):
+- [ ] An entry has been added to the corresponding _RHODS build announcement_ (see [folder](https://drive.google.com/drive/folders/1sgkK1WZgGo9CXsLizNe0GbAzVKuSKrZL))
 
-For new automated tests:
+For new automated tests for RHODS (not ODH):
 - [ ] Test case is authored in Polarion
 - [ ]  _Automation = Automated_ in Polarion
 - [ ] _Automated = Yes_ in Jira
-- [ ] Test case has tier information and Polarion ID in its Tags (more info [here](https://docs.google.com/document/d/11ZJOPI1uq-0Wl6a2V8fkAv_TQhfzp9t_IjXAheaJxmQ/edit#heading=h.s819p3c5ud7p))
+- [ ] Test case contains Polarion ID, tier information and all mandatory Tags (more info [here](https://docs.google.com/document/d/11ZJOPI1uq-0Wl6a2V8fkAv_TQhfzp9t_IjXAheaJxmQ/edit#heading=h.s819p3c5ud7p))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,9 @@
 - [ ] Commits are squashed in a cohesive manner and have meaningful messages (see [how](https://cbea.ms/git-commit))
-- [ ] Code is formatted following the _ODS-CI Robot Framework Style Guide_ (see [how](https://github.com/red-hat-data-services/ods-ci/blob/master/docs/check-code-style.md))
-- [ ] For new automated tests: _Automation = Automated_ in Polarion
-- [ ] For new automated tests: _Automated = Yes_ in Jira
+- [ ] The robocop analyser doesn't detect any issues in the test suites modified by this PR (see [check-code-style](https://github.com/red-hat-data-services/ods-ci/blob/master/docs/check-code-style.md))
+- [ ] Code is formatted following the _[ODS-CI RobotFramework Style Guide](https://docs.google.com/document/d/11ZJOPI1uq-0Wl6a2V8fkAv_TQhfzp9t_IjXAheaJxmQ/edit?usp=sharing)_
+
+For new automated tests:
+- [ ] Test case is authored in Polarion
+- [ ]  _Automation = Automated_ in Polarion
+- [ ] _Automated = Yes_ in Jira
+- [ ] Test case has tier information and Polarion ID in its Tags (more info [here](https://docs.google.com/document/d/11ZJOPI1uq-0Wl6a2V8fkAv_TQhfzp9t_IjXAheaJxmQ/edit#heading=h.s819p3c5ud7p))

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,4 @@
+- [ ] Commits are squashed in a cohesive manner and have meaningful messages (see [how](https://cbea.ms/git-commit))
+- [ ] Code is formatted following the _ODS-CI Robot Framework Style Guide_ (see [how](https://github.com/red-hat-data-services/ods-ci/blob/master/docs/check-code-style.md))
+- [ ] For new automated tests: _Automation = Automated_ in Polarion
+- [ ] For new automated tests: _Automated = Yes_ in Jira


### PR DESCRIPTION
Adds a  [pull request template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository), similar to the ones used  in [ody-deployer](https://github.com/red-hat-data-services/odh-deployer/pull/206). 

When we create a PR for ods-ci the pull request body will have this content:
- [ ] Commits are squashed in a cohesive manner and have meaningful messages (see [how](https://cbea.ms/git-commit))
- [ ] Code is formatted following the _ODS-CI Robot Framework Style Guide_ (see [how](https://github.com/red-hat-data-services/ods-ci/blob/master/docs/check-code-style.md))
- [ ] For new automated tests: _Automation = Automated_ in Polarion
- [ ] For new automated tests: _Automated = Yes_ in Jira

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>
