### PR TITLE
added pattern to check failed entry

### DIFF
--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
@@ -18,7 +18,7 @@ Suite Setup     RHOSi Setup
 
 *** Variables ***
 ${namespace}           redhat-ods-operator
-${regex_pattern}       level=([Ee]rror).*
+${regex_pattern}       level=([Ee]rror).*|([Ff]ailed) to list .*
 
 *** Test Cases ***
 Verify RHODS Operator log


### PR DESCRIPTION
Added pattern to capture failed entry in operator log. This is handle https://issues.redhat.com/browse/RHODS-2527
Signed-off-by: Tarun Kumar <takumar@redhat.com>