### PR TITLE
Update ODS-CI container with new features

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -29,6 +29,8 @@ Additional arguments for container run
 # env variables to control test execution
 RUN_SCRIPT_ARGS:
   --skip-oclogin (default: false): script does not perform login using OC CLI
+    --service-account (default: ""): if assigned, ODS-CI will try to log into the cluster using the given service account. ODS-CI automatically creates SERVICE_ACCOUNT.NAME and SERVICE_ACCOUNT.FULL_NAME global variables to be used in tests.
+    --sa-namespace (default: "default"): the namespace where the service account is created
   --set-urls-variables (default: false): script gets automatically the cluster URLs (i.e., OCP Console, RHODS Dashboard, OCP API Server)
   --include: run only test cases with the given tags (e.g., --include Smoke --include XYZ)
   --exclude: do not run the test cases with the given tag (e.g., --exclude LongLastingTC)
@@ -39,13 +41,13 @@ RUN_SCRIPT_ARGS:
   --email-report (default: false): send the test run artifacts via email
     --email-from: (mandatory if email report is true) set the sender email address
     --email-to: (mandatory if email report is true) set the email address which will receive the result artifacts
-    --email-server (default: localhost): set the smtp server to use
+    --email-server (default: localhost): set the smtp server to use, e.g., smtp.gmail.com:465 (the port specification is not mandatory, the default value is 587)
     --email-server-user: (optional, depending on the smtp server) username to access smtp server
     --email-server-pw: (optional, depending on the smtp server) password to access smtp server
-    --email-server-ssl (default: false): set the encryption type to SSL
+    --email-server-ssl (default: false): if true, it forces the usage of encrypted connection (TLS)
     --email-server-unsecure (default: false): no encryption applied, using SMTP unsecure connection
 
-* The container uses TLS (using STARTTLS) by default if --email-server-ssl and --email-server-unsecure are set to false
+* The container uses STARTTLS protocol by default if --email-server-ssl and --email-server-unsecure are set to false
 
 ROBOT_EXTRA_ARGS: it takes any robot framework arguments. Look at robot --help to see all the options (e.g., --log NONE, --dryrun )
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -29,7 +29,8 @@ Additional arguments for container run
 # env variables to control test execution
 RUN_SCRIPT_ARGS:
   --skip-oclogin (default: false): script does not perform login using OC CLI
-    --service-account (default: ""): if assigned, ODS-CI will try to log into the cluster using the given service account. ODS-CI automatically creates SERVICE_ACCOUNT.NAME and SERVICE_ACCOUNT.FULL_NAME global variables to be used in tests.
+    --service-account (default: ""): if assigned, ODS-CI will try to log into the cluster using the given service account.
+            ODS-CI automatically creates SERVICE_ACCOUNT.NAME and SERVICE_ACCOUNT.FULL_NAME global variables to be used in tests.
     --sa-namespace (default: "default"): the namespace where the service account is created
   --set-urls-variables (default: false): script gets automatically the cluster URLs (i.e., OCP Console, RHODS Dashboard, OCP API Server)
   --include: run only test cases with the given tags (e.g., --include Smoke --include XYZ)

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -254,6 +254,9 @@ if command -v yq &> /dev/null
                         echo "Performing oc login using service account"
                         sa_token=$(oc serviceaccounts get-token ${SERVICE_ACCOUNT} -n ${SA_NAMESPACE})
                         oc login --token=$sa_token --server=${oc_host} --insecure-skip-tls-verify=true
+                        sa_fullname=$(oc whoami)
+                        TEST_VARIABLES="${TEST_VARIABLES} --variable SERVICE_ACCOUNT.NAME:${SERVICE_ACCOUNT} --variable SERVICE_ACCOUNT.FULL_NAME:${sa_fullname}"
+
                 fi
 
                 ## no point in going further if the login is not working

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -253,7 +253,7 @@ if command -v yq &> /dev/null
                     else
                         echo "Performing oc login using service account"
                         sa_token=$(oc serviceaccounts get-token ${SERVICE_ACCOUNT} -n ${SA_NAMESPACE})
-                        oc login --token=$sa_token --server=${oc_host}
+                        oc login --token=$sa_token --server=${oc_host} --insecure-skip-tls-verify=true
                 fi
 
                 ## no point in going further if the login is not working

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -1,6 +1,8 @@
 #/bin/bash
 
 SKIP_OC_LOGIN=false
+SERVICE_ACCOUNT=""
+SA_NAMESPACE="default"
 SET_RHODS_URLS=false
 TEST_CASE_FILE=tests/Tests
 TEST_VARIABLES_FILE=test-variables.yml
@@ -24,6 +26,18 @@ while [ "$#" -gt 0 ]; do
     --skip-oclogin)
       shift
       SKIP_OC_LOGIN=$1
+      shift
+      ;;
+
+    --service-account)
+      shift
+      SERVICE_ACCOUNT=$1
+      shift
+      ;;
+
+    --sa-namespace)
+      shift
+      SA_NAMESPACE=$1
       shift
       ;;
 
@@ -204,10 +218,13 @@ if ${SET_RHODS_URLS}
         # ocp_console="https://$(oc get route console -n openshift-console -o jsonpath='{.spec.host}{"\n"}')"
         rhods_dashboard="https://$(oc get route rhods-dashboard -n redhat-ods-applications -o jsonpath='{.spec.host}{"\n"}')"
         api_server=$(oc whoami --show-server)
-        TEST_VARIABLES="${TEST_VARIABLES} --variable OCP_CONSOLE_URL:${ocp_console} --variable ODH_DASHBOARD_URL:${rhods_dashboard}"
+        prom_server="https://$(oc get route prometheus -n redhat-ods-monitoring -o jsonpath='{.spec.host}{"\n"}')"
+        prom_token="$(oc serviceaccounts get-token prometheus -n redhat-ods-monitoring)"
+        TEST_VARIABLES="${TEST_VARIABLES} --variable OCP_CONSOLE_URL:${ocp_console} --variable ODH_DASHBOARD_URL:${rhods_dashboard} --variable RHODS_PROMETHEUS_URL:${prom_server} --variable RHODS_PROMETHEUS_TOKEN:${prom_token}"
         echo "OCP Console URL set to: ${ocp_console}"
         echo "RHODS Dashboard URL set to: ${rhods_dashboard}"
         echo "RHODS API Server URL set to: ${api_server}"
+        echo "RHODS Prometheus URL set to: ${prom_server}"
 fi
 
 ## if we have yq installed
@@ -225,11 +242,19 @@ if command -v yq &> /dev/null
                     else
                         oc_host=$(yq  e '.OCP_API_URL' ${TEST_VARIABLES_FILE})
                 fi
-                oc_user=$(yq  e '.OCP_ADMIN_USER.USERNAME' ${TEST_VARIABLES_FILE})
-                oc_pass=$(yq  e '.OCP_ADMIN_USER.PASSWORD' ${TEST_VARIABLES_FILE})
 
-                ## do an oc login here
-                oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
+
+                if [ -z "${SERVICE_ACCOUNT}" ]
+                    then
+                        echo "Performing oc login using username and password"
+                        oc_user=$(yq  e '.OCP_ADMIN_USER.USERNAME' ${TEST_VARIABLES_FILE})
+                        oc_pass=$(yq  e '.OCP_ADMIN_USER.PASSWORD' ${TEST_VARIABLES_FILE})
+                        oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
+                    else
+                        echo "Performing oc login using service account"
+                        sa_token=$(oc serviceaccounts get-token ${SERVICE_ACCOUNT} -n ${SA_NAMESPACE})
+                        oc login --token=$sa_token --server=${oc_host}
+                fi
 
                 ## no point in going further if the login is not working
                 retVal=$?

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -186,7 +186,7 @@ Clean Up User Notebook
 
   # Verify that ${admin_username}  is connected to the cluster
   ${oc_whoami} =  Run   oc whoami
-  IF    '${oc_whoami}' == '${admin_username}'
+  IF    '${oc_whoami}' == '${admin_username}' or '${oc_whoami}' == '${SERVICE_ACCOUNT.FULL_NAME}'
       # We import the library here so it's loaded only when we are connected to the cluster
       # Having the usual "Library OpenShiftCLI" in the header raises an error when loading the file
       # if there is not any connection opened
@@ -211,7 +211,7 @@ Delete Folder In User Notebook
 
   # Verify that ${admin_username}  is connected to the cluster
   ${oc_whoami} =  Run   oc whoami
-  IF    '${oc_whoami}' == '${admin_username}'
+  IF    '${oc_whoami}' == '${admin_username}' or '${oc_whoami}' == '${SERVICE_ACCOUNT.FULL_NAME}'
       # We import the library here so it's loaded only when we are connected to the cluster
       # Having the usual "Library OpenShiftCLI" in the header raises an error when loading the file
       # if there is not any connection opened


### PR DESCRIPTION
This PR contains new developments for the ODS-CI container:
1. **SA Login**. A new (user)option to allow the robot to do "oc login" using the Service account instead of using user/password. It is necessary to make our tests running in MSP when they need to explicitly log into the cluster (e.g., use of `Run oc` or `openshiftlibrary for RF`). The script `run_robot_test.sh` automatically sets the following global variables to be used in the tests:
`SERVICE_ACCOUNT.NAME` (e.g., `rhods-test-runner`) and `SERVICE_ACCOUNT.FULL_NAME` (e.g., `system:serviceaccount:<namespace>:<service_account_name>`)
Plus, it changes `Clean Up User Notebook` and `Delete Folder In User Notebook` to run when the login is performed using SA instead of admin credentials

2. **Auto-set Prometheus variables**. `run_robot_test.sh` automatically fetches the RHODS Prometheus URL and its token, and set the global variables to be used in the tests: `RHODS_PROMETHEUS_URL` and `RHODS_PROMETHEUS_TOKEN`

3. **Update container README**

Signed-off-by: bdattoma [bdattoma@redhat.com](bdattoma@redhat.com)