### PR TITLE
Fix Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM quay.io/centos/centos:stream8
 
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}


### PR DESCRIPTION
- switch to CentOS Streams 8 for more package availability
- install s3cmd to upload test results to s3 easily
- switch to using python3-virtualenv to force Python 3.8 in venv, otherwise Python 3.6 is used. This [commit](https://github.com/red-hat-data-services/ods-ci/commit/ff7ac1f73e52eed135cc0f1e16426cf63c3e994a) uses Python 3.7, leading pip to try to install backports-datetime-fromisoformat which fails because the image has no gcc.

```
    gcc -pthread -Wno-unused-result -Wsign-compare -DDYNAMIC_ANNOTATIONS_ENABLED=1 -DNDEBUG -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -Wp,-D_GLIBCXX_ASSERTIONS -fexceptions -fstack-protector-strong -grecord-gcc-switches -m64 -mtune=generic -fasynchronous-unwind-tables -fstack-clash-protection -fcf-protection -D_GNU_SOURCE -fPIC -fwrapv -fPIC -I/tmp/ods-ci/venv/include -I/usr/include/python3.6m -c backports/datetime_fromisoformat/module.c -o build/temp.linux-x86_64-3.6/backports/datetime_fromisoformat/module.o
    unable to execute 'gcc': No such file or directory
    error: command 'gcc' failed with exit status 1
```