### PR TITLE
Remove Anaconda Teardown for Smoke TCs + fix compatibility issue with OCP4.10

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -17,7 +17,7 @@ Get Pod Logs From UI
     Click Link    xpath://tr[@data-key='0-0']/td/span/a
     Click Link    Logs
     Sleep    4
-    # Capture Page Screenshot    logs_page.png
+    Capture Page Screenshot    logs_page.png
     ${log_lines_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
     ...    xpath://div[@class='log-window__lines']
     ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -4,6 +4,7 @@ Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 Library    ../../../../libs/Helpers.py
 
+
 *** Keywords ***
 Get Pod Logs From UI
   [Arguments]  ${namespace}  ${pod_search_term}
@@ -13,9 +14,18 @@ Get Pod Logs From UI
   Click Link    Logs
   Sleep  4
   Capture Page Screenshot  logs_page.png
-  ${logs_text}=  Get Text    xpath://div[@class='log-window__contents']
-  ${logs_text}=  Get Text    xpath://div[@class='log-window__body']
-  # ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
+  ${log_lines_flag}=   Run Keyword And Return Status    Wait Until Page Contains Element    xpath://div[@class='log-window__lines']
+  ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element    xpath://div[@class='pf-c-log-viewer__list']
+  IF    ${log_lines_flag} == ${TRUE}
+      ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
+  ELSE IF   ${log_list_flag} == ${TRUE}
+      Click Link   Raw
+      Switch Window   NEW
+      ${logs_text}=  Get Text    xpath://pre
+      Close Window
+  ELSE
+      Fail    No logs window found..
+  END
   ${log_rows}=  Text To List  ${logs_text}
   [Return]  ${log_rows}
 

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -17,7 +17,7 @@ Get Pod Logs From UI
     Click Link    xpath://tr[@data-key='0-0']/td/span/a
     Click Link    Logs
     Sleep    4
-    Capture Page Screenshot    logs_page.png
+    # Capture Page Screenshot    logs_page.png
     ${log_lines_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
     ...    xpath://div[@class='log-window__lines']
     ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
@@ -29,6 +29,7 @@ Get Pod Logs From UI
         Switch Window    NEW
         ${logs_text}=    Get Text    xpath://pre
         Close Window
+        Switch Window    MAIN
     ELSE
         Fail    No logs window found..
     END

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -1,47 +1,58 @@
 *** Settings ***
-Library    OpenShiftCLI
-Resource   ../../OCPDashboard/Page.robot
-Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
-Library    ../../../../libs/Helpers.py
+Documentation       Collection of keywords to work with Pods
+
+Library             OpenShiftCLI
+Resource            ../../OCPDashboard/Page.robot
+Resource            ../../ODH/ODHDashboard/ODHDashboard.robot
+Library             ../../../../libs/Helpers.py
 
 
 *** Keywords ***
 Get Pod Logs From UI
-  [Arguments]  ${namespace}  ${pod_search_term}
-  Navigate To Page    Workloads    Pods
-  Search Last Item Instance By Title in OpenShift Table  search_term=${pod_search_term}  namespace=${namespace}
-  Click Link    xpath://tr[@data-key='0-0']/td/span/a
-  Click Link    Logs
-  Sleep  4
-  Capture Page Screenshot  logs_page.png
-  ${log_lines_flag}=   Run Keyword And Return Status    Wait Until Page Contains Element    xpath://div[@class='log-window__lines']
-  ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element    xpath://div[@class='pf-c-log-viewer__list']
-  IF    ${log_lines_flag} == ${TRUE}
-      ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
-  ELSE IF   ${log_list_flag} == ${TRUE}
-      Click Link   Raw
-      Switch Window   NEW
-      ${logs_text}=  Get Text    xpath://pre
-      Close Window
-  ELSE
-      Fail    No logs window found..
-  END
-  ${log_rows}=  Text To List  ${logs_text}
-  [Return]  ${log_rows}
+    [Documentation]    Get pod logs text from OCP UI
+    [Arguments]    ${namespace}    ${pod_search_term}
+    Navigate To Page    Workloads    Pods
+    Search Last Item Instance By Title In OpenShift Table    search_term=${pod_search_term}
+    ...    namespace=${namespace}
+    Click Link    xpath://tr[@data-key='0-0']/td/span/a
+    Click Link    Logs
+    Sleep    4
+    Capture Page Screenshot    logs_page.png
+    ${log_lines_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
+    ...    xpath://div[@class='log-window__lines']
+    ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
+    ...    xpath://div[@class='pf-c-log-viewer__list']
+    IF    ${log_lines_flag} == ${TRUE}
+        ${logs_text}=    Get Text    xpath://div[@class='log-window__lines']
+    ELSE IF    ${log_list_flag} == ${TRUE}
+        Click Link    Raw
+        Switch Window    NEW
+        ${logs_text}=    Get Text    xpath://pre
+        Close Window
+    ELSE
+        Fail    No logs window found..
+    END
+    ${log_rows}=    Text To List    ${logs_text}
+    [Return]    ${log_rows}
 
 Delete Pods Using Label Selector
-    [Arguments]   ${namespace}                ${label_selector}
-    ${status}      Check If POD Exists       ${namespace}        ${label_selector}
-    Run Keyword IF          '${status}'=='PASS'   OpenShiftCLI.Delete   kind=Pod     namespace=${namespace}   label_selector=${label_selector}
-    ...        ELSE      FAIL        No PODS present with Label '${label_selector}' in '${namespace}' namespace, Check the label selector and namespace provide is correct and try again
+    [Documentation]    Deletes an openshift pod by label selector
+    [Arguments]    ${namespace}    ${label_selector}
+    ${status}=    Check If POD Exists    ${namespace}    ${label_selector}
+    Run Keyword IF    '${status}'=='PASS'    OpenShiftCLI.Delete    kind=Pod    namespace=${namespace}
+    ...    label_selector=${label_selector}    ELSE    FAIL
+    ...    No PODS present with Label '${label_selector}' in '${namespace}' namespace, Check the label selector and namespace provide is correct and try again
     Sleep    2
-    ${status}      Check If POD Exists       ${namespace}        ${label_selector}
-    Run Keyword IF          '${status}'!='FAIL'     FAIL        PODS with Label '${label_selector}' is not deleted in '${namespace}' namespace
+    ${status}=    Check If POD Exists    ${namespace}    ${label_selector}
+    Run Keyword IF    '${status}'!='FAIL'    FAIL
+    ...    PODS with Label '${label_selector}' is not deleted in '${namespace}' namespace
 
 Check If POD Exists
-    [Arguments]   ${namespace}   ${label_selector}
-    ${status}     ${val}       Run keyword and Ignore Error   OpenShiftCLI.Get   kind=Pod     namespace=${namespace}   label_selector=${label_selector}
-    [Return]   ${status}
+    [Documentation]    Check existence of an openshift pod by label selector
+    [Arguments]    ${namespace}    ${label_selector}
+    ${status}    ${val}=    Run Keyword And Ignore Error    OpenShiftCLI.Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=${label_selector}
+    [Return]    ${status}
 
 Verify Operator Pod Status
     [Documentation]    Verify Pod status

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -13,7 +13,9 @@ Get Pod Logs From UI
   Click Link    Logs
   Sleep  4
   Capture Page Screenshot  logs_page.png
-  ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
+  ${logs_text}=  Get Text    xpath://div[@class='log-window__contents']
+  ${logs_text}=  Get Text    xpath://div[@class='log-window__body']
+  # ${logs_text}=  Get Text    xpath://div[@class='log-window__lines']
   ${log_rows}=  Text To List  ${logs_text}
   [Return]  ${log_rows}
 

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -11,8 +11,6 @@ Library         SeleniumLibrary
 Library         JupyterLibrary
 Library         ../../../../libs/Helpers.py
 Suite Setup     Anaconda Commercial Edition Suite Setup
-## Suite Teardown  Remove Anaconda Commercial Edition Component
-Library    OpenShiftCLI
 
 
 *** Test Cases ***
@@ -89,20 +87,8 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Maybe Open JupyterLab Sidebar   File Browser
   Fix Spawner Status  # used to close the server and go back to Spawner
   Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']  timeout=15
+  [Teardown]    Remove Anaconda Commercial Edition Component
 
-Verify logs
-  [Tags]   logs
-  Open Browser   ${OCP_CONSOLE_URL}    browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-  Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
-  Maybe Skip Tour
-  ${validator_pod}=   OpenShiftCLI.Get    kind=Pod   label_selector=job-name = anaconda-ce-periodic-validator-job-custom-run
-  ...                namespace=redhat-ods-applications
-  Log    ${validator_pod}
-  # ${val_result}=  Get Pod Logs From UI  namespace=redhat-ods-applications
-  # ...
-  ${val_result}=  Get Pod Logs From UI  namespace=redhat-ods-applications
-  ...                                   pod_search_term=anaconda-ce-periodic-validator-job-custom-run
-  Close All Browsers
 
 *** Keywords ***
 Anaconda Commercial Edition Suite Setup

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -11,7 +11,8 @@ Library         SeleniumLibrary
 Library         JupyterLibrary
 Library         ../../../../libs/Helpers.py
 Suite Setup     Anaconda Commercial Edition Suite Setup
-Suite Teardown  Remove Anaconda Commercial Edition Component
+## Suite Teardown  Remove Anaconda Commercial Edition Component
+Library    OpenShiftCLI
 
 
 *** Test Cases ***
@@ -89,7 +90,19 @@ Verify User Is Able to Activate Anaconda Commercial Edition
   Fix Spawner Status  # used to close the server and go back to Spawner
   Wait Until Page Contains Element  xpath://input[@name='Anaconda Commercial Edition']  timeout=15
 
-
+Verify logs
+  [Tags]   logs
+  Open Browser   ${OCP_CONSOLE_URL}    browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
+  Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
+  Maybe Skip Tour
+  ${validator_pod}=   OpenShiftCLI.Get    kind=Pod   label_selector=job-name = anaconda-ce-periodic-validator-job-custom-run
+  ...                namespace=redhat-ods-applications
+  Log    ${validator_pod}
+  # ${val_result}=  Get Pod Logs From UI  namespace=redhat-ods-applications
+  # ...
+  ${val_result}=  Get Pod Logs From UI  namespace=redhat-ods-applications
+  ...                                   pod_search_term=anaconda-ce-periodic-validator-job-custom-run
+  Close All Browsers
 
 *** Keywords ***
 Anaconda Commercial Edition Suite Setup


### PR DESCRIPTION
This PR wants to address to Anaconda failures points:
1. Suite Teardown fails during Smoke because ODS-262 doesn't install Anaconda. Issue raised after moving e2e Anaconda TCs out from Smoke
2. The keyword to read pod logs from UI wasn't compatible with new UI in OCP 4.10. It makes anaconda e2e failing