### PR TITLE
Fix configuration of autogeneration of release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,8 +1,6 @@
 changelog:
   exclude:
     labels:
-      - "needs testing"
-      - ":warning: high priority review"
       - "do not merge"
       - "ignore for release"
     authors:


### PR DESCRIPTION
When autogenerating the release notes for ods-ci, do not exclude branches with the labels "high priority review" or "needs testing"

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>