### PR TITLE
Include pip package build deps

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ ARG OC_CHANNEL=stable
 
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y jq git python3 unzip chromium chromedriver redhat-lsb-core &&\
+    dnf install -y jq git gcc gcc-c++ python3 python3-devel unzip chromium chromedriver redhat-lsb-core &&\
     dnf clean all
 
 ## Install yq in the image


### PR DESCRIPTION
In attempting to build this image, I noticed it's missing gcc/gcc-c++ and python3-devel which are both required for the pip packages to build successfully