### PR TITLE
change tier tags for AiApps installation test cases

### DIFF
--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -43,7 +43,7 @@ Verify Anaconda Commercial Edition Is Available In RHODS Dashboard Explore/Enabl
 Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
   [Documentation]  Checks that if user inserts an invalid key,
   ...              the Anaconda CE validation fails as expected
-  [Tags]  Smoke  Sanity
+  [Tags]  Tier2
   ...     ODS-310  ODS-367
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
@@ -60,7 +60,7 @@ Verify Anaconda Commercial Edition Fails Activation When Key Is Invalid
   Page Should Not Contain Element  xpath://div[@class="pf-c-card__title"]/span[.="Anaconda Commercial Edition"]
 
 Verify User Is Able to Activate Anaconda Commercial Edition
-  [Tags]  Sanity  Smoke
+  [Tags]  Tier2
   ...     ODS-272  ODS-344  ODS-501
   [Documentation]  Performs the Anaconda CE activation, spawns a JL using the Anaconda image,
   ...              validate the token, install a library and try to import it.

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -25,7 +25,7 @@ Verify intel aikit Is Available In RHODS Dashboard Explore Page
   Verify Service Provides "Get Started" Button In The Explore Page     ${intel_aikit_container_name}
 
 Verify Inetl AIKIT Operator Can Be Installed Using OpenShift Console
-   [Tags]  ODS-760   ODS-702   Sanity
+   [Tags]  ODS-760   ODS-702   Tier2
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
    Check And Install Operator in Openshift    ${intel_aikit_container_name}    ${intel_aikit_appname}

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -49,7 +49,7 @@ Verify User Can Enable RHOSAK from Dashboard Explore Page
     Wait Until Page Contains    Kafka Instances
 
 Verify User Is Able to Produce and Consume Events
-  [Tags]  Sanity  Tier2
+  [Tags]  Tier2
   ...     ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-241  ODS-239  ODS-242
   [Teardown]  Clean Up RHOSAK    stream_to_delete=${STREAM_NAME_TEST}
   ...                            topic_to_delete=${TOPIC_NAME_TEST}

--- a/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -23,7 +23,7 @@ Verify OpenVino Is Available In RHODS Dashboard Explore Page
   Verify Service Provides "Get Started" Button In The Explore Page    OpenVINO
 
 Verify Openvino Operator Can Be Installed Using OpenShift Console
-   [Tags]  ODS-675   ODS-702  Sanity
+   [Tags]  ODS-675   ODS-702  Tier2
    [Documentation]  This Test Case Installed Openvino operator in Openshift cluster
    ...               and Check and Launch AIKIT notebook image from RHODS dashboard
    Check And Install Operator in Openshift    ${openvino_operator_name}   ${openvino_appname}


### PR DESCRIPTION
The test cases for app installation are currently set as Sanity/Smoke. This PR wants to bring them to Tier2 and removing from Sanity/Smoke

Signed-off-by: bdattoma <bdattoma@redhat.com>