### PR TITLE
Add test cases to check error messages about RHODS groups

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -124,6 +124,8 @@ Get Cluster Name From Console URL
     [Return]    ${name}[2]
 
 Clean Resource YAML Before Creating It
+    [Documentation]    Removes from a yaml of an Openshift resource the metadata which prevent
+    ...                the yaml to be applied after being copied
     [Arguments]    ${yaml_data}
     ${clean_yaml_data}=     Copy Dictionary    dictionary=${yaml_data}  deepcopy=True
     Remove From Dictionary    ${clean_yaml_data}[metadata]  managedFields  resourceVersion  uid  creationTimestamp  annotations

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -122,3 +122,10 @@ Get Cluster Name From Console URL
     [Documentation]    Get the cluster name from the Openshift console URL
     ${name}=    Split String    ${OCP_CONSOLE_URL}        .
     [Return]    ${name}[2]
+
+Clean Resource YAML Before Creating It
+    [Arguments]    ${yaml_data}
+    ${clean_yaml_data}=     Copy Dictionary    dictionary=${yaml_data}  deepcopy=True
+    Remove From Dictionary    ${clean_yaml_data}[metadata]  managedFields  resourceVersion  uid  creationTimestamp  annotations
+    [Return]   ${clean_yaml_data}
+

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -97,7 +97,6 @@ Apply Access Groups Settings
     OpenShiftCLI.Patch    kind=ConfigMap
     ...                   src={"metadata":{"labels": {"opendatahub.io/modified": "${groups_modified_flag}"}}}
     ...                   name=rhods-groups-config   namespace=redhat-ods-applications  type=merge
-    # Rollout JupyterHub
 
 Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -338,3 +338,9 @@ OpenShift Resource Component Field Should Not Be Empty
     [Arguments]    ${resource_component_field}
     Run Keyword And Continue On Failure    Should Not Be Empty    ${resource_component_field}
 
+Delete RHODS Config Map
+    [Documentation]    Deletes the given config map. It assumes the namespace is
+    ...                redhat-ods-applications, but can be changed using the
+    ...                corresponding argument
+    [Arguments]     ${name}  ${namespace}=redhat-ods-applications
+    OpenShiftLibrary.Oc Delete    kind=ConfigMap  name=${name}  namespace=${namespace}

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -90,6 +90,13 @@ Set Standard RHODS Groups Variables
 
 Apply Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
+    ...                and rolls out JH to make the changes effecting in Jupyter
+    [Arguments]     ${admins_group}   ${users_group}    ${groups_modified_flag}
+    Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}    groups_modified_flag=${groups_modified_flag}
+    Rollout JupyterHub
+
+Set Access Groups Settings
+    [Documentation]    Changes the rhods-groups config map to set the new access configuration
     [Arguments]     ${admins_group}   ${users_group}    ${groups_modified_flag}
     OpenShiftCLI.Patch    kind=ConfigMap
     ...                   src={"data":{"admin_groups": "${admins_group}","allowed_groups": "${users_group}"}}
@@ -102,7 +109,6 @@ Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map
     Apply Access Groups Settings     admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=${STANDARD_GROUPS_MODIFIED}
-    Rollout JupyterHub
 
 Uninstall RHODS From OSD Cluster
     [Documentation]    Selects the cluster type and triggers the RHODS uninstallation

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -97,12 +97,13 @@ Apply Access Groups Settings
     OpenShiftCLI.Patch    kind=ConfigMap
     ...                   src={"metadata":{"labels": {"opendatahub.io/modified": "${groups_modified_flag}"}}}
     ...                   name=rhods-groups-config   namespace=redhat-ods-applications  type=merge
-    Rollout JupyterHub
+    # Rollout JupyterHub
 
 Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map
     Apply Access Groups Settings     admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=${STANDARD_GROUPS_MODIFIED}
+    Rollout JupyterHub
 
 Uninstall RHODS From OSD Cluster
     [Documentation]    Selects the cluster type and triggers the RHODS uninstallation

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -623,4 +623,9 @@ Get Dashboard Pods Logs
     ${pod_logs}=            Oc Get Pod Logs  name=${pod_name}  namespace=redhat-ods-applications  container=rhods-dashboard
     ${pod_logs_lines}=      Split String    string=${pod_logs}  separator=\n
     ${n_lines}=     Get Length    ${pod_logs_lines}
+    Log     ${pod_logs_lines}[${n_lines-3}:]
+    IF   "${pod_logs_lines}[${n_lines-1}]" == "${EMPTY}"
+        Remove From List    ${pod_logs_lines}   ${n_lines-1}
+        ${n_lines}=     Get Length    ${pod_logs_lines}
+    END
     [Return]    ${pod_logs_lines}   ${n_lines}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -609,3 +609,18 @@ Clear Dashboard Notifications
         Click Element    xpath=//*[contains(@class,"odh-dashboard__notification-drawer__item-remove")]
     END
     Close Notification Drawer
+Get Dashboard Pods Names
+    ${dash_pods}=    Oc Get    kind=Pod    namespace=redhat-ods-applications     label_selector=app=rhods-dashboard
+    ...                        fields=['metadata.name']
+    ${names}=   Create List
+    FOR    ${pod_name}    IN    @{dash_pods}
+        Append To List      ${names}    ${pod_name}[metadata.name]
+    END
+    [Return]   ${names}
+
+Get Dashboard Pods Logs
+    [Arguments]     ${pod_name}
+    ${pod_logs}=            Oc Get Pod Logs  name=${pod_name}  namespace=redhat-ods-applications  container=rhods-dashboard
+    ${pod_logs_lines}=      Split String    string=${pod_logs}  separator=\n
+    ${n_lines}=     Get Length    ${pod_logs_lines}
+    [Return]    ${pod_logs_lines}   ${n_lines}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -610,6 +610,7 @@ Clear Dashboard Notifications
     END
     Close Notification Drawer
 Get Dashboard Pods Names
+    [Documentation]     Retrieves the names of dashboard pods
     ${dash_pods}=    Oc Get    kind=Pod    namespace=redhat-ods-applications     label_selector=app=rhods-dashboard
     ...                        fields=['metadata.name']
     ${names}=   Create List
@@ -619,6 +620,7 @@ Get Dashboard Pods Names
     [Return]   ${names}
 
 Get Dashboard Pods Logs
+    [Documentation]     Fetches the logs from one dashboard pod
     [Arguments]     ${pod_name}
     ${pod_logs}=            Oc Get Pod Logs  name=${pod_name}  namespace=redhat-ods-applications  container=rhods-dashboard
     ${pod_logs_lines}=      Split String    string=${pod_logs}  separator=\n

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -637,13 +637,14 @@ Get Dashboard Pods Logs
 Get ConfigMaps For RHODS Groups Configuration
     [Documentation]     Returns a dictionary containing "rhods-group-config" and "groups-config"
     ...                 ConfigMaps
-    ${rgc_yaml}=     OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${RHODS_GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
-    ${gc_yaml}=      OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
-    IF   $rgc_yaml is None
-        ${rgc_yaml}=    Create List
+    ${rgc_status}   ${rgc_yaml}=     Run Keyword And Ignore Error     OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${RHODS_GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
+    ${gc_status}   ${gc_yaml}=      Run Keyword And Ignore Error     OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
+    IF   $rgc_status == 'FAIL'
+        ${rgc_yaml}=    Create List   ${EMPTY}
     END
-    IF   $gc_yaml is None
-        ${gc_yaml}=    Create List
+    IF   $gc_status == 'FAIL'
+        ${gc_yaml}=    Create List    ${EMPTY}
     END
     ${group_config_maps}=   Create Dictionary     rgc=${rgc_yaml}[0]     gc=${gc_yaml}[0]
+    Log     ${group_config_maps}
     [Return]    ${group_config_maps}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -36,6 +36,8 @@ ${CUSTOM_IMAGE_EDIT_BTN}=  button[@id="edit-package-software-button"]
 ${CUSTOM_IMAGE_REMOVE_BTN}=  button[@id="delete-package-software-button"]
 ${NOTIFICATION_DRAWER_CLOSE_BTN}=  //div[@class="pf-c-drawer__panel"]/div/div//button
 ${NOTIFICATION_DRAWER_CLOSED}=  //div[@class="pf-c-drawer__panel" and @hidden=""]
+${GROUPS_CONFIG_CM}=    groups-config
+${RHODS_GROUPS_CONFIG_CM}=    rhods-groups-config
 
 
 *** Keywords ***
@@ -631,3 +633,17 @@ Get Dashboard Pods Logs
         ${n_lines}=     Get Length    ${pod_logs_lines}
     END
     [Return]    ${pod_logs_lines}   ${n_lines}
+
+Get ConfigMaps For RHODS Groups Configuration
+    [Documentation]     Returns a dictionary containing "rhods-group-config" and "groups-config"
+    ...                 ConfigMaps
+    ${rgc_yaml}=     OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${RHODS_GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
+    ${gc_yaml}=      OpenShiftLibrary.Oc Get    kind=ConfigMap  name=${GROUPS_CONFIG_CM}   namespace=redhat-ods-applications
+    IF   $rgc_yaml is None
+        ${rgc_yaml}=    Create List
+    END
+    IF   $gc_yaml is None
+        ${gc_yaml}=    Create List
+    END
+    ${group_config_maps}=   Create Dictionary     rgc=${rgc_yaml}[0]     gc=${gc_yaml}[0]
+    [Return]    ${group_config_maps}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -611,6 +611,7 @@ Clear Dashboard Notifications
         Click Element    xpath=//*[contains(@class,"odh-dashboard__notification-drawer__item-remove")]
     END
     Close Notification Drawer
+
 Get Dashboard Pods Names
     [Documentation]     Retrieves the names of dashboard pods
     ${dash_pods}=    Oc Get    kind=Pod    namespace=redhat-ods-applications     label_selector=app=rhods-dashboard
@@ -621,7 +622,7 @@ Get Dashboard Pods Names
     END
     [Return]   ${names}
 
-Get Dashboard Pods Logs
+Get Dashboard Pod Logs
     [Documentation]     Fetches the logs from one dashboard pod
     [Arguments]     ${pod_name}
     ${pod_logs}=            Oc Get Pod Logs  name=${pod_name}  namespace=redhat-ods-applications  container=rhods-dashboard

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -251,7 +251,6 @@ Verify "Enabled" Keeps Being Available After One Of The ISV Operators If Uninsta
    [Teardown]    Check And Uninstall Operator In Openshift    ${openvino_operator_name}   ${openvino_appname}
 
 
-Verify Error Message When A RHODS Group Is Empty
 Verify Error Message In Logs When A RHODS Group Is Empty
     [Tags]  Sanity
     ...     ODS-1408
@@ -285,7 +284,7 @@ Verify Error Message In Logs When A RHODS Group Does Not Exist
     Logs Of Dashboard Pods Should Not Contain New Lines    lengths_dict=${lengths_dict_after}
     [Teardown]      Set Default Groups And Check Logs Do Not Change
 
-Verify Error Message In Logs When erify Error Message In Logs When All Authenticated Users Are Set As RHODS Admins
+Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admins
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when 'system:authenticated'
     ...                 is set as admin in "rhods-group-config" ConfigMap

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -251,6 +251,9 @@ Verify "Enabled" Keeps Being Available After One Of The ISV Operators If Uninsta
 Verify Error Message When A RHODS Group Is Empty
     [Tags]  ODS-1408
     ...     Sanity
+    [Documentation]     Verifies the messages printed out in the logs of
+    ...                 dashboard pods are the ones expected when an empty group
+    ...                 is set as admin in "rhods-group-config" ConfigMap
     [Setup]     Set Standard RHODS Groups Variables
     Set Library Search Order    SeleniumLibrary
     Create Group    group_name=${CUSTOM_EMPTY_GROUP}
@@ -271,6 +274,8 @@ Verify Error Message When A RHODS Group Is Empty
 
 *** Keywords ***
 Get Logs Lengths Before Setting An Empty Group
+    [Documentation]     Computes the number of lines present in the logs of both the dashboard pods
+    ...                 and returns them as dictionary
     ${lenghts_dict}=    Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
@@ -284,6 +289,7 @@ Get Logs Lengths Before Setting An Empty Group
     [Return]    ${lenghts_dict}
 
 New Lines In Logs Of Dashboard Pods Should Contain
+    [Documentation]     Verifies that newly generated lines in the logs contain the given message
     [Arguments]     ${exp_msg}      ${prev_logs_lenghts}
     &{new_logs_lenghts}=   Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
@@ -300,6 +306,7 @@ New Lines In Logs Of Dashboard Pods Should Contain
     [Return]    ${new_logs_lenghts}
 
 Wait Until New Log Lines Are Generated In Dashboard Pods
+    [Documentation]     Waits until new messages in the logs are generated
     [Arguments]     ${prev_length}  ${pod_name}  ${retries}=10    ${retries_interval}=5s
     FOR  ${retry_idx}  IN RANGE  0  1+${retries}
         ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
@@ -314,10 +321,14 @@ Wait Until New Log Lines Are Generated In Dashboard Pods
     [Return]    ${pod_logs_lines}[${prev_length-1}:]     ${n_lines}
 
 Set Empty Group
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
     Apply Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set Default Groups And Check Logs Do Not Change
+    [Documentation]     Teardown for ODS-1408. It sets the default configuration of "rhods-groups-config"
+    ...                 ConfigMap and checks if no new lines are generated in the logs after that.
     [Arguments]     ${lenghts_dict}
     Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
@@ -328,6 +339,7 @@ Set Default Groups And Check Logs Do Not Change
     Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
 
 Logs Of Dashboard Pods Should Not Contain New Lines
+    [Documentation]     Checks if no new lines are generated in the logs after that.
     [Arguments]     ${lenghts_dict}
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_lenght=${lenghts_dict}[${pod_name}]  pod_name=${pod_name}

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -357,7 +357,7 @@ Get Lengths Of Dashboard Pods Logs
     ${lengths_dict}=    Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
-        ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
+        ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pod Logs     pod_name=${pod_name}
         Set To Dictionary   ${lengths_dict}     ${pod_name}  ${n_lines}
     END
     [Return]    ${lengths_dict}
@@ -368,7 +368,7 @@ New Lines In Logs Of Dashboard Pods Should Contain
     &{new_logs_lengths}=   Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
-        ${pod_log_lines_new}    ${n_lines_new}=   Wait Until New Log Lines Are Generated In Dashboard Pods
+        ${pod_log_lines_new}    ${n_lines_new}=   Wait Until New Log Lines Are Generated In A Dashboard Pod
         ...     prev_length=${prev_logs_lengths}[${pod_name}]  pod_name=${pod_name}
         Set To Dictionary   ${new_logs_lengths}     ${pod_name}    ${n_lines_new}
         Log     ${pod_log_lines_new}
@@ -379,11 +379,11 @@ New Lines In Logs Of Dashboard Pods Should Contain
     END
     [Return]    ${new_logs_lengths}
 
-Wait Until New Log Lines Are Generated In Dashboard Pods
+Wait Until New Log Lines Are Generated In A Dashboard Pod
     [Documentation]     Waits until new messages in the logs are generated
     [Arguments]     ${prev_length}  ${pod_name}  ${retries}=10    ${retries_interval}=3s
     FOR  ${retry_idx}  IN RANGE  0  1+${retries}
-        ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
+        ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pod Logs     pod_name=${pod_name}
         Log     ${n_lines} vs ${prev_length}
         ${equal_flag}=     Run Keyword And Return Status    Should Be True     "${n_lines}" > "${prev_length}"
         Exit For Loop If    $equal_flag == True
@@ -441,7 +441,7 @@ Logs Of Dashboard Pods Should Not Contain New Lines
     [Arguments]     ${lengths_dict}
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         ${new_lines_flag}=  Run Keyword And Return Status
-        ...                 Wait Until New Log Lines Are Generated In Dashboard Pods
+        ...                 Wait Until New Log Lines Are Generated In A Dashboard Pod
         ...                 prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
         Run Keyword And Continue On Failure     Should Be Equal     ${new_lines_flag}   ${FALSE}
     END

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -301,7 +301,7 @@ Verify Error Message In Logs When erify Error Message In Logs When All Authentic
 
 Verify Error Message In Logs When RHODS Groups ConfigMaps Do Not Exist
     [Tags]    Sanity
-    ...       ODS-1945
+    ...       ODS-1495
     [Setup]     Set Variables For Group Testing
     ${groups_configmaps_dict}=     Get ConfigMaps For RHODS Groups Configuration
     ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -320,7 +320,7 @@ Set Variables For Group Testing
      ...                Dashboard logs about rhods groups
     Set Standard RHODS Groups Variables
     Set Suite Variable      ${EXP_ERROR_INEXISTENT_GRP}      Error: Failed to retrieve Group ${CUSTOM_INEXISTENT_GROUP}, might not exist.
-    Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set \\"system:authenticated\\" or an empty string as admin group.
+    Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set system:authenticated or an empty string as admin group.
     Set Suite Variable      ${EXP_ERROR_MISSING_RGC}      Error: Failed to retrieve ConfigMap ${RHODS_GROUPS_CONFIG_CM}, might be malformed or doesn't exist.
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -335,7 +335,7 @@ Restore Group ConfigMap And Check Logs Do Not Change
     ${clean_yaml}=    Clean Resource YAML Before Creating It    ${cm_yaml}
     Log    ${clean_yaml}
     OpenShiftLibrary.Oc Create    kind=ConfigMap    src=${clean_yaml}   namespace=redhat-ods-applications
-    ${lengths_dict}=    Get Lengths of Dashboard Pods Logs
+    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
 
 Restore Group ConfigMaps And Check Logs Do Not Change
@@ -400,7 +400,7 @@ Set RHODS Admins Group Empty Group
     Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
-Set RHODS Admins Group To system:authenticated
+Set RHODS Admins Group To system:authenticated    # robocop:disable
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=system:authenticated
@@ -428,7 +428,7 @@ Set Default Groups And Check Logs Do Not Change
     [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
     ...                 ConfigMap and checks if no new lines are generated in the logs after that.
     [Arguments]     ${delete_group}=${FALSE}
-    ${lengths_dict}=    Get Lengths of Dashboard Pods Logs
+    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
@@ -440,7 +440,9 @@ Logs Of Dashboard Pods Should Not Contain New Lines
     [Documentation]     Checks if no new lines are generated in the logs after that.
     [Arguments]     ${lengths_dict}
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
-        ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
+        ${new_lines_flag}=  Run Keyword And Return Status
+        ...                 Wait Until New Log Lines Are Generated In Dashboard Pods
+        ...                 prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
         Run Keyword And Continue On Failure     Should Be Equal     ${new_lines_flag}   ${FALSE}
     END
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -252,8 +252,8 @@ Verify "Enabled" Keeps Being Available After One Of The ISV Operators If Uninsta
 
 Verify Error Message When A RHODS Group Is Empty
 Verify Error Message In Logs When A RHODS Group Is Empty
-    [Tags]  ODS-1408
-    ...     Sanity
+    [Tags]  Sanity
+    ...     ODS-1408
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an empty group
     ...                 is set as admin in "rhods-group-config" ConfigMap
@@ -270,8 +270,8 @@ Verify Error Message In Logs When A RHODS Group Is Empty
     [Teardown]      Set Default Groups And Check Logs Do Not Change     delete_group=${TRUE}
 
 Verify Error Message In Logs When A RHODS Group Does Not Exist
-    [Tags]  ODS-1494
-    ...     Sanity
+    [Tags]  Sanity
+    ...     ODS-1494
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an inexistent group
     ...                 is set as admin in "rhods-group-config" ConfigMap
@@ -292,6 +292,8 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when 'system:authenticated'
     ...                 is set as admin in "rhods-group-config" ConfigMap
+    [Tags]    Sanity
+    ...       ODS-1500
     [Setup]     Set Variables For Group Testing
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
@@ -300,6 +302,7 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
     ${lenghts_dict_after}=    New Lines In Logs Of Dashboard Pods Should Contain
     ...     exp_msg=${EXP_ERROR_SYS_AUTH}
     ...     prev_logs_lenghts=${lenghts_dict_before}
+    [Teardown]      Set Default Groups And Check Logs Do Not Change
 
 
 *** Keywords ***

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -270,7 +270,7 @@ Verify Error Message When A RHODS Group Is Empty
         ...     exp_msg=Failed to get groups: TypeError: Cannot read property 'includes' of null
         ...     prev_logs_lenghts=${lenghts_dict_before}
     END
-    [Teardown]      Set Default Groups And Check Logs Do Not Change   ${lenghts_dict_after}
+    [Teardown]      Set Default Groups And Check Logs Do Not Change   lenghts_dict=${lenghts_dict_after}  delete_group=${TRUE}
 
 Verify Error Message When A RHODS Group Does Not Exist
     [Tags]  ODS-1494
@@ -286,7 +286,7 @@ Verify Error Message When A RHODS Group Does Not Exist
     ${lenghts_dict_after}=  New Lines In Logs Of Dashboard Pods Should Contain
     ...     exp_msg=${EXP_ERROR_INEXISTENT_GRP}
     ...     prev_logs_lenghts=${lenghts_dict_before}
-    [Teardown]      Set Default Groups And Check Logs Do Not Change   ${lenghts_dict_after}
+    [Teardown]      Set Default Groups And Check Logs Do Not Change   lenghts_dict=${lenghts_dict_after}
 
 
 *** Keywords ***
@@ -360,16 +360,18 @@ Set RHODS Admin Group To Inexistent Group
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set Default Groups And Check Logs Do Not Change
-    [Documentation]     Teardown for ODS-1408. It sets the default configuration of "rhods-groups-config"
+    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
     ...                 ConfigMap and checks if no new lines are generated in the logs after that.
-    [Arguments]     ${lenghts_dict}
+    [Arguments]     ${lenghts_dict}     ${delete_group}=${FALSE}
     Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_lenght=${lenghts_dict}[${pod_name}]  pod_name=${pod_name}
         Should Be Equal     ${new_lines_flag}   ${FALSE}
     END
-    Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
+    IF  "${delete_group}" == "${TRUE}"
+        Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
+    END
 
 Logs Of Dashboard Pods Should Not Contain New Lines
     [Documentation]     Checks if no new lines are generated in the logs after that.

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -250,7 +250,6 @@ Verify "Enabled" Keeps Being Available After One Of The ISV Operators If Uninsta
    Uninstall Operator And Check Enabled Page Is Rendering  operator_name=${openvino_operator_name}  operator_appname=${openvino_appname}
    [Teardown]    Check And Uninstall Operator In Openshift    ${openvino_operator_name}   ${openvino_appname}
 
-
 Verify Error Message In Logs When A RHODS Group Is Empty
     [Tags]  Sanity
     ...     ODS-1408
@@ -394,31 +393,31 @@ Wait Until New Log Lines Are Generated In Dashboard Pods
 Set RHODS Admins Group Empty Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
-    Apply Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
+    Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set RHODS Admins Group To system:authenticated
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
-    Apply Access Groups Settings    admins_group=system:authenticated
+    Set Access Groups Settings    admins_group=system:authenticated
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set RHODS Users Group Empty Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
-    Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${CUSTOM_EMPTY_GROUP}   groups_modified_flag=true
 
 Set RHODS Admins Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
-    Apply Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
+    Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set RHODS Users Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
-    Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${CUSTOM_INEXISTENT_GROUP}   groups_modified_flag=true
 
 Set Default Groups And Check Logs Do Not Change
@@ -426,7 +425,7 @@ Set Default Groups And Check Logs Do Not Change
     ...                 ConfigMap and checks if no new lines are generated in the logs after that.
     [Arguments]     ${delete_group}=${FALSE}
     ${lengths_dict}=    Get Lengths of Dashboard Pods Logs
-    Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
     IF  "${delete_group}" == "${TRUE}"

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -344,7 +344,7 @@ Restore Group ConfigMaps And Check Logs Do Not Change
     ${cm_dicts}=      Run Keyword And Continue On Failure    Get ConfigMaps For RHODS Groups Configuration
     FOR    ${key}    IN   @{cm_dicts.keys()}
         ${cm}=    Get From Dictionary    dictionary=${cm_dicts}    key=${key}
-        IF   $cm is not None
+        IF   $cm is None
             Restore Group ConfigMap And Check Logs Do Not Change    cm_yaml=${cm_yamls}[${key}]
         END
     END

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -299,7 +299,7 @@ Verify Error Message In Logs When erify Error Message In Logs When All Authentic
     ...     prev_logs_lengths=${lengths_dict_before}
     [Teardown]      Set Default Groups And Check Logs Do Not Change
 
-Verify Error Message In Logs When RHODS Groups ConfigMaps Do Not Exist
+Verify Error Message In Logs When rhods-groups-config ConfigMap Does Not Exist
     [Tags]    Sanity
     ...       ODS-1495
     [Setup]     Set Variables For Group Testing

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -252,6 +252,7 @@ Verify "Enabled" Keeps Being Available After One Of The ISV Operators If Uninsta
 
 Verify Error Message In Logs When A RHODS Group Is Empty
     [Tags]  Sanity
+    ...     Tier1
     ...     ODS-1408
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an empty group
@@ -268,6 +269,7 @@ Verify Error Message In Logs When A RHODS Group Is Empty
 
 Verify Error Message In Logs When A RHODS Group Does Not Exist
     [Tags]  Sanity
+    ...     Tier1
     ...     ODS-1494
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an inexistent group
@@ -288,6 +290,7 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
     ...                 dashboard pods are the ones expected when 'system:authenticated'
     ...                 is set as admin in "rhods-group-config" ConfigMap
     [Tags]    Sanity
+    ...       Tier1
     ...       ODS-1500
     [Setup]     Set Variables For Group Testing
     ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
@@ -302,6 +305,7 @@ Verify Error Message In Logs When rhods-groups-config ConfigMap Does Not Exist
     ...                 dashboard pods are the ones expected when "rhods-groups-config"
     ...                 ConfigMap does not exist
     [Tags]    Sanity
+    ...       Tier1
     ...       ODS-1495
     [Setup]     Set Variables For Group Testing
     ${groups_configmaps_dict}=     Get ConfigMaps For RHODS Groups Configuration
@@ -316,7 +320,7 @@ Verify Error Message In Logs When rhods-groups-config ConfigMap Does Not Exist
 *** Keywords ***
 Set Variables For Group Testing
     [Documentation]     Sets the suite variables used by the test cases for checking
-     ...                Dashboard logs about rhods groups
+    ...                 Dashboard logs about rhods groups
     Set Standard RHODS Groups Variables
     Set Suite Variable      ${EXP_ERROR_INEXISTENT_GRP}      Error: Failed to retrieve Group ${CUSTOM_INEXISTENT_GROUP}, might not exist.
     Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set system:authenticated or an empty string as admin group.

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -299,6 +299,9 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
     [Teardown]      Set Default Groups And Check Logs Do Not Change
 
 Verify Error Message In Logs When rhods-groups-config ConfigMap Does Not Exist
+    [Documentation]     Verifies the messages printed out in the logs of
+    ...                 dashboard pods are the ones expected when "rhods-groups-config"
+    ...                 ConfigMap does not exist
     [Tags]    Sanity
     ...       ODS-1495
     [Setup]     Set Variables For Group Testing

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -309,11 +309,6 @@ Verify Error Message In Logs When RHODS Groups ConfigMaps Do Not Exist
     ${lengths_dict_after}=      New Lines In Logs Of Dashboard Pods Should Contain
     ...     exp_msg=${EXP_ERROR_MISSING_RGC}
     ...     prev_logs_lengths=${lengths_dict_before}
-    Restore Group ConfigMap And Check Logs Do Not Change    cm_yaml=${groups_configmaps_dict}[rgc]
-    Delete RHODS Config Map     name=${GROUPS_CONFIG_CM}
-    ${lengths_dict_after}=      New Lines In Logs Of Dashboard Pods Should Contain
-    ...     exp_msg=${EXP_ERROR_MISSING_GC}
-    ...     prev_logs_lengths=${lengths_dict_after}
     [Teardown]      Restore Group ConfigMaps And Check Logs Do Not Change     cm_yamls=${groups_configmaps_dict}
 
 
@@ -323,7 +318,6 @@ Set Variables For Group Testing
     Set Suite Variable      ${EXP_ERROR_INEXISTENT_GRP}      Error: Failed to retrieve Group ${CUSTOM_INEXISTENT_GROUP}, might not exist.
     Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set \\"system:authenticated\\" or an empty string as admin group.
     Set Suite Variable      ${EXP_ERROR_MISSING_RGC}      Error: Failed to retrieve ConfigMap ${RHODS_GROUPS_CONFIG_CM}, might be malformed or doesn't exist.
-    Set Suite Variable      ${EXP_ERROR_MISSING_GC}      Error: Failed to retrieve ConfigMap ${GROUPS_CONFIG_CM}, might be malformed or doesn't exist.
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
 
@@ -344,7 +338,8 @@ Restore Group ConfigMaps And Check Logs Do Not Change
     ${cm_dicts}=      Run Keyword And Continue On Failure    Get ConfigMaps For RHODS Groups Configuration
     FOR    ${key}    IN   @{cm_dicts.keys()}
         ${cm}=    Get From Dictionary    dictionary=${cm_dicts}    key=${key}
-        IF   $cm is None
+        ${null}=    Run Keyword And Return Status   Should Be Equal     ${cm}   ${EMPTY}
+        IF   ${null} == ${TRUE}
             Restore Group ConfigMap And Check Logs Do Not Change    cm_yaml=${cm_yamls}[${key}]
         END
     END

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -275,7 +275,6 @@ Get Logs Lengths Before Setting An Empty Group
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
         ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
-        Log     ${pod_logs_lines}[${n_lines-1}]
         Run Keyword And Warn On Failure     Should Not Contain   container=${pod_logs_lines}
         ...     item=Failed to get groups: TypeError: Cannot read property 'includes' of null
         Run Keyword And Warn On Failure     Should Not Contain   container=${pod_logs_lines}

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -261,12 +261,12 @@ Verify Error Message In Logs When A RHODS Group Is Empty
     Create Group    group_name=${CUSTOM_EMPTY_GROUP}
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
-    ${lenghts_dict_before}=     Get Lenghts Of Dashboard Pods Logs
+    ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
     Set RHODS Admins Group Empty Group
-    Logs Of Dashboard Pods Should Not Contain New Lines     lenghts_dict=${lenghts_dict_before}
-    Set Default Groups And Check Logs Do Not Change   delete_group=${TRUE}
+    Logs Of Dashboard Pods Should Not Contain New Lines     lengths_dict=${lengths_dict_before}
+    Set Default Groups And Check Logs Do Not Change   delete_group=${FALSE}
     Set RHODS Users Group Empty Group
-    Logs Of Dashboard Pods Should Not Contain New Lines    lenghts_dict=${lenghts_dict_before}
+    Logs Of Dashboard Pods Should Not Contain New Lines    lengths_dict=${lengths_dict_before}
     [Teardown]      Set Default Groups And Check Logs Do Not Change     delete_group=${TRUE}
 
 Verify Error Message In Logs When A RHODS Group Does Not Exist
@@ -278,14 +278,14 @@ Verify Error Message In Logs When A RHODS Group Does Not Exist
     [Setup]     Set Variables For Group Testing
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
-    ${lenghts_dict_before}=     Get Lenghts Of Dashboard Pods Logs
+    ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
     Set RHODS Admins Group To Inexistent Group
-    ${lenghts_dict_after}=  New Lines In Logs Of Dashboard Pods Should Contain
+    ${lengths_dict_after}=  New Lines In Logs Of Dashboard Pods Should Contain
     ...     exp_msg=${EXP_ERROR_INEXISTENT_GRP}
-    ...     prev_logs_lenghts=${lenghts_dict_before}
+    ...     prev_logs_lengths=${lengths_dict_before}
     Set Default Groups And Check Logs Do Not Change
     Set RHODS Users Group To Inexistent Group
-    Logs Of Dashboard Pods Should Not Contain New Lines    lenghts_dict=${lenghts_dict_after}
+    Logs Of Dashboard Pods Should Not Contain New Lines    lengths_dict=${lengths_dict_after}
     [Teardown]      Set Default Groups And Check Logs Do Not Change
 
 Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admins
@@ -297,11 +297,11 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
     [Setup]     Set Variables For Group Testing
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
-    ${lenghts_dict_before}=     Get Lenghts Of Dashboard Pods Logs
+    ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
     Set RHODS Admins Group To system:authenticated
-    ${lenghts_dict_after}=    New Lines In Logs Of Dashboard Pods Should Contain
+    ${lengths_dict_after}=    New Lines In Logs Of Dashboard Pods Should Contain
     ...     exp_msg=${EXP_ERROR_SYS_AUTH}
-    ...     prev_logs_lenghts=${lenghts_dict_before}
+    ...     prev_logs_lengths=${lengths_dict_before}
     [Teardown]      Set Default Groups And Check Logs Do Not Change
 
 
@@ -309,39 +309,39 @@ Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admin
 Set Variables For Group Testing
     Set Standard RHODS Groups Variables
     Set Suite Variable      ${EXP_ERROR_INEXISTENT_GRP}      Error: Failed to retrieve Group ${CUSTOM_INEXISTENT_GROUP}, might not exist.
-    Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set \"system:authenticated\" or an empty string as admin group.
+    Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set \\"system:authenticated\\" or an empty string as admin group.
 
-Get Lenghts Of Dashboard Pods Logs
+Get Lengths Of Dashboard Pods Logs
     [Documentation]     Computes the number of lines present in the logs of both the dashboard pods
     ...                 and returns them as dictionary
-    ${lenghts_dict}=    Create Dictionary
+    ${lengths_dict}=    Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
         ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
-        Set To Dictionary   ${lenghts_dict}     ${pod_name}  ${n_lines}
+        Set To Dictionary   ${lengths_dict}     ${pod_name}  ${n_lines}
     END
-    [Return]    ${lenghts_dict}
+    [Return]    ${lengths_dict}
 
 New Lines In Logs Of Dashboard Pods Should Contain
     [Documentation]     Verifies that newly generated lines in the logs contain the given message
-    [Arguments]     ${exp_msg}      ${prev_logs_lenghts}
-    &{new_logs_lenghts}=   Create Dictionary
+    [Arguments]     ${exp_msg}      ${prev_logs_lengths}
+    &{new_logs_lengths}=   Create Dictionary
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
         Log    ${pod_name}
         ${pod_log_lines_new}    ${n_lines_new}=   Wait Until New Log Lines Are Generated In Dashboard Pods
-        ...     prev_length=${prev_logs_lenghts}[${pod_name}]  pod_name=${pod_name}
-        Set To Dictionary   ${new_logs_lenghts}     ${pod_name}    ${n_lines_new}
+        ...     prev_length=${prev_logs_lengths}[${pod_name}]  pod_name=${pod_name}
+        Set To Dictionary   ${new_logs_lengths}     ${pod_name}    ${n_lines_new}
         Log     ${pod_log_lines_new}
         FOR    ${line_idx}    ${line}    IN ENUMERATE    @{pod_log_lines_new}
             Run Keyword And Continue On Failure     Should Contain   container=${line}
             ...     item=${exp_msg}
         END
     END
-    [Return]    ${new_logs_lenghts}
+    [Return]    ${new_logs_lengths}
 
 Wait Until New Log Lines Are Generated In Dashboard Pods
     [Documentation]     Waits until new messages in the logs are generated
-    [Arguments]     ${prev_length}  ${pod_name}  ${retries}=10    ${retries_interval}=5s
+    [Arguments]     ${prev_length}  ${pod_name}  ${retries}=10    ${retries_interval}=3s
     FOR  ${retry_idx}  IN RANGE  0  1+${retries}
         ${pod_logs_lines}   ${n_lines}=     Get Dashboard Pods Logs     pod_name=${pod_name}
         Log     ${n_lines} vs ${prev_length}
@@ -352,7 +352,7 @@ Wait Until New Log Lines Are Generated In Dashboard Pods
     IF    $equal_flag == False
         Fail    Something got wrong. Check the logs
     END
-    [Return]    ${pod_logs_lines}[${prev_length-1}:]     ${n_lines}
+    [Return]    ${pod_logs_lines}[${prev_length}:]     ${n_lines}
 
 Set RHODS Admins Group Empty Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
@@ -376,35 +376,35 @@ Set RHODS Admins Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
     Apply Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
-    ...     users_group=${STANDARD_ADMINS_GROUP}   groups_modified_flag=true
+    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
 
 Set RHODS Users Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
-    Apply Access Groups Settings    admins_group=${STANDARD_USERS_GROUP}
+    Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${CUSTOM_INEXISTENT_GROUP}   groups_modified_flag=true
 
 Set Default Groups And Check Logs Do Not Change
     [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
     ...                 ConfigMap and checks if no new lines are generated in the logs after that.
     [Arguments]     ${delete_group}=${FALSE}
-    ${lenghts_dict}=    Get Lenghts of Dashboard Pods Logs
+    ${lengths_dict}=    Get Lengths of Dashboard Pods Logs
     Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
     # FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
-    #     ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_lenght=${lenghts_dict}[${pod_name}]  pod_name=${pod_name}
+    #     ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
     #     Should Be Equal     ${new_lines_flag}   ${FALSE}
     # END
-    Logs Of Dashboard Pods Should Not Contain New Lines  lenghts_dict=${lenghts_dict}
+    Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
     IF  "${delete_group}" == "${TRUE}"
         Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
     END
 
 Logs Of Dashboard Pods Should Not Contain New Lines
     [Documentation]     Checks if no new lines are generated in the logs after that.
-    [Arguments]     ${lenghts_dict}
+    [Arguments]     ${lengths_dict}
     FOR    ${index}    ${pod_name}    IN ENUMERATE    @{DASHBOARD_PODS_NAMES}
-        ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_lenght=${lenghts_dict}[${pod_name}]  pod_name=${pod_name}
+        ${new_lines_flag}=  Run Keyword And Return Status     Wait Until New Log Lines Are Generated In Dashboard Pods    prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
         Run Keyword And Continue On Failure     Should Be Equal     ${new_lines_flag}   ${FALSE}
     END
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -314,6 +314,8 @@ Verify Error Message In Logs When rhods-groups-config ConfigMap Does Not Exist
 
 *** Keywords ***
 Set Variables For Group Testing
+    [Documentation]     Sets the suite variables used by the test cases for checking
+     ...                Dashboard logs about rhods groups
     Set Standard RHODS Groups Variables
     Set Suite Variable      ${EXP_ERROR_INEXISTENT_GRP}      Error: Failed to retrieve Group ${CUSTOM_INEXISTENT_GROUP}, might not exist.
     Set Suite Variable      ${EXP_ERROR_SYS_AUTH}      Error: It is not allowed to set \\"system:authenticated\\" or an empty string as admin group.
@@ -321,11 +323,9 @@ Set Variables For Group Testing
     ${dash_pods_name}=   Get Dashboard Pods Names
     Set Suite Variable    ${DASHBOARD_PODS_NAMES}  ${dash_pods_name}
 
-Delete RHODS Config Map
-    [Arguments]     ${name}  ${namespace}=redhat-ods-applications
-    OpenShiftLibrary.Oc Delete    kind=ConfigMap  name=${name}  namespace=${namespace}
-
 Restore Group ConfigMap And Check Logs Do Not Change
+    [Documentation]    Creates the given configmap and checks the logs of Dashboard
+    ...                pods do not show new lines
     [Arguments]   ${cm_yaml}
     ${clean_yaml}=    Clean Resource YAML Before Creating It    ${cm_yaml}
     Log    ${clean_yaml}
@@ -334,6 +334,8 @@ Restore Group ConfigMap And Check Logs Do Not Change
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
 
 Restore Group ConfigMaps And Check Logs Do Not Change
+    [Documentation]    Creates the given configmaps and checks the logs of Dashboard
+    ...                pods do not show new lines after restoring each of the given CMs
     [Arguments]    ${cm_yamls}
     ${cm_dicts}=      Run Keyword And Continue On Failure    Get ConfigMaps For RHODS Groups Configuration
     FOR    ${key}    IN   @{cm_dicts.keys()}
@@ -343,9 +345,6 @@ Restore Group ConfigMaps And Check Logs Do Not Change
             Restore Group ConfigMap And Check Logs Do Not Change    cm_yaml=${cm_yamls}[${key}]
         END
     END
-
-
-
 
 Get Lengths Of Dashboard Pods Logs
     [Documentation]     Computes the number of lines present in the logs of both the dashboard pods


### PR DESCRIPTION
This PR wants to implement automation for the following TCs:
- ODS-1408
- ODS-1494
- ODS-1495 -> it does not test "groups-config" CM because it is immediately re-created by the operator if it gets deleted. I tried catching the error message, but the re-creation is very fast and sometime the msg does not appear (it would make the test very flaky, besides deleting it wouldn't be a user-scenario.
- ODS-1500

The feature tested here has been implemented in this [RHODS PR](https://github.com/red-hat-data-services/odh-dashboard/pull/217) and will be part of next release (1.13)

Signed-off-by: bdattoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)