### PR TITLE
venv: only create when absent

### DIFF
--- a/run_robot_test.sh
+++ b/run_robot_test.sh
@@ -278,10 +278,10 @@ fi
 
 
 
-#TODO: Make this optional so we are not creating/updating the virtualenv everytime we run a test
 VENV_ROOT=${currentpath}/venv
-#setup virtualenv
-python3 -m venv ${VENV_ROOT}
+if [[ ! -d "${VENV_ROOT}" ]]; then
+  python3 -m venv ${VENV_ROOT}
+fi
 source ${VENV_ROOT}/bin/activate
 
 if [[ ${SKIP_PIP_INSTALL} -eq 0 ]]; then


### PR DESCRIPTION
run_robot_test.sh would create the venv at each run.
Only create it if absent.

Signed-off-by: François Cami <fcami@redhat.com>