### PR TITLE
added more deley time to add idp oauth

### DIFF
--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -735,7 +735,7 @@ class OpenshiftClusterManager():
 
         # Waiting 5 minutes to ensure all the cluster services are
         # up even after cluster is in ready state
-        time.sleep(300)
+        time.sleep(600)
 
     def install_rhods_addon(self):
         if not self.is_addon_installed():


### PR DESCRIPTION
it came to our notice that sometime after adding the idp successfully we are not able to see the idp auth login. we suspect that it is the problem with the waiting time. Have increded the waiting time from 5 to 10 min. This is not the ideal solution. one of the Ideal solution could be wait for the osd version to get display then apply idp.
Signed-off-by: Tarun Kumar <takumar@redhat.com>