### PR TITLE
Add GitHub release config to create release notes automatically

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+changelog:
+  exclude:
+    labels:
+      - "needs testing"
+      - ":warning: high priority review"
+      - "do not merge"
+      - "ignore for release"
+    authors:
+      - octocat
+  categories:
+    - title: New Tests
+      labels:
+        - "new test"
+    - title: New Libraries
+      labels:
+        - "new lib"
+    - title: New Tasks
+      labels:
+        - "new task"
+    - title: Enhancements
+      labels:
+        - enhancements
+    - title: Enhancements in scripts and CI/CD
+      labels:
+        - utils
+    - title: Documentation
+      labels:
+        - documentation
+    - title: Misc
+      labels:
+        - misc
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ drivers/**/chromedriver
 must-gather-results.txt
 .DS_Store
 .idea/
+.vscode
 Results/
 results/
 __pycache__/


### PR DESCRIPTION
Adds configuration file to create release notes automatically based on PR labels. 
More info at https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes