### PR TITLE
Sec update for ODS-CI

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -13,7 +13,7 @@ RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.n
     dnf clean all
 
 ## Install yq in the image
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64 -o /usr/bin/yq &&\
+RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
     chmod +x /usr/bin/yq
 
 ## Install oc in the container
@@ -28,6 +28,10 @@ RUN mkdir $HOME/ods-ci
 # Change the WORKDIR so the run script references any files/folders from the root of the repo
 WORKDIR $HOME/ods-ci
 
+# create non-root user
+RUN groupadd --gid 1001 ods-ci-users
+RUN useradd -r -u 1001 -g ods-ci-users ods-ci-runner
+
 COPY tests tests/
 COPY tasks tasks/
 COPY libs libs/
@@ -41,5 +45,9 @@ RUN  chmod +x run.sh
 COPY requirements.txt setup.py .
 RUN  python3 --version
 RUN  python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
+
+# set the non-root user
+RUN chgrp -R 1001 $HOME/ods-ci && chown -R 1001 $HOME/ods-ci && chmod -R 744 $HOME/ods-ci
+USER 1001
 
 ENTRYPOINT ["./run.sh"]

--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -303,6 +303,8 @@ case "$(uname -s)" in
 esac
 
 ./venv/bin/robot ${TEST_EXCLUDE_TAG} ${TEST_INCLUDE_TAG} -d ${TEST_ARTIFACT_DIR} -x xunit_test_result.xml -r test_report.html ${TEST_VARIABLES} --variablefile ${TEST_VARIABLES_FILE} --exclude TBC ${EXTRA_ROBOT_ARGS} ${TEST_CASE_FILE}
+exit_status=$(echo $?)
+echo ${exit_status}
 
 # send test artifacts by email
 if ${EMAIL_REPORT}
@@ -319,3 +321,5 @@ if ${EMAIL_REPORT}
                         -v ${EMAIL_SERVER} -a "rf_results.tar.gz" -u  ${EMAIL_SERVER_USER}  -p  ${EMAIL_SERVER_PW} \
                         -l ${EMAIL_SERVER_SSL} -d ${EMAIL_SERVER_UNSECURE}
 fi
+
+exit ${exit_status}


### PR DESCRIPTION
This PR is going to apply two updates to ODS-CI container:
1. force the use of non-root user
2. update yq to the latest version

It includes also a small fix not related to security but to exit status: when running in a pod, if email report is enabled, the pod will not get the "failed" status if any of the tests failed. It happens because the last exit staus is 0 since the last executed command is email report instead of robot.

Signed-off-by: Berto D'Attoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)
