### PR TITLE
Fix some test Tags, Documentation and Title

### DIFF
--- a/tests/Tests/500__jupyterhub/test.robot
+++ b/tests/Tests/500__jupyterhub/test.robot
@@ -79,6 +79,7 @@ Verify Message That Image Builds Are In Progress
     [Documentation]     Verifies that Image Builds In Progress are Shown In RHODS Dashboard
     [Tags]      Tier2
     ...         ODS-460
+    ...         ODS-381
     Delete Last Pytorch Build
     ${new_buildname}=  Start New Pytorch Build
     Launch Dashboard   ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}   ocp_user_auth_type=${TEST_USER.AUTH_TYPE}   dashboard_url=${ODH_DASHBOARD_URL}   browser=${BROWSER.NAME}   browser_options=${BROWSER.OPTIONS}

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -51,7 +51,7 @@ Verify Anaconda Professional Fails Activation When Key Is Invalid
 
 Verify User Is Able to Activate Anaconda Professional
   [Tags]  Tier2
-  ...     ODS-272  ODS-344  ODS-501  ODS-588  ODS-1082  ODS-1304  ODS-462
+  ...     ODS-272  ODS-344  ODS-501  ODS-588  ODS-1082  ODS-1304  ODS-462   ODS-283
   ...     ProductBug
   [Documentation]  Performs the Anaconda CE activation, spawns a JL using the Anaconda image,
   ...              validate the token, install a library and try to import it.

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -17,7 +17,7 @@ ${intel_aikit_operator_name}    Intel® oneAPI AI Analytics Toolkit Operator
 ${image_path}                   image-registry.openshift-image-registry.svc:5000/redhat-ods-applications
 
 *** Test Cases ***
-Verify intel aikit Is Available In RHODS Dashboard Explore Page
+Verify Intel AIKIT Is Available In RHODS Dashboard Explore Page
   [Tags]  Smoke  Sanity
   ...     ODS-1017
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
@@ -15,7 +15,7 @@ Suite Teardown  RHOAM Suite Teardown
 Verify RHOAM Can Be Installed
     [Documentation]    Verifies RHOAM Addon can be successfully installed
     [Tags]  Tier3
-    ...     ODS-273
+    ...     ODS-1310
     ...     Execution-Time-Over-30min
     Pass Execution    Passing tests, as suite setup ensures that RHOAM installs correctly
 

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -53,7 +53,7 @@ Verify User Can Enable RHOSAK from Dashboard Explore Page
 
 Verify User Is Able to Produce and Consume Events
   [Tags]  Tier2
-  ...     ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-241  ODS-239  ODS-242
+  ...     ODS-248  ODS-247  ODS-246  ODS-245  ODS-243  ODS-239  ODS-242
   [Teardown]  Clean Up RHOSAK    stream_to_delete=${STREAM_NAME_TEST}
   ...                            topic_to_delete=${TOPIC_NAME_TEST}
   ...                            sa_clientid_to_delete=${KAFKA_CLIENT_ID}

--- a/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -30,7 +30,7 @@ Verify Openvino Operator Can Be Installed Using OpenShift Console
    ...      ODS-1236
    ...      ODS-651
    [Documentation]  This Test Case Installed Openvino operator in Openshift cluster
-   ...               and Check and Launch AIKIT notebook image from RHODS dashboard
+   ...               and Check and Launch Openvino notebook image from RHODS dashboard
    Check And Install Operator in Openshift    ${openvino_operator_name}   ${openvino_appname}
    Create Tabname Instance For Installed Operator        ${openvino_operator_name}       Notebook    redhat-ods-applications
    Wait Until Keyword Succeeds    1200      1   Check Image Build Status    Complete        openvino-notebook


### PR DESCRIPTION
- change RHOAM automated TC to replace ODS-273 as tag with the new polarion id
- remove ODS-241 from RHOSAK installation TC because covered by 239 now;  delete ODS-241 from polarion
- change openvino test case doc to replace aikit with openvino
- add tag ODS-381 tag to the TCs in RF and set polarion TC to automated
- add tag ODS-283 in the RF test and set automation field on polarion

Signed-off-by: bdattoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)