### PR TITLE
Add rhods-groups configuration task

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -88,7 +88,7 @@ case "$(uname -s)" in
          ;;
     Linux)
        case "$(lsb_release --id --short)" in
-       "Fedora"|"CentOS")
+       "Fedora"|"CentOS"|"RedHatEnterprise")
              ## Bootstrap script to setup drivers ##
              echo "setting driver  to $currentpath/Drivers/fedora"
              PATH=$PATH:$currentpath/drivers/fedora

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
         "robotframework-requests",
         "robotframework-seleniumlibrary",
         "robotframework-jupyterlibrary>=0.3.1",
+        "robotframework-openshift",
         "robotframework-OpenShiftCLI==1.0.1",
         "ipython",
         "pytest",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "robotframework-requests",
         "robotframework-seleniumlibrary",
         "robotframework-jupyterlibrary>=0.3.1",
-        "robotframework-openshift",
+        "robotframework-openshift==1.0.0",
         "robotframework-OpenShiftCLI==1.0.1",
         "ipython",
         "pytest",

--- a/tasks/Resources/Configurations/groups/rhods-groups-config.resource
+++ b/tasks/Resources/Configurations/groups/rhods-groups-config.resource
@@ -9,10 +9,15 @@ ${RHODS_GROUPS_CONFIG} =        tasks/Resources/Configurations/groups/rhods_grou
 
 
 *** Keywords ***
-Modify RHODS Groups
+Modify ODS Groups
     [Documentation]    (string, string) -> list(dict)
+    ...    Args:
+    ...        admin_groups(str): One or more comma separated admin groups
+    ...        allowed_groups(str): One or more comma separated allowed groups
+    ...    Returns:
+    ...        group_config(list(dict)): Groups data from configmap 
     [Arguments]    ${admin_groups}    ${allowed_groups}
-    ${modified_label} =    Set Rhods Groups Modified Label    ${admin_groups}    ${allowed_groups}
+    ${modified_label} =    Set ODS Groups Modified Label    ${admin_groups}    ${allowed_groups}
     &{template_data} =    Create Dictionary
     ...    admin_groups=${admin_groups}
     ...    allowed_groups=${allowed_groups}
@@ -22,8 +27,13 @@ Modify RHODS Groups
     Restart JupyterHub Pods
     [Return]    ${groups_config[0]['data']}
 
-Set Rhods Groups Modified Label
+Set ODS Groups Modified Label
     [Documentation]    (str, str) -> str
+    ...    Args:
+    ...        admin_groups(str): One or more comma separated admin groups
+    ...        allowed_groups(str): One or more comma separated allowed groups
+    ...    Returns:
+    ...        modified_label(str): Modify label to true or false depending on default groups  
     [Arguments]    ${admin_groups}    ${allowed_groups}
 
     IF    "${admin_groups}" == "${DEFAULT_ADMIN_GROUPS}" and "${allowed_groups}" == "${DEFAULT_ALLOWED_GROUPS}"

--- a/tasks/Resources/Configurations/groups/rhods-groups-config.resource
+++ b/tasks/Resources/Configurations/groups/rhods-groups-config.resource
@@ -1,0 +1,39 @@
+*** Settings ***
+Documentation    Keywords for task RHODS groups configuration
+
+
+*** Variables ***
+${DEFAULT_ADMIN_GROUPS} =       dedicated-admins
+${DEFAULT_ALLOWED_GROUPS} =     system:authenticated
+${RHODS_GROUPS_CONFIG} =        tasks/Resources/Configurations/groups/rhods_groups_config.yaml
+
+
+*** Keywords ***
+Modify RHODS Groups
+    [Documentation]    (string, string) -> list(dict)
+    [Arguments]    ${admin_groups}    ${allowed_groups}
+    ${modified_label} =    Set Rhods Groups Modified Label    ${admin_groups}    ${allowed_groups}
+    &{template_data} =    Create Dictionary
+    ...    admin_groups=${admin_groups}
+    ...    allowed_groups=${allowed_groups}
+    ...    modified_label=${modified_label}
+    ${groups_config} =    Oc Apply    kind=ConfigMap    src=${RHODS_GROUPS_CONFIG}
+    ...    api_version=v1    template_data=${template_data}
+    Restart JupyterHub Pods
+    [Return]    ${groups_config[0]['data']}
+
+Set Rhods Groups Modified Label
+    [Documentation]    (str, str) -> str
+    [Arguments]    ${admin_groups}    ${allowed_groups}
+
+    IF    "${admin_groups}" == "${DEFAULT_ADMIN_GROUPS}" and "${allowed_groups}" == "${DEFAULT_ALLOWED_GROUPS}"
+        Set Local Variable    ${modified_label}    "false"
+    ELSE
+        Set Local Variable    ${modified_label}    "true"
+    END
+    [Return]    ${modified_label}
+
+Restart JupyterHub Pods
+    [Documentation]    () -> None
+    Oc Delete    kind=Pod    namespace=redhat-ods-applications
+    ...    api_version=v1    label_selector=app=jupyterhub

--- a/tasks/Resources/Configurations/groups/rhods_groups_config.yaml
+++ b/tasks/Resources/Configurations/groups/rhods_groups_config.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+data:
+  admin_groups: {{ admin_groups }}
+  allowed_groups: {{ allowed_groups }}
+kind: ConfigMap
+metadata:
+  labels:
+    app: jupyterhub
+    opendatahub.io/modified: {{ modified_label }}
+  name: rhods-groups-config
+  namespace: redhat-ods-applications

--- a/tasks/Tasks/rhods-groups-config.robot
+++ b/tasks/Tasks/rhods-groups-config.robot
@@ -1,0 +1,28 @@
+*** Settings ***
+Documentation       Task to modify groups
+...                 How to change groups dynamically:
+...                 ./run_robot_test.sh --test-case ./tasks/Tasks/rhods-groups-config.robot
+...                 -i Custom-Groups --test-variable ADMIN_GROUPS:<admin_groups>
+...                 --test-variable ALLOWED_GROUPS:<allowed_groups>
+
+
+Library             OpenShiftLibrary
+Resource            ../Resources/Configurations/groups/rhods-groups-config.resource
+
+
+*** Variables ***
+${ADMIN_GROUPS} =       rhods-admins
+${ALLOWED_GROUPS} =     rhods-users
+
+
+*** Test Cases ***
+Configure Custom RHODS Groups Configuration
+    [Documentation]  Configure Custom RHODS Groups Configuration
+    [Tags]    Custom-Groups
+    Set Test Variable    ${EXPECTED_ADMIN_GROUPS}    ${ADMIN_GROUPS}
+    Set Test Variable    ${EXPECTED_ALLOWED_GROUPS}    ${ALLOWED_GROUPS}
+    ${actual_value} =    Modify RHODS Groups    ${ADMIN_GROUPS}    ${ALLOWED_GROUPS}
+    Should Be Equal As Strings    ${actual_value['admin_groups']}
+    ...    ${EXPECTED_ADMIN_GROUPS}
+    Should Be Equal As Strings    ${actual_value['allowed_groups']}
+    ...    ${EXPECTED_ALLOWED_GROUPS}

--- a/tasks/Tasks/rhods-groups-config.robot
+++ b/tasks/Tasks/rhods-groups-config.robot
@@ -15,13 +15,13 @@ ${ADMIN_GROUPS} =       rhods-admins
 ${ALLOWED_GROUPS} =     rhods-users
 
 
-*** Test Cases ***
-Configure Custom RHODS Groups Configuration
-    [Documentation]  Configure Custom RHODS Groups Configuration
+*** Tasks ***
+Configure Custom ODS Groups
+    [Documentation]  Task that allows to configure dynamically cus 
     [Tags]    Custom-Groups
     Set Test Variable    ${EXPECTED_ADMIN_GROUPS}    ${ADMIN_GROUPS}
     Set Test Variable    ${EXPECTED_ALLOWED_GROUPS}    ${ALLOWED_GROUPS}
-    ${actual_value} =    Modify RHODS Groups    ${ADMIN_GROUPS}    ${ALLOWED_GROUPS}
+    ${actual_value} =    Modify ODS Groups    ${ADMIN_GROUPS}    ${ALLOWED_GROUPS}
     Should Be Equal As Strings    ${actual_value['admin_groups']}
     ...    ${EXPECTED_ADMIN_GROUPS}
     Should Be Equal As Strings    ${actual_value['allowed_groups']}


### PR DESCRIPTION
Signed-off-by: Pablo Felix Estevez Pico <pestevez@redhat.com>
The task allows to change dynamically rhods groups by modifying the test variables in the command:
         ./run_robot_test.sh --test-case ./tasks/Tasks/rhods-groups-config.robot -i Custom-Groups --test-variable ADMIN_GROUPS:<admin_groups> --test-variable ALLOWED_GROUPS:<allowed_groups>