### PR TITLE
Fix HCC Splash page on login and increased timeout to check card existence on Enabled page

### DIFF
--- a/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -24,7 +24,7 @@ Login to HCC
     Input Text  id=password  ${password}
     Click Button    Log in
   END
-  Run Keyword And Continue On Failure    Wait For HCC Splash Page
+  Run Keyword And Ignore Error     Wait For HCC Splash Page
   Maybe Handle Something Went Wrong Page
 
 Maybe Skip RHOSAK Tour

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -70,7 +70,7 @@ Verify Service Is Enabled
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Enabled
   Wait Until Page Contains    JupyterHub  timeout=30
-  Wait Until Page Contains    ${app_name}  timeout=150
+  Wait Until Page Contains    ${app_name}  timeout=180
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..   message=${app_name} should be enabled in ODS Dashboard
   Page Should Not Contain Element    xpath://article//*[.='${app_name}']/..//div[contains(@class,'enabled-controls')]/span[contains(@class,'disabled-text')]  message=${app_name} is marked as Disabled. Check the license
 


### PR DESCRIPTION
This PR wants to fix two failures faced running Sanity/Smoke on RHODS v1.8.0. 
