### PR TITLE
Change requirements to robotframework 4.* (and not 5.x)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     author_email="ods-ci@redhat.com",
     install_requires=[
         "reportportal-client",
-        "robotframework>=4",
+        "robotframework==4.*",
         "robotframework-debuglibrary",
         "robotframework-requests",
         "robotframework-seleniumlibrary",


### PR DESCRIPTION
We will use robotframework 5 after testing it carefully with all test suites

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>