### PR TITLE
Modify update_notification_email_address keyword so that it doesn't stop test execution on errors

### DIFF
--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -82,7 +82,7 @@ class Helpers:
         """Update notification email for add-ons using OCM"""
         ocm_client = OpenshiftClusterManager()
         ocm_client.cluster_name = cluster_name
-        status = ocm_client.update_notification_email_address(addon_name, email_address)
+        status = ocm_client.update_notification_email_address(addon_name, email_address, exit_on_failure=False)
         if not status:
             self.BuiltIn.fail("Unable to update notification email, Check if operator is installed via Add-on")
 

--- a/libs/Helpers.py
+++ b/libs/Helpers.py
@@ -2,9 +2,13 @@ from semver import VersionInfo
 from robotlibcore import keyword
 from utils.scripts.ocm.ocm import OpenshiftClusterManager
 from robot.api import logger
+from robot.libraries.BuiltIn import BuiltIn
 
 class Helpers:
     """Custom keywords written in Python"""
+    def __init__(self):
+        self.BuiltIn = BuiltIn()
+
     @keyword
     def text_to_list(self, text):
         rows = text.split('\n')
@@ -78,7 +82,9 @@ class Helpers:
         """Update notification email for add-ons using OCM"""
         ocm_client = OpenshiftClusterManager()
         ocm_client.cluster_name = cluster_name
-        ocm_client.update_notification_email_address(addon_name, email_address)
+        status = ocm_client.update_notification_email_address(addon_name, email_address)
+        if not status:
+            self.BuiltIn.fail("Unable to update notification email, Check if operator is installed via Add-on")
 
     @keyword
     def convert_to_hours_and_minutes(self, seconds):

--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -852,7 +852,7 @@ class OpenshiftClusterManager():
         if ret is None:
             log.info("Failed to update email address to {} addon on cluster "
                   "{}".format(addon_name, self.cluster_name))
-            sys.exit(1)
+            return False
 
 
 

--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -855,7 +855,7 @@ class OpenshiftClusterManager():
             if exit_on_failure:
                 sys.exit(1)
             else:
-                return True
+                return False
 
 
 if __name__ == "__main__":

--- a/utils/scripts/ocm/ocm.py
+++ b/utils/scripts/ocm/ocm.py
@@ -836,7 +836,7 @@ class OpenshiftClusterManager():
                    " EXITING".format(self.cluster_name))
             sys.exit(1)
 
-    def update_notification_email_address(self, addon_name, email_address):
+    def update_notification_email_address(self, addon_name, email_address, exit_on_failure=True):
         """Update notification email to Addons"""
         replace_vars = {
                        "EMAIL_ADDER": email_address
@@ -852,8 +852,10 @@ class OpenshiftClusterManager():
         if ret is None:
             log.info("Failed to update email address to {} addon on cluster "
                   "{}".format(addon_name, self.cluster_name))
-            return False
-
+            if exit_on_failure:
+                sys.exit(1)
+            else:
+                return True
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
When we are using Update Notification Email Address keyword if keyword execution fails then it will stop whole robot execution du to sys.exit(1)  process chnaging it so that it return status
Signed-off-by: Tarun Kumar <takumar@redhat.com>