### PR TITLE
Small changes in Sanity

### DIFF
--- a/tests/Resources/Page/ODH/AiApps/Anaconda.resource
+++ b/tests/Resources/Page/ODH/AiApps/Anaconda.resource
@@ -43,7 +43,7 @@ Validate Anaconda License Key
     [Arguments]    ${license_validity}=${TRUE}
     Click Button    Connect
     IF    ${license_validity} == ${TRUE}
-        Wait Until Keyword Succeeds    60    1    Page Should Not Contain Element
+        Wait Until Keyword Succeeds    90    1    Page Should Not Contain Element
         ...    xpath://*/div[contains(@class, "bullseye")]
     ELSE IF    ${license_validity} == ${FALSE}
         Wait Until Keyword Succeeds    40    2    Check Connect Button Status    false

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -90,6 +90,7 @@ Verify License Of Disabled Cards Can Be Re-validated
     ...               from Enabled page. it uses Anaconda CE as example to test the feature.
     [Tags]    Sanity
     ...       ODS-1097   ODS-357
+    ...       FlakyTest
     Enable Anaconda    license_key=${ANACONDA_CE.ACTIVATION_KEY}
     Menu.Navigate To Page    Applications    Enabled
     Wait Until RHODS Dashboard JupyterHub Is Visible

--- a/tests/Tests/500__jupyterhub/culler.robot
+++ b/tests/Tests/500__jupyterhub/culler.robot
@@ -41,6 +41,7 @@ Verify Culler Kills Inactive Server
     ...    server after timeout has passed.
     [Tags]    Sanity    Tier1
     ...       ODS-1254
+    ...       ProductBug
     Spawn Minimal Image
     Clone Git Repository And Run    https://github.com/redhat-rhods-qe/ods-ci-notebooks-main    ods-ci-notebooks-main/notebooks/500__jupyterhub/notebook-culler/Inactive.ipynb
     Open With JupyterLab Menu    File    Save Notebook
@@ -59,7 +60,7 @@ Verify Culler Kills Inactive Server
         ${drift} =  Evaluate  ${drift}+${30}
     END
     IF  ${drift}>${120}
-        Fail    Drift was over 2 minutes, it was ${drift} seconds    ProductBug
+        Fail    Drift was over 2 minutes, it was ${drift} seconds
     END
 
 Verify Culler Does Not Kill Active Server


### PR DESCRIPTION
this PR wants to bring 3 changes in sanity:
1. `Verify License Of Disabled Cards Can Be Re-validated` is a bit flaky, sometimes it fails while enabling anaconda (timing issue). I've increase a timeout
2. `Verify License Of Disabled Cards Can Be Re-validated` I've added the "FlakyTest" tag because of point 1)
3. `Verify Culler Kills Inactive Server` . I've added the "ProductBug" tag, because otherwise it wasn't possible to filter out from runs. The test used to add the tag as outcome of "Fail" keyword, but it doesn't allow to filter out the test case before running it