### PR TITLE
Dockerfile: switch to virtualenv

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -9,7 +9,7 @@ ARG OC_CHANNEL=stable
 
 
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y python38 jq git unzip chromium chromedriver redhat-lsb-core &&\
+    dnf install -y python38 jq git unzip chromium chromedriver redhat-lsb-core python3-virtualenv &&\
     dnf clean all
 
 ## Install yq in the image
@@ -43,8 +43,7 @@ COPY utils/scripts/logger.py  utils/scripts/logger.py
 COPY utils/scripts/util.py  utils/scripts/util.py
 RUN  chmod +x run.sh
 COPY requirements.txt setup.py .
-RUN  python3 --version
-RUN  python3 -m venv venv && source venv/bin/activate &&  pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
+RUN  virtualenv -p /usr/bin/python3.8 venv && source venv/bin/activate && pip3 install --upgrade pip && venv/bin/pip3 install -r requirements.txt
 
 # set the non-root user
 RUN chgrp -R 1001 $HOME/ods-ci && chown -R 1001 $HOME/ods-ci && chmod -R 744 $HOME/ods-ci


### PR DESCRIPTION
Installing any RPM-packaged Python application will pull Python 3.6
on RHEL8/Streams8 because 3.6 is the system default.
This, in turn, will break building the ods-ci container because ods-ci
has been using Python 3.7 features since ff7ac1f7.

virtualenv ( https://virtualenv.pypa.io/en/latest/ ) should be used
instead of the venv module to force Python's version to 3.8 instead
of the RHEL8/Streams8 default 3.6.
    
Fixes: https://github.com/red-hat-data-services/ods-ci/issues/406
