### PR TITLE
add jq to test container image

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ ARG OC_CHANNEL=stable
 
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y git python3 unzip chromium chromedriver redhat-lsb-core &&\
+    dnf install -y jq git python3 unzip chromium chromedriver redhat-lsb-core &&\
     dnf clean all
 
 ## Install yq in the image


### PR DESCRIPTION
Tests spit out warnings/errors when missing `jq` which is required by some tests and the
utils: https://github.com/red-hat-data-services/ods-ci/search?l=RobotFramework&q=jq

Signed-off-by: Brady Pratt <bpratt@redhat.com>