### PR TITLE
Add test to check dynamic update of available GPUs

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -63,9 +63,14 @@ Set Number Of Required GPUs
 
 Fetch Max Number Of GPUs In Spawner Page
     [Documentation]    Returns the maximum number of GPUs a user can request from the spawner
-    Click Element    xpath:${JUPYTERHUB_DROPDOWN_XPATH}\[2]
-    ${maxGPUs} =    Get Text    xpath://li[@class="pf-c-select__menu-wrapper"][last()]/button
-    ${maxGPUs} =    Convert To Integer    ${maxGPUs}
+    ${gpu_visible} =    Run Keyword And Return Status    Wait Until GPU Dropdown Exists
+    IF  ${gpu_visible}==True
+       Click Element    xpath:${JUPYTERHUB_DROPDOWN_XPATH}\[2]
+       ${maxGPUs} =    Get Text    xpath://li[@class="pf-c-select__menu-wrapper"][last()]/button
+       ${maxGPUs} =    Convert To Integer    ${maxGPUs}
+    ELSE
+       ${maxGPUs} =    Set Variable    ${0}
+    END
     [Return]    ${maxGPUs}
 
 Add Spawner Environment Variable

--- a/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
@@ -61,7 +61,12 @@ Verify CUDA Image Suite Setup
     ...    ${ODH_DASHBOARD_URL}    ${BROWSER.NAME}    ${BROWSER.OPTIONS}
     Launch JupyterHub Spawner From Dashboard    ${TEST_USER_2.USERNAME}    ${TEST_USER.PASSWORD}
     ...    ${TEST_USER.AUTH_TYPE}
+    # This will fail in case there are two nodes with the same number of GPUs
+    # Since the overall available number won't change even after 1 GPU is assigned
+    # However I can't think of a better way to execute this check, under the assumption that
+    # the Resources-GPU tag will always ensure there is 1 node with 1 GPU on the cluster.
+    ${maxNo} =    Find Max Number Of GPUs In One Node
     ${maxSpawner} =    Fetch Max Number Of GPUs In Spawner Page
-    Should Be Equal    ${maxSpawner}    ${0}
+    Should Be Equal    ${maxSpawner}    ${maxNo-1}
     Close Browser
     Switch Browser  ${old_browser}[0]

--- a/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
@@ -18,29 +18,30 @@ ${EXPECTED_CUDA_VERSION} =  11.4
 
 *** Test Cases ***
 Verify CUDA Image Can Be Spawned With GPU
-    [Documentation]    Spawns CUDA image with 1 GPU
-    [Tags]  Sanity
+    [Documentation]    Spawns CUDA image with 1 GPU and verifies that the GPU is
+    ...    not available for other users.
+    [Tags]  Sanity    Tier1
     ...     Resources-GPU
-    ...     ODS-1141    ODS-346
+    ...     ODS-1141    ODS-346    ODS-1359
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 Verify CUDA Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Sanity
+    [Tags]  Sanity    Tier1
     ...     Resources-GPU
     ...     ODS-1142
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify PyTorch Library Can See GPUs In Minimal CUDA
     [Documentation]    Installs PyTorch and verifies it can see the GPU
-    [Tags]  Sanity
+    [Tags]  Sanity    Tier1
     ...     Resources-GPU
     ...     ODS-1144
     Verify Pytorch Can See GPU    install=True
 
 Verify Tensorflow Library Can See GPUs In Minimal CUDA
     [Documentation]    Installs Tensorflow and verifies it can see the GPU
-    [Tags]  Sanity
+    [Tags]  Sanity    Tier1
     ...     Resources-GPU
     ...     ODS-1143
     Verify Tensorflow Can See GPU    install=True
@@ -49,6 +50,18 @@ Verify Tensorflow Library Can See GPUs In Minimal CUDA
 *** Keywords ***
 Verify CUDA Image Suite Setup
     [Documentation]    Suite Setup, spawns CUDA img with one GPU attached
+    ...    Additionally, checks that the number of available GPUs decreases
+    ...    after the GPU is assigned.
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Default  gpus=1
+    # Verifies that now there are no GPUs available for selection
+    @{old_browser} =  Get Browser Ids
+    Launch Dashboard    ${TEST_USER2.USERNAME}    ${TEST_USER2.PASSWORD}    ${TEST_USER2.AUTH_TYPE}
+    ...    ${ODH_DASHBOARD_URL}    ${BROWSER.NAME}    ${BROWSER.OPTIONS}
+    Launch JupyterHub Spawner From Dashboard    ${TEST_USER_2.USERNAME}    ${TEST_USER.PASSWORD}
+    ...    ${TEST_USER.AUTH_TYPE}
+    ${maxSpawner} =    Fetch Max Number Of GPUs In Spawner Page
+    Should Be Equal    ${maxSpawner}    ${0}
+    Close Browser
+    Switch Browser  ${old_browser}[0]


### PR DESCRIPTION
Signed-off-by: Luca Giorgi <lgiorgi@redhat.com>

I have updated the Suite setup keyword for `minimal-cuda-test.robot`, as this will ensure that whatever TC is run from this suite, the check on the number of available GPUs is still run.