### PR TITLE
Automated test for text formatting bug - RHODS-3149

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -41,3 +41,10 @@ Load Json File
     ${j_file}    Get File    ${file_path}
     ${obj}    Evaluate    json.loads('''${j_file}''')    json
     [Return]    ${obj}
+
+Get CSS Property Value
+    [Documentation]    Get the CSS property value of a given element
+    [Arguments]    ${locator}    ${property_name}
+    ${element} =       Get WebElement    ${locator}
+    ${css_prop} =    Call Method       ${element}    value_of_css_property    ${property_name}
+    [Return]     ${css_prop}

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -48,3 +48,15 @@ Get CSS Property Value
     ${element} =       Get WebElement    ${locator}
     ${css_prop} =    Call Method       ${element}    value_of_css_property    ${property_name}
     [Return]     ${css_prop}
+
+CSS Property Value Should Be
+    [Documentation]     Compare the actual CSS property value with the expected one
+    [Arguments]   ${locator}    ${property}    ${exp_value}   ${operation}=equal
+    ${el_text}=   Get Text   xpath:${locator}
+    Log    Text of the target element: ${el_text}
+    ${actual_value}=    Get CSS Property Value   xpath:${locator}    ${property}
+    IF    $operation == "contains"
+        Run Keyword And Continue On Failure   Should Contain    ${actual_value}    ${exp_value}
+    ELSE
+        Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}
+    END

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -322,18 +322,21 @@ Check CSS Property Has The Expected Value
     END
 
 Check CSS Style Is The Expected One
-    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.7.0
+    ${version-check}=  Is RHODS Version Greater Or Equal Than  1.7.0
     IF  ${version-check}==True
         Check CSS Property Has The Expected Value    locator=//pre
         ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
+        Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
+    ...    property=margin-bottom    exp_value=8px
     ELSE
         Check CSS Property Has The Expected Value    locator=//pre
         ...    property=background-color    exp_value=rgba(245, 245, 245, 1)
+        Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
+    ...    property=margin-bottom    exp_value=10px
     END
     Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
     ...    property=font-size    exp_value=24px
     Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
     ...    property=font-family    exp_value=RedHatDisplay
     ...    operation=contains
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-    ...    property=margin-bottom    exp_value=8px
+

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -330,12 +330,12 @@ Check CSS Style Is The Expected One
         Check CSS Property Has The Expected Value    locator=//pre
         ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
         Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-    ...    property=margin-bottom    exp_value=8px
+        ...    property=margin-bottom    exp_value=8px
     ELSE
         Check CSS Property Has The Expected Value    locator=//pre
         ...    property=background-color    exp_value=rgba(245, 245, 245, 1)
         Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-    ...    property=margin-bottom    exp_value=10px
+        ...    property=margin-bottom    exp_value=10px
     END
     Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
     ...    property=font-size    exp_value=24px

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -322,6 +322,9 @@ Check CSS Property Has The Expected Value
     END
 
 Check CSS Style Is The Expected One
+    [Documentation]     Compare the some CSS properties of the Explore page
+    ...                 with the expected ones. The expected values change based
+    ...                 on the RHODS version
     ${version-check}=  Is RHODS Version Greater Or Equal Than  1.7.0
     IF  ${version-check}==True
         Check CSS Property Has The Expected Value    locator=//pre

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -19,6 +19,7 @@ ${OFFICIAL_BADGE_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "ti
 ${FALLBK_IMAGE_XP}=  ${HEADER_XP}/svg[contains(@class, 'odh-card__header-fallback-img')]
 ${IMAGE_XP}=  ${HEADER_XP}/img[contains(@class, 'odh-card__header-brand')]
 ${APPS_DICT_PATH}=  tests/Resources/Page/ODH/ODHDashboard/AppsInfoDictionary.json
+${SIDEBAR_TEXT_CONTAINER_XP}=  //div[contains(@class,'odh-markdown-view')]
 ${SUCCESS_MSG_XP}=  //div[@class='pf-c-alert pf-m-success']
 
 

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -9,6 +9,7 @@ ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}=                //*[@class="pf-c-drawer__p
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //article[contains(@class, 'pf-c-card')]
+${JH_CARDS_XP}=   //article[@id="jupyterhub"]
 ${HEADER_XP}=  div[@class='pf-c-card__header']
 ${TITLE_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "title")]
 ${PROVIDER_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "provider")]
@@ -306,3 +307,9 @@ Re-validate License For Disabled Application From Enabled Page
    Wait Until Page Contains   To remove card click
    ${buttons_here}=  Get WebElements    xpath://div[contains(@class,'popover__body')]//button[text()='here']
    Click Element  ${buttons_here}[0]
+
+Check CSS Property Has The Expected Value
+    [Arguments]   ${locator}    ${property}    ${exp_value}
+    ${el_text}=   Get Text   xpath:${locator}
+    ${actual_value}=    Get CSS Property Value   xpath:${locator}    ${property}
+    Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -321,3 +321,19 @@ Check CSS Property Has The Expected Value
         Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}
     END
 
+Check CSS Style Is The Expected One
+    ${version-check} =  Is RHODS Version Greater Or Equal Than  1.7.0
+    IF  ${version-check}==True
+        Check CSS Property Has The Expected Value    locator=//pre
+        ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
+    ELSE
+        Check CSS Property Has The Expected Value    locator=//pre
+        ...    property=background-color    exp_value=rgba(245, 245, 245, 1)
+    END
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
+    ...    property=font-size    exp_value=24px
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
+    ...    property=font-family    exp_value=RedHatDisplay
+    ...    operation=contains
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
+    ...    property=margin-bottom    exp_value=8px

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -313,6 +313,7 @@ Check CSS Property Has The Expected Value
     [Documentation]     Compare the actual CSS property value with the expected one
     [Arguments]   ${locator}    ${property}    ${exp_value}   ${operation}=equal
     ${el_text}=   Get Text   xpath:${locator}
+    Log    Text of the target element: ${el_text}
     ${actual_value}=    Get CSS Property Value   xpath:${locator}    ${property}
     IF    $operation == "contains"
         Run Keyword And Continue On Failure   Should Contain    ${actual_value}    ${exp_value}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -309,7 +309,13 @@ Re-validate License For Disabled Application From Enabled Page
    Click Element  ${buttons_here}[0]
 
 Check CSS Property Has The Expected Value
-    [Arguments]   ${locator}    ${property}    ${exp_value}
+    [Documentation]     Compare the actual CSS property value with the expected one
+    [Arguments]   ${locator}    ${property}    ${exp_value}   ${operation}=equal
     ${el_text}=   Get Text   xpath:${locator}
     ${actual_value}=    Get CSS Property Value   xpath:${locator}    ${property}
-    Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}
+    IF    $operation == "contains"
+        Run Keyword And Continue On Failure   Should Contain    ${actual_value}    ${exp_value}
+    ELSE
+        Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}
+    END
+

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -309,37 +309,4 @@ Re-validate License For Disabled Application From Enabled Page
    ${buttons_here}=  Get WebElements    xpath://div[contains(@class,'popover__body')]//button[text()='here']
    Click Element  ${buttons_here}[0]
 
-Check CSS Property Has The Expected Value
-    [Documentation]     Compare the actual CSS property value with the expected one
-    [Arguments]   ${locator}    ${property}    ${exp_value}   ${operation}=equal
-    ${el_text}=   Get Text   xpath:${locator}
-    Log    Text of the target element: ${el_text}
-    ${actual_value}=    Get CSS Property Value   xpath:${locator}    ${property}
-    IF    $operation == "contains"
-        Run Keyword And Continue On Failure   Should Contain    ${actual_value}    ${exp_value}
-    ELSE
-        Run Keyword And Continue On Failure   Should Be Equal    ${actual_value}    ${exp_value}
-    END
-
-Check CSS Style Is The Expected One
-    [Documentation]     Compare the some CSS properties of the Explore page
-    ...                 with the expected ones. The expected values change based
-    ...                 on the RHODS version
-    ${version-check}=  Is RHODS Version Greater Or Equal Than  1.7.0
-    IF  ${version-check}==True
-        Check CSS Property Has The Expected Value    locator=//pre
-        ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
-        Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-        ...    property=margin-bottom    exp_value=8px
-    ELSE
-        Check CSS Property Has The Expected Value    locator=//pre
-        ...    property=background-color    exp_value=rgba(245, 245, 245, 1)
-        Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-        ...    property=margin-bottom    exp_value=10px
-    END
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
-    ...    property=font-size    exp_value=24px
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
-    ...    property=font-family    exp_value=RedHatDisplay
-    ...    operation=contains
 

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -83,12 +83,12 @@ Verify CSS Style Of Getting Started Descriptions
     Capture Page Screenshot    get_started_sidebar.png
     Check CSS Property Has The Expected Value    locator=//pre
     ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
-    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
     ...    property=font-size    exp_value=24px
-    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
     ...    property=font-family    exp_value=RedHatDisplay
     ...    operation=contains
-    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]//p
+    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
     ...    property=margin-bottom    exp_value=8px
 
 

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -81,15 +81,7 @@ Verify CSS Style Of Getting Started Descriptions
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status    card_locator=${JH_CARDS_XP}
     Capture Page Screenshot    get_started_sidebar.png
-    Check CSS Property Has The Expected Value    locator=//pre
-    ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
-    ...    property=font-size    exp_value=24px
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
-    ...    property=font-family    exp_value=RedHatDisplay
-    ...    operation=contains
-    Check CSS Property Has The Expected Value    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
-    ...    property=margin-bottom    exp_value=8px
+    Check CSS Style Is The Expected One
 
 
 *** Keywords ***

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -75,7 +75,8 @@ Verify License Of Disabled Cards Can Be Re-validated
 
 Verify CSS Style Of Getting Started Descriptions
     [Documentation]    Verifies the CSS style is not changed. It uses JupyterHub card as sample
-    [Tags]  ODS-XYZ
+    [Tags]    Smoke
+    ...       ODS-1165
     Click Link    Explore
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status   card_locator=${JH_CARDS_XP}

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -81,7 +81,7 @@ Verify CSS Style Of Getting Started Descriptions
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status    card_locator=${JH_CARDS_XP}
     Capture Page Screenshot    get_started_sidebar.png
-    Check CSS Style Is The Expected One
+    Verify JupyterHub Card CSS Style
 
 
 *** Keywords ***
@@ -93,3 +93,25 @@ Dashboard Test Setup
 
 Dashboard Test Teardown
   Close All Browsers
+
+Verify JupyterHub Card CSS Style
+    [Documentation]     Compare the some CSS properties of the Explore page
+    ...                 with the expected ones. The expected values change based
+    ...                 on the RHODS version
+    ${version-check}=  Is RHODS Version Greater Or Equal Than  1.7.0
+    IF  ${version-check}==True
+        CSS Property Value Should Be    locator=//pre
+        ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
+        CSS Property Value Should Be    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
+        ...    property=margin-bottom    exp_value=8px
+    ELSE
+        CSS Property Value Should Be    locator=//pre
+        ...    property=background-color    exp_value=rgba(245, 245, 245, 1)
+        CSS Property Value Should Be    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
+        ...    property=margin-bottom    exp_value=10px
+    END
+    CSS Property Value Should Be    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
+    ...    property=font-size    exp_value=24px
+    CSS Property Value Should Be    locator=${SIDEBAR_TEXT_CONTAINER_XP}/h1
+    ...    property=font-family    exp_value=RedHatDisplay
+    ...    operation=contains

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -73,6 +73,19 @@ Verify License Of Disabled Cards Can Be Re-validated
     Capture Page Screenshot     after_revalidation.png
     [Teardown]    Remove Anaconda Commercial Edition Component
 
+Verify CSS Style Of Getting Started Descriptions
+    [Documentation]    Verifies the CSS style is not changed. It uses JupyterHub card as sample
+    [Tags]  ODS-XYZ
+    Click Link    Explore
+    Wait Until Cards Are Loaded
+    Open Get Started Sidebar And Return Status   card_locator=${JH_CARDS_XP}
+    Check CSS Property Has The Expected Value    locator=//pre
+    ...                                          property=background-color    exp_value=rgba(245, 245, 245, 1)
+    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
+    ...                                          property=font-size    exp_value=24px
+    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
+    ...                                          property=color    exp_value=rgba(21, 21, 21, 1)
+
 
 *** Keywords ***
 Dashboard Test Setup

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -80,6 +80,7 @@ Verify CSS Style Of Getting Started Descriptions
     Click Link    Explore
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status    card_locator=${JH_CARDS_XP}
+    Capture Page Screenshot    get_started_sidebar.png
     Check CSS Property Has The Expected Value    locator=//pre
     ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
     Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1

--- a/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
+++ b/tests/Tests/400_ods_dashboard/400_ods_dashboard.robot
@@ -79,13 +79,16 @@ Verify CSS Style Of Getting Started Descriptions
     ...       ODS-1165
     Click Link    Explore
     Wait Until Cards Are Loaded
-    Open Get Started Sidebar And Return Status   card_locator=${JH_CARDS_XP}
+    Open Get Started Sidebar And Return Status    card_locator=${JH_CARDS_XP}
     Check CSS Property Has The Expected Value    locator=//pre
-    ...                                          property=background-color    exp_value=rgba(245, 245, 245, 1)
+    ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
     Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
-    ...                                          property=font-size    exp_value=24px
+    ...    property=font-size    exp_value=24px
     Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]/h1
-    ...                                          property=color    exp_value=rgba(21, 21, 21, 1)
+    ...    property=font-family    exp_value=RedHatDisplay
+    ...    operation=contains
+    Check CSS Property Has The Expected Value    locator=//div[contains(@class,'odh-markdown-view')]//p
+    ...    property=margin-bottom    exp_value=8px
 
 
 *** Keywords ***


### PR DESCRIPTION
This PR wants to check if the css style used in Explore page > (click on a card) sidebar is the expected one. It uses JupyterHub card as sample for the testing, since the css rules are set in an external sheet which applies for all the cards.


Signed-off-by: bdattoma <bdattoma@redhat.com>