### PR TITLE
Add test to check if Intel images are pinned to a numeric version

### DIFF
--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -34,6 +34,7 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    ...      ODS-1247
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
+   ...              ProductBug: RHODS-2748
    Check And Install Operator in Openshift    ${intel_aikit_container_name}    ${intel_aikit_appname}
    Create Tabname Instance For Installed Operator        ${intel_aikit_operator_name}      AIKitContainer    redhat-ods-applications
    Go To RHODS Dashboard

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -32,8 +32,10 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    ...      ODS-1237
    ...      ODS-715
    ...      ODS-1247
+   ...      ProductBug
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
+   ...              ProductBug: RHODS-2748
    Check And Install Operator in Openshift    ${intel_aikit_container_name}    ${intel_aikit_appname}
    Create Tabname Instance For Installed Operator        ${intel_aikit_operator_name}      AIKitContainer    redhat-ods-applications
    Go To RHODS Dashboard

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -32,10 +32,8 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    ...      ODS-1237
    ...      ODS-715
    ...      ODS-1247
-   ...      ProductBug
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
-   ...              ProductBug: RHODS-2748
    Check And Install Operator in Openshift    ${intel_aikit_container_name}    ${intel_aikit_appname}
    Create Tabname Instance For Installed Operator        ${intel_aikit_operator_name}      AIKitContainer    redhat-ods-applications
    Go To RHODS Dashboard

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -38,8 +38,10 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    Go To RHODS Dashboard
    Verify Service Is Enabled          ${intel_aikit_container_name}
    Verify JupyterHub Can Spawn AIKIT Notebook
+   Image Should Be Pinned To A Numeric Version
    Verify Git Plugin
    [Teardown]   Remove AIKIT Operator
+
 
 ***Keywords ***
 Intel_Aikit Suite Setup

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -31,6 +31,7 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    ...      ODS-760
    ...      ODS-1237
    ...      ODS-715
+   ...      ODS-1247
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
    Check And Install Operator in Openshift    ${intel_aikit_container_name}    ${intel_aikit_appname}

--- a/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -32,6 +32,7 @@ Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console
    ...      ODS-1237
    ...      ODS-715
    ...      ODS-1247
+   ...      ProductBug
    [Documentation]  This Test Case Installed Intel AIKIT operator in Openshift cluster
    ...              Check and Launch AIKIT notebook image from RHODS dashboard
    ...              ProductBug: RHODS-2748

--- a/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -30,6 +30,7 @@ Verify Openvino Operator Can Be Installed Using OpenShift Console
    ...      ODS-495
    ...      ODS-1236
    ...      ODS-651
+   ...      ODS-1085
    [Documentation]  This Test Case Installed Openvino operator in Openshift cluster
    ...               and Check and Launch Openvino notebook image from RHODS dashboard
    Check And Install Operator in Openshift    ${openvino_operator_name}   ${openvino_appname}

--- a/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -38,6 +38,7 @@ Verify Openvino Operator Can Be Installed Using OpenShift Console
    Go To RHODS Dashboard
    Verify Service Is Enabled          ${openvino_container_name}
    Verify JupyterHub Can Spawn Openvino Notebook
+   Image Should Be Pinned To A Numeric Version
    Verify Git Plugin
    [Teardown]   Remove Openvino Operator
 


### PR DESCRIPTION
This PR covers ODS-1085 and ODS-1247.
The check on image tag cannot be 100% reliable because every ISV can use different versioning formats. So, the code here is first checking if the image tag contains generic strings like "latest" (fail if true). If the first check is false, then it looks for numbers in the image tag. If numbers are there the test is passed. However, it checks if the numeric tag follow the usual versioning formats like x.y.z-n or x.y-n or x.y.

Signed-off-by: bdattoma [[bdattoma@redhat.com](mailto:bdattoma@redhat.com)]