### PR TITLE
Fix test "Verify That MT-SRE Are Not Paged For Alerts ..." with new keyword "Get Cluster Name From Console URL"

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -104,3 +104,8 @@ Verify NPM Version
     [Arguments]  ${library}  ${expected_version}  ${pod}  ${namespace}  ${container}=""  ${prefix}=""  ${depth}=0
     ${installed_version} =  Run  oc exec -n ${namespace} ${pod} -c ${container} -- npm list --prefix ${prefix} --depth=${depth} | awk -F@ '/${library}/ { print $2}'
     Should Be Equal  ${installed_version}  ${expected_version}
+
+Get Cluster Name From Console URL
+    [Documentation]    Get the cluster name from the Openshitf console URL
+    ${name}=    Split String    ${OCP_CONSOLE_URL}        .
+    [Return]    ${name}[2]

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -119,6 +119,6 @@ Verify NPM Version
     Should Be Equal  ${installed_version}  ${expected_version}
 
 Get Cluster Name From Console URL
-    [Documentation]    Get the cluster name from the Openshitf console URL
+    [Documentation]    Get the cluster name from the Openshift console URL
     ${name}=    Split String    ${OCP_CONSOLE_URL}        .
     [Return]    ${name}[2]

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
@@ -22,7 +22,9 @@ ${regex_pattern}       level=([Ee]rror).*|([Ff]ailed) to list .*
 
 *** Test Cases ***
 Verify RHODS Operator log
-   [Tags]  ODS-1007   Sanity
+   [Tags]  Sanity
+   ...     ProductBug
+   ...     ODS-1007
    #Get the POD name
    ${data}       Run keyword   OpenShiftCLI.Get   kind=Pod     namespace=${namespace}   label_selector=name=rhods-operator
    #Capture the logs based on containers

--- a/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
@@ -310,7 +310,7 @@ Verify Alert "JupyterHub Image Builds Are Failing" Fires At Least 20 Minutes Whe
     ...    failed_build_name=${failed_build_name}    build_config_name=s2i-pytorch-gpu-cuda-11.4.2-notebook
 
 Verify That MT-SRE Are Not Paged For Alerts In Clusters Used For Development Or Testing
-    [Documentation]     Verify that MT-SRE are not paged for alerts in clusters used for development or testing	
+    [Documentation]     Verify that MT-SRE are not paged for alerts in clusters used for development or testing
     [Tags]              Sanity
     ...                 ODS-1058
     ...                 Tier1
@@ -325,7 +325,7 @@ Verify That MT-SRE Are Not Paged For Alerts In Clusters Used For Development Or 
     Check Particular Text Is Present In Rhods-operator's Log  text_to_check=${text_to_check}
     Verify Receiver Value In Configmap Alertmanager Is  receiver=${receiver}
     [Teardown]    Close All Browsers
-    
+
 *** Keywords ***
 Alerts Suite Setup
     [Documentation]    Test suite configuration
@@ -488,8 +488,7 @@ Delete Failed Build And Start New One
 
 Check Cluster Name Contain "Aisrhods" Or Not
     [Documentation]     Return true if cluster name contains aisrhods and if not return false
-    ${cluster_id} =     Get Cluster ID
-    ${cluster_name} =    Get Cluster Name By Cluster ID  cluster_id=${cluster_id}
+    ${cluster_name} =    Common.Get Cluster Name From Console URL
     ${return_value} =  Evaluate  "aisrhods" in "${cluster_name}"
     [Return]  ${return_value}
 


### PR DESCRIPTION
Added keyword to get name and assign tag "productbug" for the log verification Tc

Signed-off-by: Tarun Kumar <takumar@redhat.com>