### PR TITLE
[ods-ci container] fix test selection features and other fixes

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,6 +8,10 @@ RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf install -y git python3 unzip chromium chromedriver redhat-lsb-core &&\
     dnf clean all
 
+## Install yq in the image
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 -o /usr/bin/yq &&\
+    chmod +x /usr/bin/yq
+
 ## Install oc in the container
 COPY build/oc /usr/local/bin/oc
 # COPY oc /usr/local/bin/oc

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,8 +1,8 @@
 FROM centos:centos8
 
 # Use this build arg to set any default test script arguments
-ARG RUN_SCRIPT_ARGS=
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
+ENV ROBOT_EXTRA_ARGS=${ROBOT_EXTRA_ARGS}
 
 ENV HOME /tmp
 
@@ -23,4 +23,9 @@ RUN chgrp -R 0 /tmp && chmod -R g=u /tmp
 
 USER 1001
 
-CMD ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS}
+CMD if [ -n "${RUN_SCRIPT_ARGS}" ]; then \
+	        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "'${ROBOT_EXTRA_ARGS}'" ;\
+     else \
+            ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS};\
+     fi
+

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,5 @@
-FROM registry.access.redhat.com/ubi8/ubi:8.1
+FROM quay.io/centos/centos:stream8
+# FROM registry.access.redhat.com/ubi8/ubi:8.1
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
 ENV ROBOT_EXTRA_ARGS=${ROBOT_EXTRA_ARGS}
@@ -16,26 +17,23 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_a
 COPY build/oc /usr/local/bin/oc
 # COPY oc /usr/local/bin/oc
 RUN chmod 755 /usr/local/bin/oc &&\
-         oc version --client &&\
-         oc config set-context loadtest
+         oc version --client
 
 RUN mkdir $HOME/ods-ci
 # Change the WORKDIR so the run script references any files/folders from the root of the repo
 WORKDIR $HOME/ods-ci
 
-COPY requirements.txt setup.py .
-RUN python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
-
 COPY tests tests/
 COPY libs libs/
 COPY run_robot_test.sh  .
+COPY requirements.txt setup.py .
+RUN python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
 
 # Set the group ownership so non-root users can write to /tmp
 RUN chgrp -R 0 /tmp && chmod -R g=u /tmp
 RUN chown -R 1001 /tmp
 
 USER 1001
-
 
 CMD if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
             echo --extra-robot-args "${ROBOT_EXTRA_ARGS}" &&\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -17,9 +17,9 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_a
     chmod +x /usr/bin/yq
 
 ## Install oc in the container
-RUN curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o ./oc_client.tar.gz && \
-    tar xvf oc_client.tar.gz -C /usr/local/bin/ && \
-    rm -rf oc_client.tar.gz && rm /usr/local/bin/README.md
+RUN curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \
+    tar xvf $HOME/oc_client.tar.gz -C /usr/local/bin/ && \
+    rm -rf $HOME/oc_client.tar.gz && rm /usr/local/bin/README.md
 
 RUN chmod 755 /usr/local/bin/oc &&\
          oc version --client

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,31 +1,42 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.1
-
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
 ENV ROBOT_EXTRA_ARGS=${ROBOT_EXTRA_ARGS}
-
 ENV HOME /tmp
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y git python3 unzip chromium chromedriver &&\
+    dnf install -y git python3 unzip chromium chromedriver redhat-lsb-core &&\
     dnf clean all
+
+## Install oc in the container
+COPY build/oc /usr/local/bin/oc
+# COPY oc /usr/local/bin/oc
+RUN chmod 755 /usr/local/bin/oc &&\
+         oc version --client &&\
+         oc config set-context loadtest
 
 RUN mkdir $HOME/ods-ci
 # Change the WORKDIR so the run script references any files/folders from the root of the repo
 WORKDIR $HOME/ods-ci
 
+COPY requirements.txt setup.py .
+RUN python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
+
 COPY tests tests/
-COPY requirements.txt run_robot_test.sh setup.py .
-RUN python3 -m venv venv && source venv/bin/activate && venv/bin/pip3 install -r requirements.txt
+COPY libs libs/
+COPY run_robot_test.sh  .
 
 # Set the group ownership so non-root users can write to /tmp
 RUN chgrp -R 0 /tmp && chmod -R g=u /tmp
+RUN chown -R 1001 /tmp
 
 USER 1001
 
-CMD if [ -n "${RUN_SCRIPT_ARGS}" ]; then \
-	        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "'${ROBOT_EXTRA_ARGS}'" ;\
+
+CMD if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
+            echo --extra-robot-args "${ROBOT_EXTRA_ARGS}" &&\
+	        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}" ;\
      else \
+            echo execute all &&\
             ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS};\
      fi
-

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -4,8 +4,9 @@ FROM quay.io/centos/centos:stream8
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
 ENV ROBOT_EXTRA_ARGS=${ROBOT_EXTRA_ARGS}
 ENV HOME /tmp
+ARG OC_VERSION=4.10
+ARG OC_CHANNEL=stable
 
-ARG oc_local_path=build/oc
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
     dnf install -y git python3 unzip chromium chromedriver redhat-lsb-core &&\
@@ -16,9 +17,10 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_a
     chmod +x /usr/bin/yq
 
 ## Install oc in the container
-COPY ${oc_local_path} /usr/local/bin/oc
-# COPY build/oc /usr/local/bin/oc
-# COPY oc /usr/local/bin/oc
+RUN curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o ./oc_client.tar.gz && \
+    tar xvf oc_client.tar.gz -C /usr/local/bin/ && \
+    rm -rf oc_client.tar.gz && rm /usr/local/bin/README.md
+
 RUN chmod 755 /usr/local/bin/oc &&\
          oc version --client
 

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:centos8
+FROM registry.access.redhat.com/ubi8/ubi:8.1
 
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,6 +5,8 @@ ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
 ENV ROBOT_EXTRA_ARGS=${ROBOT_EXTRA_ARGS}
 ENV HOME /tmp
 
+ARG oc_local_path=build/oc
+
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
     dnf install -y git python3 unzip chromium chromedriver redhat-lsb-core &&\
     dnf clean all
@@ -14,7 +16,8 @@ RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_a
     chmod +x /usr/bin/yq
 
 ## Install oc in the container
-COPY build/oc /usr/local/bin/oc
+COPY ${oc_local_path} /usr/local/bin/oc
+# COPY build/oc /usr/local/bin/oc
 # COPY oc /usr/local/bin/oc
 RUN chmod 755 /usr/local/bin/oc &&\
          oc version --client

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -34,12 +34,6 @@ COPY run_robot_test.sh  .
 COPY requirements.txt setup.py .
 RUN python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
 
-# Set the group ownership so non-root users can write to /tmp
-RUN chgrp -R 0 /tmp && chmod -R g=u /tmp
-RUN chown -R 1001 /tmp
-
-USER 1001
-
 CMD if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
             echo --extra-robot-args "${ROBOT_EXTRA_ARGS}" &&\
 	        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}" ;\

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -36,4 +36,4 @@ RUN  chmod +x run.sh
 COPY requirements.txt setup.py .
 RUN  python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
 
-ENTRYPOINT ["./run.sh", "${ROBOT_EXTRA_ARGS}", "${RUN_SCRIPT_ARGS}"]
+ENTRYPOINT ["./run.sh"]

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -31,13 +31,9 @@ WORKDIR $HOME/ods-ci
 COPY tests tests/
 COPY libs libs/
 COPY run_robot_test.sh  .
+COPY build/run.sh  .
+RUN  chmod +x run.sh
 COPY requirements.txt setup.py .
-RUN python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
+RUN  python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
 
-CMD if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
-            echo --extra-robot-args "${ROBOT_EXTRA_ARGS}" &&\
-	        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}" ;\
-     else \
-            echo execute all &&\
-            ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS};\
-     fi
+ENTRYPOINT ["./run.sh", "${ROBOT_EXTRA_ARGS}", "${RUN_SCRIPT_ARGS}"]

--- a/build/README.md
+++ b/build/README.md
@@ -28,7 +28,7 @@ podman build -t ods-ci:master -f build/Dockerfile .
 
 ```
 Additional arguments for container run
-```bash
+```
 # env variables to control test execution
 RUN_SCRIPT_ARGS:
   --skip-oclogin (default: false): script does not perform login using OC CLI
@@ -41,21 +41,32 @@ RUN_SCRIPT_ARGS:
   --test-artifact-dir: set the RF output directory to store log files
 
 ROBOT_EXTRA_ARGS: it takes any robot framework arguments. Look at robot --help to see all the options (e.g., --log NONE, --dryrun )
+```
 
+Example of test execution using the container
+```bash
 # example
 $ podman run --rm -v $PWD/test-variables.yml:/tmp/ods-ci/test-variables.yml:Z
                   -v $PWD/test-output:/tmp/ods-ci/test-output:Z
                   -e ROBOT_EXTRA_ARGS='-l NONE'
                   -e RUN_SCRIPT_ARGS='--skip-oclogin false --set-urls-variables true --include Smoke'
                   ods-ci:master
-
 ```
 
 ### Running the ods-ci container image in OpenShift
 
-After building the container, you can deploy the container in a pod running on OpenShift. You can use [this](./ods-ci.pod.yaml) PersistentVolumeClaim and Pod definition to deploy the ods-ci container.  NOTE: This example pod attaches a PVC to preserve the test artifacts directory between runs and mounts the test-variables.yml file from a Secret.
+After building the container, you can deploy the container in a pod running on OpenShift. You can use [this](./ods-ci.pod.yaml) PersistentVolumeClaim and Pod definition to deploy the ods-ci container.
+Before deploying the pod:
+- create the namespace/project "ods-ci"
+- apply the rbac settings
+- create a secret to store your "test-variables.yml" file
+
+NOTE: This example pod attaches a PVC to preserve the test artifacts directory between runs and mounts the test-variables.yml file from a Secret.
 
 ```
+# Apply rbac settings
+oc apply -f ods_ci_rbac.yaml
+
 # Creates a Secret with test variables that can be mounted in ODS-CI container
 oc create secret generic ods-ci-test-variables --from-file test-variables.yml
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -1,7 +1,7 @@
 # ODS-CI Container Image
 
 A [Dockerfile](Dockerfile) is available for running tests in a container.
-The latest build can be downloaded from: https://quay.io/odsci/ods-ci:latest
+The latest build can be downloaded from: https://quay.io/odsci/ods-ci:latest (<em>this image has been deprecated, a new one will be available soon. Please build your own image using the instructions below</em>)
 
 eg: podman pull quay.io/odsci/ods-ci:latest
 
@@ -11,7 +11,44 @@ $ podman build -t ods-ci:master -f build/Dockerfile .
 
 # Mount a file volume to provide a test-variables.yml file at runtime
 # Mount a volume to preserve the test run artifacts
-$ podman run --rm -v $PWD/test-variables.yml:/tmp/ods-ci/test-variables.yml:Z -v $PWD/test-output:/tmp/ods-ci/test-output:Z ods-ci:master
+$ podman run --rm -v $PWD/test-variables.yml:/tmp/ods-ci/test-variables.yml:Z
+                  -v $PWD/test-output:/tmp/ods-ci/test-output:Z
+                  ods-ci:master
+```
+Additional arguments for container build
+```bash
+# oc CLI version to install
+OC_VERSION (default: 4.10)
+OC_CHANNEL (default: stable)
+
+# example
+podman build -t ods-ci:master -f build/Dockerfile .
+             --build-arg OC_CHANNEL=latest
+             --build-arg OC_VERSION=4.9
+
+```
+Additional arguments for container run
+```bash
+# env variables to control test execution
+RUN_SCRIPT_ARGS:
+  --skip-oclogin (default: false): script does not perform login using OC CLI
+  --set-urls-variables (default: false): script gets automatically the cluster URLs (i.e., OCP Console, RHODS Dashboard, OCP API Server)
+  --include: run only test cases with the given tags (e.g., --include Smoke --include XYZ)
+  --exclude: do not run the test cases with the given tag (e.g., --exclude LongLastingTC)
+  --test-variable: set a global RF variable
+  --test-variables-file (default: test-variables.yml): set the RF file containing global variables to use in TCs
+  --test-case: run only the test cases from the given robot file
+  --test-artifact-dir: set the RF output directory to store log files
+
+ROBOT_EXTRA_ARGS: it takes any robot framework arguments. Look at robot --help to see all the options (e.g., --log NONE, --dryrun )
+
+# example
+$ podman run --rm -v $PWD/test-variables.yml:/tmp/ods-ci/test-variables.yml:Z
+                  -v $PWD/test-output:/tmp/ods-ci/test-output:Z
+                  -e ROBOT_EXTRA_ARGS='-l NONE'
+                  -e RUN_SCRIPT_ARGS='--skip-oclogin false --set-urls-variables true --include Smoke'
+                  ods-ci:master
+
 ```
 
 ### Running the ods-ci container image in OpenShift

--- a/build/README.md
+++ b/build/README.md
@@ -1,9 +1,6 @@
 # ODS-CI Container Image
 
-A [Dockerfile](Dockerfile) is available for running tests in a container.
-The latest build can be downloaded from: https://quay.io/odsci/ods-ci:latest (<em>this image has been deprecated, a new one will be available soon. Please build your own image using the instructions below</em>)
-
-eg: podman pull quay.io/odsci/ods-ci:latest
+A [Dockerfile](Dockerfile) is available for running tests in a container. Below you can read how to build and run ods-ci test suites container.
 
 ```bash
 # Build the container (optional if you dont want to use the latest from quay.io/odsci)

--- a/build/ods-ci.pod.yaml
+++ b/build/ods-ci.pod.yaml
@@ -20,15 +20,16 @@ spec:
   securityContext:
     # This is required to make the test-output volume Writable
     fsGroup: 0
+  serviceAccountName: rhods-test-runner
   containers:
 
     - image: <INSERT URL TO YOUR BUILT IMAGE>
       imagePullPolicy: Always
-      name: ods-ci
+      name: ods-ci-testrun
       env:
         # Use this environment variable to pass args to the ods-ci run script in the container
         - name: RUN_SCRIPT_ARGS
-          value: "--test-variables-file /tmp/ods-ci-test-variables/test-variables.yml"
+          value: "--test-variables-file /tmp/ods-ci-test-variables/test-variables.yml --skip-oclogin true --set-urls-variables true"
         - name: ROBOT_EXTRA_ARGS
           # value: INSERT ROBOT FRAMEWORK ARGS OR LEAVE EMPTY. e.g., -i Smoke. Write inside the quotes
           value: ""

--- a/build/ods-ci.pod.yaml
+++ b/build/ods-ci.pod.yaml
@@ -29,6 +29,9 @@ spec:
         # Use this environment variable to pass args to the ods-ci run script in the container
         - name: RUN_SCRIPT_ARGS
           value: "--test-variables-file /tmp/ods-ci-test-variables/test-variables.yml"
+        - name: ROBOT_EXTRA_ARGS
+          # value: INSERT ROBOT FRAMEWORK ARGS OR LEAVE EMPTY. e.g., -i Smoke. Write inside the quotes
+          value: ""
       volumeMounts:
           # Mount the test-variables to prevent leaking secure info for the cluster you test against
         - name: ods-ci-test-variables

--- a/build/ods-ci.pod.yaml
+++ b/build/ods-ci.pod.yaml
@@ -16,6 +16,7 @@ metadata:
   labels:
     deployment: ods-ci
   name: ods-ci
+  namespace: ods-ci
 spec:
   securityContext:
     # This is required to make the test-output volume Writable

--- a/build/ods_ci_rbac.yaml
+++ b/build/ods_ci_rbac.yaml
@@ -1,0 +1,18 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kuttl-rhods-tester
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cluster-admin
+subjects:
+- kind: ServiceAccount
+  name: rhods-test-runner
+  namespace: redhat-rhods-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: rhods-test-runner
+  namespace: redhat-rhods-operator

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
-echo run script args "${RUN_SCRIPT_ARGS}"
-echo --extra-robot-args "${ROBOT_EXTRA_ARGS}"
+echo RUN SCRIPT ARGS: "${RUN_SCRIPT_ARGS}"
+echo ROBOT EXTRA ARGS: "${ROBOT_EXTRA_ARGS}"
 
 if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
         ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}" ;\

--- a/build/run.sh
+++ b/build/run.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+echo run script args "${RUN_SCRIPT_ARGS}"
+echo --extra-robot-args "${ROBOT_EXTRA_ARGS}"
+
+if [ -n "${ROBOT_EXTRA_ARGS}" ]; then \
+        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}" ;\
+else \
+        ./run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS};\
+fi
+

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,6 @@
 #/bin/bash
 
-SKIP_OC_LOGIN=true
+SKIP_OC_LOGIN=false
 SET_RHODS_URLS=false
 TEST_CASE_FILE=tests/Tests
 TEST_VARIABLES_FILE=test-variables.yml

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -39,7 +39,7 @@ while [ "$#" -gt 0 ]; do
       shift
       ;;
 
-    # Specify included tags 
+    # Specify included tags
     # Example: sanityANDinstall sanityORinstall installNOTsanity
     --include)
       shift
@@ -113,6 +113,34 @@ case "$(uname -s)" in
           exit 1
         ;;
 esac
+
+## if we have yq installed
+if command -v yq &> /dev/null
+then
+    echo "INFO: we found a yq executable"
+
+    ## get the user, pass and API hostname for OpenShift
+    oc_user=$(yq  e '.OCP_ADMIN_USER.USERNAME' ${TEST_VARIABLES_FILE})
+    oc_pass=$(yq  e '.OCP_ADMIN_USER.PASSWORD' ${TEST_VARIABLES_FILE})
+    oc_host=$(yq  e '.OCP_API_URL' ${TEST_VARIABLES_FILE})
+
+    ## do an oc login here
+    oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
+    
+    ## no point in going further if the login is not working
+    retVal=$?
+    if [ $retVal -ne 0 ]; then
+        echo "The oc login command seems to have failed"
+        echo "Please review the content of ${TEST_VARIABLES_FILE}"
+        exit $retVal
+    fi
+    oc cluster-info
+    printf "\nconnected as openshift user ' $(oc whoami) '\n"
+    echo "since the oc login was successful, continuing."
+else
+    echo "we did not find yq, so not trying the oc login"
+fi
+
 
 #TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test
 VENV_ROOT=${currentpath}/venv

--- a/test-variables.yml.example
+++ b/test-variables.yml.example
@@ -3,8 +3,9 @@ BROWSER:
   # List of Chrome options - https://peter.sh/experiments/chromium-command-line-switches/
   # --disable-dev-shm-usage  and --no-sandbox are required for running chromedriver in a container
   OPTIONS: add_argument("--ignore-certificate-errors");add_argument("window-size=1920,1024");add_argument("--disable-dev-shm-usage");add_argument("--no-sandbox")
-OCP_CONSOLE_URL: "http://console-openshift-console.apps.my-cluster.test.redhat.com/"
-ODH_DASHBOARD_URL: "http://odh-dashboard-opendatahub.apps.my-cluster.test.redhat.com/"
+OCP_CONSOLE_URL: "http://console-openshift-console.apps.my-cluster.test.redhat.com"
+ODH_DASHBOARD_URL: "http://odh-dashboard-opendatahub.apps.my-cluster.test.redhat.com"
+OCP_API_URL: "https://api.my-cluster.test.redhat.com:my-port"
 RHODS_PROMETHEUS_URL: "https://prometheus-redhat-ods-monitoring.apps.my-cluster.test.redhat.com/"
 # RHODS_PROMETHEUS_TOKEN can be obtained running: oc serviceaccounts get-token prometheus -n redhat-ods-monitoring #
 RHODS_PROMETHEUS_TOKEN: "prometheus-token"


### PR DESCRIPTION
This PR wants to fix the issue reported in PR https://github.com/red-hat-data-services/ods-ci/pull/166#discussion_r782735501 

- _Test selection_: The idea is to use two different Env variables to handle args for  `run_robot_test` and `robot` commands
To select a subset of tests it is possible to run the container adding the env variables `ROBOT_EXTRA_ARGS` like this:
`podman run --rm -e ROBOT_EXTRA_ARGS='-i Smoke'  [...] `
- _Other fixes_: base image changed in dockerfile, intergated fix from #166 to connect to ocp cluster in run script. 


Signed-off-by: bdattoma <bdattoma@redhat.com>