### PR TITLE
Fix failures in library version check TC

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -16,6 +16,7 @@ ${JUPYTERHUB_SPAWNER_HEADER_XPATH} =
 ...   //div[contains(@class,"jsp-app__header__title") and .="Start a notebook server"]
 ${JUPYTERHUB_DROPDOWN_XPATH} =
 ...   //div[contains(concat(' ',normalize-space(@class),' '),' jsp-spawner__size_options__select ')]
+${JUPYTERHUB_CONTAINER_SIZE_TITLE} =    //div[@id="container-size"]
 
 
 *** Keywords ***
@@ -27,6 +28,7 @@ JupyterHub Spawner Is Visible
 
 Wait Until JupyterHub Spawner Is Ready
     [Documentation]  Waits for the spawner page to be ready using the server size dropdown
+    Wait Until Page Contains Element    xpath:${JUPYTERHUB_CONTAINER_SIZE_TITLE}
     Wait Until Page Contains Element    xpath:${JUPYTERHUB_DROPDOWN_XPATH}\[1]
 
 Select Notebook Image
@@ -183,8 +185,9 @@ Launch JupyterHub Spawner From Dashboard
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
-    Fix Spawner Status  # TODO: Remove or speed up
+    Fix Spawner Status
     Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+    Wait Until JupyterHub Spawner Is Ready
 
 Get Spawner Progress Message
    [Documentation]  Get the progress message currently displayed

--- a/tests/Tests/500__jupyterhub/test-versions.robot
+++ b/tests/Tests/500__jupyterhub/test-versions.robot
@@ -1,38 +1,36 @@
 *** Settings ***
-Force Tags       Sanity
+Documentation    Test Suite to verify installed library versions
 Resource         ../../Resources/ODS.robot
 Resource         ../../Resources/Common.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Library          JupyterLibrary
-Suite Setup      Begin Web Test
+Suite Setup      Load Spawner Page
 Suite Teardown   End Web Test
 
+
 *** Variables ***
-@{status_list}
+@{status_list}  # robocop: disable
+
 
 *** Test Cases ***
 Open JupyterHub Spawner Page
-    [Tags]  ODS-695
-    Wait for RHODS Dashboard to Load
-    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
-    IF  ${version-check}==True
-        Launch JupyterHub From RHODS Dashboard Link
-    ELSE
-        Launch JupyterHub From RHODS Dashboard Dropdown
-    END
-    Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
-    Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
+    [Documentation]    Verifies that Spawner page can be loaded
+    [Tags]    Sanity
+    ...       ODS-695
+    Pass Execution    Passing tests, as suite setup ensures that spawner can be loaded
 
 Verify Libraries in Minimal Image
+    [Documentation]    Verifies libraries in Minimal Python image
+    [Tags]    Sanity
     @{additional_libs} =    Create List
     ${status} =  Verify Libraries In Base Image    s2i-minimal-notebook    ${additional_libs}
     Append To List  ${status_list}  ${status}
     Run Keyword If  '${status}' == 'FAIL'  Fail  Shown and installed libraries for minimal image do not match
 
 Verify Libraries in SDS Image
+    [Documentation]    Verifies libraries in Standard Data Science image
+    [Tags]    Sanity
     @{additional_libs} =    Create List
     Append To List    ${additional_libs}    JupyterLab v3.2    Notebook v6.4
     ${status} =  Verify Libraries In Base Image    s2i-generic-data-science-notebook    ${additional_libs}
@@ -40,7 +38,9 @@ Verify Libraries in SDS Image
     Run Keyword If  '${status}' == 'FAIL'  Fail  Shown and installed libraries for SDS image do not match
 
 Verify Libraries in PyTorch Image
-    [Tags]  ODS-215  ODS-216  ODS-217  ODS-218
+    [Documentation]    Verifies libraries in PyTorch image
+    [Tags]    Sanity
+    ...       ODS-215  ODS-216  ODS-217  ODS-218
     @{additional_libs} =    Create List
     Append To List    ${additional_libs}    JupyterLab v3.2    Notebook v6.4
     ${status} =  Verify Libraries In Base Image    pytorch    ${additional_libs}
@@ -48,7 +48,9 @@ Verify Libraries in PyTorch Image
     Run Keyword If  '${status}' == 'FAIL'  Fail  Shown and installed libraries for pytorch image do not match
 
 Verify Libraries in Tensorflow Image
-    [Tags]  ODS-204  ODS-205  ODS-206  ODS-207
+    [Documentation]    Verifies libraries in Tensorflow image
+    [Tags]    Sanity
+    ...       ODS-204  ODS-205  ODS-206  ODS-207
     @{additional_libs} =    Create List
     Append To List    ${additional_libs}    JupyterLab v3.2    Notebook v6.4
     ${status} =  Verify Libraries In Base Image    tensorflow    ${additional_libs}
@@ -56,20 +58,25 @@ Verify Libraries in Tensorflow Image
     Run Keyword If  '${status}' == 'FAIL'  Fail  Shown and installed libraries for tensorflow image do not match
 
 Verify All Images And Spawner
-    [Tags]  ODS-340
+    [Documentation]    Verifies that all images have the correct libraries
+    [Tags]    Sanity
+    ...       ODS-340
     List Should Not Contain Value  ${status_list}  FAIL
     ${length} =  Get Length  ${status_list}
     Should Be Equal As Integers  ${length}  4
     Log To Console  ${status_list}
 
+
 *** Keywords ***
-Verify Libraries In Base Image
+Verify Libraries In Base Image  # robocop: disable
+    [Documentation]    Fetches library versions from JH spawner and checks
+    ...    they match the installed versions.
     [Arguments]  ${img}  ${additional_libs}
     @{list} =  Create List
     ${text} =  Fetch Image Description Info  ${img}
     Append To List  ${list}  ${text}
     ${tmp} =  Fetch Image Tooltip Info  ${img}
-    ${list} =  Combine Lists  ${list}  ${tmp}
+    ${list} =  Combine Lists  ${list}  ${tmp}  # robocop: disable
     ${list} =  Combine Lists  ${list}  ${additional_libs}
     Log  ${list}
     Spawn Notebook With Arguments  image=${img}
@@ -77,7 +84,12 @@ Verify Libraries In Base Image
     Clean Up Server
     Stop JupyterLab Notebook Server
     Go To  ${ODH_DASHBOARD_URL}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch JupyterHub From RHODS Dashboard Link
     Wait Until JupyterHub Spawner Is Ready
     [Return]  ${status}
+
+Load Spawner Page
+    [Documentation]    Suite Setup, loads JH Spawner
+    Begin Web Test
+    Launch JupyterHub Spawner From Dashboard


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

There was a corner case bug in the way we check that the spawner has loaded; this would cause our TC for version verification to sometimes fail. This PR aims to fix that bug by enforcing a stricter check on the spawner being ready before starting TC execution.