### PR TITLE
Fix for spawner failures in 1.7 automated runs

### DIFF
--- a/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -40,7 +40,7 @@ Verify PyTorch Image Can Be Spawned With GPU
     ...     ODS-1145
     Clean Up Server
     Stop JupyterLab Notebook Server
-    Handle Start My Server
+    Fix Spawner Status
     Wait Until JupyterHub Spawner Is Ready
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Default  gpus=1
 

--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -41,7 +41,7 @@ Verify Tensorflow Image Can Be Spawned With GPU
     ...     ODS-1151
     Clean Up Server
     Stop JupyterLab Notebook Server
-    Handle Start My Server
+    Fix Spawner Status
     Wait Until JupyterHub Spawner Is Ready
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Default  gpus=1
 


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

Potential fix for some of the failures seen in the automated runs for 1.7 (i.e. spawner page not being loaded). Will need to wait for rebuild to happen to test it out.