### PR TITLE
Check aggregate availability in "RHOSi Setup" and "RHOSi Teardown"

### DIFF
--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -1,0 +1,107 @@
+*** Settings ***
+Documentation       Contains ODS Monitoring Keywords
+
+Resource            ../Prometheus/Prometheus.resource
+
+
+*** Variables ***
+${SLA_AVAILABILITY}             99.95
+${SUITE_AVAILABILITY_2M}        0
+${SUITE_AVAILABILITY_15M}       0
+${SUITE_AVAILABILITY_1H}        0
+${SUITE_AVAILABILITY_3H}        0
+
+
+*** Keywords ***
+Get Average Availability For Time Range
+    [Documentation]    Returns the average availability of ODS for a time range
+    ...    querying the Prometheus instance at ${pm_url} using token ${pm_token}.
+    ...
+    ...    returns =    avg_over_time(rhods_aggregate_availability[${time_range}]) * 100
+    [Arguments]    ${pm_url}    ${pm_token}    ${time_range}=15m    ${precision}=2
+    ${response}=    Prometheus.Run Query
+    ...    pm_url=${pm_url}
+    ...    pm_token=${pm_token}
+    ...    pm_query=avg_over_time(rhods_aggregate_availability[${time_range}])*100
+    ${value}=    Set Variable    ${response.json()["data"]["result"][0]["value"][-1]}
+    ${value}=    Convert To Number    ${value}    ${precision}
+    [Return]    ${value}
+
+Log If Average Availability For Time Range Breached SLA
+    [Documentation]    Gets Average Availability for ${time_range} and Logs a WARN message
+    ...    if the value is under 99.95
+    ...    returns =    avg_over_time(rhods_aggregate_availability[${time_range}]) * 100
+    [Arguments]    ${pm_url}    ${pm_token}    ${time_range}=15m    ${message_prefix}=${EMPTY}
+    ${availability}=    Get Average Availability For Time Range    ${pm_url}    ${pm_token}    ${time_range}
+    IF    ${availability} < ${SLA_AVAILABILITY}
+        #robocop:disable
+        ${message}=    Set Variable
+        ...    ${message_prefix}ODS Availability didn't meet SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
+        Log    message=${message}    level=WARN    console=False
+    END
+    [Return]    ${availability}
+
+Fail If Average Availability For Time Range Breached SLA
+    [Documentation]    Gets Average Availability for ${time_range} and Fails test if the value is under 99.95
+    [Arguments]    ${pm_url}    ${pm_token}    ${time_range}=15m
+    ${availability}=    Get Average Availability For Time Range    ${pm_url}    ${pm_token}    ${time_range}
+    IF    ${availability} < ${SLA_AVAILABILITY}
+        Fail    ODS Availability didn't meet SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
+    END
+
+Log Availability Comparison    #robocop:disable:too-many-arguments
+    [Documentation]    Gets Average Availability for ${time_range}, compares with ${previous_value} and
+    ...    Logs a WARN message if current availability < ${previous_value}
+    [Arguments]    ${message_prefix}    ${previous_value}    ${pm_url}    ${pm_token}    ${time_range}=15m    ${precision}=2    #robocop:disable:line-too-long
+
+    ${current_availability}=    Get Average Availability For Time Range
+    ...    ${pm_url}    ${pm_token}    ${time_range}    ${precision}
+    IF    ${current_availability} < ${previous_value}
+        #robocop:disable
+        ${message}=    Set Variable
+        ...    ${message_prefix}ODS Availability was reduced since previous check: ${current_availability} < ${previous_value} (time_range:${time_range})
+        Log    message=${message}    level=WARN    console=False
+    ELSE
+        #robocop:disable
+        ${message}=    Set Variable
+        ...    ${message_prefix}ODS Availability equal or better than previous check: ${current_availability} >= ${previous_value} (time_range:${time_range})
+        Log    message=${message}    level=INFO    console=False
+    END
+
+Suite Availability Setup
+    [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
+    ...    Log a WARN message if availability is under 99.95
+    [Arguments]    ${pm_url}    ${pm_token}
+
+    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=2m    message_prefix=Suite Setup: ${SUITE NAME}:
+    Set Global Variable    ${SUITE_AVAILABILITY_2M}    ${availability}
+
+    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=15m    message_prefix=Suite Setup: ${SUITE NAME}:
+    Set Global Variable    ${SUITE_AVAILABILITY_15M}    ${availability}
+
+    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=1h    message_prefix=Suite Setup: ${SUITE NAME}:
+    Set Global Variable    ${SUITE_AVAILABILITY_1H}    ${availability}
+
+    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=3h    message_prefix=Suite Setup: ${SUITE NAME}:
+    Set Global Variable    ${SUITE_AVAILABILITY_3H}    ${availability}
+
+Suite Availability Teardown
+    [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
+    ...    Logs a WARN message if the current values are lower
+    [Arguments]    ${pm_url}    ${pm_token}
+
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    ...    previous_value=${SUITE_AVAILABILITY_2M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=2m
+
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    ...    previous_value=${SUITE_AVAILABILITY_15M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=15m
+
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    ...    previous_value=${SUITE_AVAILABILITY_1H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=1h
+
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    ...    previous_value=${SUITE_AVAILABILITY_3H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=3h

--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -36,7 +36,7 @@ Log If Average Availability For Time Range Breached SLA
     IF    ${availability} < ${SLA_AVAILABILITY}
         #robocop:disable
         ${message}=    Set Variable
-        ...    ${message_prefix}ODS Availability didn't meet SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
+        ...    ${message_prefix}ODS Availability is currently breaching SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
         Log    message=${message}    level=WARN    console=False
     END
     [Return]    ${availability}
@@ -46,7 +46,7 @@ Fail If Average Availability For Time Range Breached SLA
     [Arguments]    ${pm_url}    ${pm_token}    ${time_range}=15m
     ${availability}=    Get Average Availability For Time Range    ${pm_url}    ${pm_token}    ${time_range}
     IF    ${availability} < ${SLA_AVAILABILITY}
-        Fail    ODS Availability didn't meet SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
+        Fail    ODS Availability is currently breaching SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
     END
 
 Log Availability Comparison    #robocop:disable:too-many-arguments
@@ -59,12 +59,12 @@ Log Availability Comparison    #robocop:disable:too-many-arguments
     IF    ${current_availability} < ${previous_value}
         #robocop:disable
         ${message}=    Set Variable
-        ...    ${message_prefix}ODS Availability was reduced since previous check: ${current_availability} < ${previous_value} (time_range:${time_range})
+        ...    ${message_prefix}ODS Availability is worse than previous value: ${current_availability} < ${previous_value} (time_range:${time_range})
         Log    message=${message}    level=WARN    console=False
     ELSE
         #robocop:disable
         ${message}=    Set Variable
-        ...    ${message_prefix}ODS Availability equal or better than previous check: ${current_availability} >= ${previous_value} (time_range:${time_range})
+        ...    ${message_prefix}ODS Availability is equal or better than previous value: ${current_availability} >= ${previous_value} (time_range:${time_range})
         Log    message=${message}    level=INFO    console=False
     END
 
@@ -94,14 +94,14 @@ Suite Availability Teardown
     ...    Logs a WARN message if the current values are lower
     [Arguments]    ${pm_url}    ${pm_token}
 
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
     ...    previous_value=${SUITE_AVAILABILITY_2M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=2m
 
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
     ...    previous_value=${SUITE_AVAILABILITY_15M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=15m
 
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
     ...    previous_value=${SUITE_AVAILABILITY_1H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=1h
 
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}
+    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
     ...    previous_value=${SUITE_AVAILABILITY_3H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=3h

--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -27,6 +27,72 @@ Get Average Availability For Time Range
     ${value}=    Convert To Number    ${value}    ${precision}
     [Return]    ${value}
 
+Create Suite Availability Checkpoint
+    [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
+    [Arguments]    ${pm_url}    ${pm_token}      ${message_prefix}=${EMPTY}
+
+    ${availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=2m
+    Set Global Variable    ${SUITE_AVAILABILITY_2M}    ${availability}
+
+    ${availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=15m
+    Set Global Variable    ${SUITE_AVAILABILITY_15M}    ${availability}
+
+    ${availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=1h
+    Set Global Variable    ${SUITE_AVAILABILITY_1H}    ${availability}
+
+    ${availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=3h
+    Set Global Variable    ${SUITE_AVAILABILITY_3H}    ${availability}
+
+#robocop:disable
+Log If Availability Decreased Since Suite Availability Checkpoint
+    [Documentation]    Obtains current Average Availability for the last 2m, 15m, 1h and 3h and
+    ...    Logs a WARN message in case it decreased, and an INFO message if it's the same or better
+    [Arguments]    ${pm_url}    ${pm_token}    ${message_prefix}=${EMPTY}
+
+    ${availability_decreased}=    Set Variable    False
+
+    ${current_availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=2m
+    IF    ${current_availability} < ${SUITE_AVAILABILITY_2M}
+        ${availability_decreased}=    Set Variable    True
+    END
+    ${availability_info}=    Set Variable    2m: ${current_availability} vs ${SUITE_AVAILABILITY_2M};
+
+    ${current_availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=15m
+    IF    ${current_availability} < ${SUITE_AVAILABILITY_15M}
+        ${availability_decreased}=    Set Variable    True
+    END
+    ${availability_info}=    Set Variable    ${availability_info} 15m: ${current_availability} vs ${SUITE_AVAILABILITY_15M};
+
+    ${current_availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=1h
+    IF    ${current_availability} < ${SUITE_AVAILABILITY_1H}
+        ${availability_decreased}=    Set Variable    True
+    END
+    ${availability_info}=    Set Variable    ${availability_info} 1h: ${current_availability} vs ${SUITE_AVAILABILITY_1H};
+
+    ${current_availability}=    Get Average Availability For Time Range    pm_url=${pm_url}
+    ...    pm_token=${pm_token}    time_range=3h
+    IF    ${current_availability} < ${SUITE_AVAILABILITY_3H}
+        ${availability_decreased}=    Set Variable    True
+    END
+    ${availability_info}=    Set Variable    ${availability_info} 3h: ${current_availability} vs ${SUITE_AVAILABILITY_3H}
+
+    IF    ${availability_decreased} == True
+        ${message}=    Set Variable
+        ...    ${message_prefix} Average Availability decreased since previous checkpoint: (${availability_info})
+        Log    message=${message}    level=WARN    console=False
+    ELSE
+        ${message}=    Set Variable
+        ...    ${message_prefix} Average Availability not decreased since previous checkpoint: (${availability_info})
+        Log    message=${message}    level=INFO    console=False
+    END
+
 Log If Average Availability For Time Range Breached SLA
     [Documentation]    Gets Average Availability for ${time_range} and Logs a WARN message
     ...    if the value is under 99.95
@@ -49,59 +115,16 @@ Fail If Average Availability For Time Range Breached SLA
         Fail    ODS Availability is currently breaching SLA: ${availability} < ${SLA_AVAILABILITY} (time-range:${time_range})
     END
 
-Log Availability Comparison    #robocop:disable:too-many-arguments
-    [Documentation]    Gets Average Availability for ${time_range}, compares with ${previous_value} and
-    ...    Logs a WARN message if current availability < ${previous_value}
-    [Arguments]    ${message_prefix}    ${previous_value}    ${pm_url}    ${pm_token}    ${time_range}=15m    ${precision}=2    #robocop:disable:line-too-long
-
-    ${current_availability}=    Get Average Availability For Time Range
-    ...    ${pm_url}    ${pm_token}    ${time_range}    ${precision}
-    IF    ${current_availability} < ${previous_value}
-        #robocop:disable
-        ${message}=    Set Variable
-        ...    ${message_prefix}ODS Availability is worse than previous value: ${current_availability} < ${previous_value} (time_range:${time_range})
-        Log    message=${message}    level=WARN    console=False
-    ELSE
-        #robocop:disable
-        ${message}=    Set Variable
-        ...    ${message_prefix}ODS Availability is equal or better than previous value: ${current_availability} >= ${previous_value} (time_range:${time_range})
-        Log    message=${message}    level=INFO    console=False
-    END
-
 Suite Availability Setup
     [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
     ...    Log a WARN message if availability is under 99.95
     [Arguments]    ${pm_url}    ${pm_token}
-
-    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
-    ...    pm_token=${pm_token}    time_range=2m    message_prefix=Suite Setup: ${SUITE NAME}:
-    Set Global Variable    ${SUITE_AVAILABILITY_2M}    ${availability}
-
-    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
-    ...    pm_token=${pm_token}    time_range=15m    message_prefix=Suite Setup: ${SUITE NAME}:
-    Set Global Variable    ${SUITE_AVAILABILITY_15M}    ${availability}
-
-    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
-    ...    pm_token=${pm_token}    time_range=1h    message_prefix=Suite Setup: ${SUITE NAME}:
-    Set Global Variable    ${SUITE_AVAILABILITY_1H}    ${availability}
-
-    ${availability}=    Log If Average Availability For Time Range Breached SLA    pm_url=${pm_url}
-    ...    pm_token=${pm_token}    time_range=3h    message_prefix=Suite Setup: ${SUITE NAME}:
-    Set Global Variable    ${SUITE_AVAILABILITY_3H}    ${availability}
+    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
 
 Suite Availability Teardown
     [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
     ...    Logs a WARN message if the current values are lower
     [Arguments]    ${pm_url}    ${pm_token}
 
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
-    ...    previous_value=${SUITE_AVAILABILITY_2M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=2m
-
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
-    ...    previous_value=${SUITE_AVAILABILITY_15M}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=15m
-
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
-    ...    previous_value=${SUITE_AVAILABILITY_1H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=1h
-
-    Log Availability Comparison    message_prefix=Suite Teardown: ${SUITE NAME}:
-    ...    previous_value=${SUITE_AVAILABILITY_3H}    pm_url=${pm_url}    pm_token=${pm_token}    time_range=3h
+    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
+    ...    message_prefix=Suite Teardown: ${SUITE NAME}:

--- a/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
+++ b/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
@@ -8,7 +8,9 @@ Library             RequestsLibrary
 
 *** Keywords ***
 Run Query
-    [Documentation]    Runs a Prometheus query using the API
+    [Documentation]    Runs a prometheus query, obtaining the current value. More info at:
+    ...                - https://promlabs.com/blog/2020/06/18/the-anatomy-of-a-promql-query
+    ...                - https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
     [Arguments]    ${pm_url}    ${pm_token}    ${pm_query}
     ${pm_headers}=    Create Dictionary    Authorization=Bearer ${pm_token}
     ${resp}=    RequestsLibrary.GET    url=${pm_url}/api/v1/query?query=${pm_query}
@@ -18,13 +20,14 @@ Run Query
     [Return]    ${resp}
 
 Run Range Query
-    [Documentation]    Runs a prometheus range query, in order to obtain the result of a PromQL expression over a given time range. More info at:
+    [Documentation]    Runs a prometheus range query, in order to obtain the result of a PromQL expression over a given
+    ...                time range. More info at:
     ...                - https://promlabs.com/blog/2020/06/18/the-anatomy-of-a-promql-query
     ...                - https://prometheus.io/docs/prometheus/latest/querying/api/#range-queries
     [Arguments]    ${pm_query}    ${pm_url}    ${pm_token}    ${interval}=12h     ${steps}=172
-    ${time} =    Get Start Time And End Time  interval=${interval}
+    ${time}=    Get Start Time And End Time  interval=${interval}
     ${pm_headers}=    Create Dictionary    Authorization=Bearer ${pm_token}
-    ${resp}=    RequestsLibrary.GET    url=${pm_url}/api/v1/query_range?query=${pm_query}&start=${time[0]}&end=${time[1]}&step=${steps}
+    ${resp}=    RequestsLibrary.GET    url=${pm_url}/api/v1/query_range?query=${pm_query}&start=${time[0]}&end=${time[1]}&step=${steps}    #robocop:disable
     ...    headers=${pm_headers}    verify=${False}
     Status Should Be    200    ${resp}
     [Return]    ${resp}
@@ -32,11 +35,11 @@ Run Range Query
 Get Start Time And End Time
     [Documentation]     Returns start and end time for Query range from current time
     [Arguments]         ${interval}   # like 12h  7 days etc
-    ${end_time} =  Get Current Date
-    ${end_time} =  BuiltIn.Evaluate  datetime.datetime.fromisoformat("${end_time}").timestamp()
-    ${start_time} =    Subtract Time From Date    ${end_time}    ${interval}
-    ${start_time} =  BuiltIn.Evaluate  datetime.datetime.fromisoformat("${start_time}").timestamp()
-    @{time} =  Create List  ${start_time}  ${end_time}
+    ${end_time}=  Get Current Date
+    ${end_time}=  BuiltIn.Evaluate  datetime.datetime.fromisoformat("${end_time}").timestamp()
+    ${start_time}=    Subtract Time From Date    ${end_time}    ${interval}
+    ${start_time}=  BuiltIn.Evaluate  datetime.datetime.fromisoformat("${start_time}").timestamp()
+    @{time}=  Create List  ${start_time}  ${end_time}
     [Return]    ${time}
 
 Get Rules
@@ -115,7 +118,7 @@ Alert Should Be Firing    # robocop: disable:too-many-calls-in-keyword
 
 Alert Severity Should Be    # robocop: disable:too-many-calls-in-keyword
     [Documentation]    Fails if a given Prometheus alert does not have the expected severity
-    [Arguments]    ${pm_url}    ${pm_token}    ${rule_group}    ${alert}    ${alert-severity}    ${alert-duration}=${EMPTY}
+    [Arguments]    ${pm_url}    ${pm_token}    ${rule_group}    ${alert}    ${alert-severity}    ${alert-duration}=${EMPTY}    #robocop:disable
     ${all_rules}=    Get Rules    ${pm_url}    ${pm_token}    alert
     ${all_rules}=    Get From Dictionary    ${all_rules['data']}    groups
     ${alert_found}=    Set Variable    False
@@ -202,7 +205,7 @@ Wait Until Alert Is Not Firing    # robocop: disable:too-many-arguments
 Get Target Endpoints
     [Documentation]     Returns list of Endpoint URLs
     [Arguments]         ${target_name}    ${pm_url}    ${pm_token}    ${username}    ${password}
-    ${links}=    Run  curl --silent -X GET -H "Authorization:Bearer ${pm_token}" -u ${username}:${password} -k ${pm_url}/api/v1/targets | jq '.data.activeTargets[] | select(.scrapePool == "${target_name}") | .globalUrl'
+    ${links}=    Run  curl --silent -X GET -H "Authorization:Bearer ${pm_token}" -u ${username}:${password} -k ${pm_url}/api/v1/targets | jq '.data.activeTargets[] | select(.scrapePool == "${target_name}") | .globalUrl'       #robocop:disable
     ${links}=    Replace String    ${links}    "    ${EMPTY}
     @{links}=    Split String  ${links}  \n
     [Return]    ${links}
@@ -210,7 +213,7 @@ Get Target Endpoints
 Get Target Endpoints Which Have State Up
     [Documentation]    Returns list of endpoints who have state is "UP"
     [Arguments]        ${target_name}    ${pm_url}    ${pm_token}    ${username}    ${password}
-    ${links}=    Run  curl --silent -X GET -H "Authorization:Bearer ${pm_token}" -u ${pm_token}:${password} -k ${pm_token}/api/v1/targets | jq '.data.activeTargets[] | select(.scrapePool == "${target_name}") | select(.health == "up") | .globalUrl'
+    ${links}=    Run  curl --silent -X GET -H "Authorization:Bearer ${pm_token}" -u ${pm_token}:${password} -k ${pm_token}/api/v1/targets | jq '.data.activeTargets[] | select(.scrapePool == "${target_name}") | select(.health == "up") | .globalUrl'    #robocop:disable
     ${links}=    Replace String    ${links}    "    ${EMPTY}
     @{links}=    Split String  ${links}  \n
     [Return]    ${links}

--- a/tests/Resources/RHOSi.resource
+++ b/tests/Resources/RHOSi.resource
@@ -1,6 +1,8 @@
 *** Settings ***
 Documentation       Applies RHOSi settings to run the test suites
-Library     RPA.RobotLogListener
+
+Library             RPA.RobotLogListener
+Resource            Page/ODH/Monitoring/Monitoring.resource
 
 
 *** Variables ***
@@ -20,14 +22,21 @@ Library     RPA.RobotLogListener
 
 *** Keywords ***
 RHOSi Setup
-    [Documentation]    Applies RHOSi Settings. The suggested usage of this keyword
-    ...                is to call it inside all the Suite Setup keywords.
-    ...                Do Not extend this keyword for high-level setup,
-    ...                e.g., don't open browser
+    [Documentation]    Applies RHOSi Settings and stores availability metrics
+    ...                The suggested usage of this keyword is to call it inside all the Suite Setup keywords.
+    ...                Do Not extend this keyword for high-level setup, e.g., don't open browser
     Protect Sensitive Variables In Keywords
+    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
     # TO DO: oc login
 
+RHOSi Teardown
+    [Documentation]    Gets current availability metrics and compares them with the ones
+    ...                stored at RHOSi setup
+    ...                The suggested usage of this keyword is to call it inside all the Suite Teardown keywords.
+    ...                Do Not extend this keyword for high-level setup, e.g., don't close browser
+    Suite Availability Teardown    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
+
 Protect Sensitive Variables In Keywords
-    [Documentation]     Register keywords which use sensitive data as "Protected"
-    ...                 to turn their log level to NONE using RobotLogListener by Robocorp
-    Register Protected Keywords     names=@{PROTECTED_KEYWORDS}
+    [Documentation]    Register keywords which use sensitive data as "Protected"
+    ...                to turn their log level to NONE using RobotLogListener by Robocorp
+    Register Protected Keywords    names=@{PROTECTED_KEYWORDS}

--- a/tests/Tests/100__deploy/100__installation/101__installation.robot
+++ b/tests/Tests/100__deploy/100__installation/101__installation.robot
@@ -48,6 +48,7 @@ OCM Suite Setup
 
 OCM Suite Teardown
   Close All Browsers
+  RHOSi Teardown
 
 OCM Test Setup
   [Documentation]   Setup for ODH in Openshift Installation Test Cases

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -1,22 +1,21 @@
 *** Settings ***
 Documentation       Post install test cases that mainly verify OCP resources and objects
-
 Library             String
 Library             OperatingSystem
 Library             OpenShiftCLI
 Library             OpenShiftLibrary
 Library             ../../../../libs/Helpers.py
+Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/OCP.resource
 Resource            ../../../Resources/Page/OCPDashboard/OCPDashboard.resource
 Resource            ../../../Resources/Page/ODH/JupyterHub/HighAvailability.robot
 Resource            ../../../Resources/Page/ODH/Prometheus/Prometheus.robot
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Page/ODH/Grafana/Grafana.resource
-
-Suite Setup         RHOSi Setup
-
 Resource            ../../../Resources/Page/HybridCloudConsole/HCCLogin.robot
 Resource            ../../../Resources/Common.robot
+Suite Setup         RHOSi Setup
+Suite Teardown      RHOSi Teardown
 
 *** Test Cases ***
 

--- a/tests/Tests/100__deploy/100__installation/103__grafana.robot
+++ b/tests/Tests/100__deploy/100__installation/103__grafana.robot
@@ -2,6 +2,10 @@
 Documentation     Post install test cases that verify OCP Grafana resources and objects
 Library           OpenShiftLibrary
 Resource          ../../../Resources/ODS.robot
+Resource          ../../../Resources/RHOSi.resource
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+
 
 *** Test Cases ***
 Verify Grafana Is Shipped And Enabled Within ODS

--- a/tests/Tests/100__deploy/100__installation/103__post_install_monitoring_port_forwarding.robot
+++ b/tests/Tests/100__deploy/100__installation/103__post_install_monitoring_port_forwarding.robot
@@ -2,10 +2,11 @@
 Library          OperatingSystem
 Library          Process
 Resource         ../../../Resources/Page/ODH/Grafana/Grafana.resource
+Resource         ../../../Resources/RHOSi.resource
 Resource         ../../../Resources/ODS.robot
 Resource         ../../../Resources/Common.robot
-Suite Setup      Set Library Search Order  SeleniumLibrary
-Suite Teardown   Close Browser
+Suite Setup      Post Install Monitoring Port Forwarding Suite Setup
+Suite Teardown   Post Install Monitoring Port Forwarding Suite Teardown
 
 
 *** Variables ***
@@ -62,3 +63,13 @@ Verify Access To Alert Manager Using Browser
     Wait Until Page Contains    text=Alertmanager
     Wait Until Page Contains    text=Silences
     Wait Until Page Contains    text=Status
+
+Post Install Monitoring Port Forwarding Suite Setup
+    [Documentation]    Suite Setup
+    RHOSi Setup
+    Set Library Search Order  SeleniumLibrary
+
+Post Install Monitoring Port Forwarding Suite Teardown
+    [Documentation]    Suite Teardown
+    Close Browser
+    RHOSi Teardown

--- a/tests/Tests/100__deploy/100__installation/104__dashboard.robot
+++ b/tests/Tests/100__deploy/100__installation/104__dashboard.robot
@@ -1,10 +1,13 @@
 *** Settings ***
 Documentation       Post install test cases that verify OCP Dashboard resources and objects
-
 Library             Collections
 Library             OpenShiftLibrary
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Page/ODH/JupyterHub/HighAvailability.robot
+Resource            ../../../Resources/RHOSi.resource
+Suite Setup         RHOSi Setup
+Suite Teardown      RHOSi Teardown
+
 
 *** Test Cases ***
 Verify Dashboard Is Shipped And Enabled Within ODS

--- a/tests/Tests/100__deploy/100__installation/105__prometheus.robot
+++ b/tests/Tests/100__deploy/100__installation/105__prometheus.robot
@@ -2,6 +2,10 @@
 Documentation     Post install test cases that verify OCP Prometheus resources and objects
 Library           OpenShiftLibrary
 Resource          ../../../Resources/ODS.robot
+Resource            ../../../Resources/RHOSi.resource
+Suite Setup         RHOSi Setup
+Suite Teardown      RHOSi Teardown
+
 
 *** Test Cases ***
 Verify Prometheus Is Shipped And Enabled Within ODS

--- a/tests/Tests/100__deploy/100__installation/106__blackbox_exporter.robot
+++ b/tests/Tests/100__deploy/100__installation/106__blackbox_exporter.robot
@@ -2,6 +2,10 @@
 Documentation     Post install test cases that verify OCP Blackbox Exporter resources and objects
 Library           OpenShiftLibrary
 Resource          ../../../Resources/ODS.robot
+Resource          ../../../Resources/RHOSi.resource
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+
 
 *** Test Cases ***
 Verify Blackbox Exporter Is Shipped And Enabled Within ODS

--- a/tests/Tests/100__deploy/100__installation/107__alert_manager.robot
+++ b/tests/Tests/100__deploy/100__installation/107__alert_manager.robot
@@ -2,6 +2,10 @@
 Documentation     Post install test cases that verify OCP Alert Manager resources and objects
 Library           OpenShiftLibrary
 Resource          ../../../Resources/ODS.robot
+Resource          ../../../Resources/RHOSi.resource
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+
 
 *** Test Cases ***
 Verify Alert Manager Is Shipped And Enabled Within ODS
@@ -21,8 +25,8 @@ Verify Alert Manager Is Shipped And Enabled Within ODS
     OpenShift Resource Field Value Should Be Equal As Strings    spec.to.name    alertmanager    @{alertmanager_routes_info}
     OpenShift Resource Field Value Should Match Regexp    spec.host    ^(alertmanager-redhat-ods-monitoring.*)    @{alertmanager_routes_info}
 
-*** Keywords ***
 
+*** Keywords ***
 Fetch Alert Manager Services Info
     [Documentation]    Fetch information from Alert Manager services
     ...    Args:

--- a/tests/Tests/100__deploy/100__installation/108__jupyterhub.robot
+++ b/tests/Tests/100__deploy/100__installation/108__jupyterhub.robot
@@ -3,6 +3,10 @@ Documentation       Post install test cases that verify OCP JupyterHub resources
 
 Library             OpenShiftLibrary
 Resource          ../../../Resources/ODS.robot
+Resource          ../../../Resources/RHOSi.resource
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+
 
 *** Test Cases ***
 Verify JupyterHub DB Is Shipped And Enabled Within ODS

--- a/tests/Tests/100__deploy/100__installation/109__operator.robot
+++ b/tests/Tests/100__deploy/100__installation/109__operator.robot
@@ -31,7 +31,7 @@ Verify That The Operator Pod Does Not Get Stuck After Upgrade
     ...       ODS-818
     ${operator_pod_info}=    Fetch operator Pod Info
     ${length}=    Get length    ${operator_pod_info}
-    IF    ${length} == 2
+    IF    ${length} == 1
         ${crashloopbackoff}=    Verify Operator Pods Have CrashLoopBackOff Status After upgrade    ${operator_pod_info}
         IF   ${crashloopbackoff}
             Log Error And Fail Pods When Pods Were Terminated    ${operator_pod_info}    Opertator Pod Stuck

--- a/tests/Tests/100__deploy/100__installation/109__operator.robot
+++ b/tests/Tests/100__deploy/100__installation/109__operator.robot
@@ -3,6 +3,9 @@ Documentation       Post install test cases that verify OCP operator resources a
 
 Library             OpenShiftLibrary
 Resource            ../../../Resources/ODS.robot
+Resource          ../../../Resources/RHOSi.resource
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
 
 
 *** Test Cases ***
@@ -74,32 +77,31 @@ Fetch Operator Pod Info
 Verify Operator Pods Have CrashLoopBackOff Status After Upgrade
     [Documentation]  Verifies operator pods have CrashLoopBackOff status after upgrade
     ...    Args:
-    ...        operator_pod_info(dict): Dictionary containing the information of the operator pod 
+    ...        operator_pod_info(dict): Dictionary containing the information of the operator pod
     ...    Returns:
     ...        crashloopbackoff(bool): True when the status CrashLoopBackOff is present
     [Arguments]    ${operator_pod_info}
-    ${crashloopbackoff}=    Run Keyword And Return Status   
+    ${crashloopbackoff}=    Run Keyword And Return Status
     ...    Wait Until Keyword Succeeds  60 seconds  1 seconds
-    ...    OpenShift Resource Field Value Should Be Equal As Strings    
+    ...    OpenShift Resource Field Value Should Be Equal As Strings
     ...    status.containerStatuses[0].state.waiting.reason
     ...    CrashLoopBackOff
     ...    @{operator_pod_info}
     [Return]    ${crashloopbackoff}
 
 Log Error And Fail Pods When Pods Were Terminated
-    [Documentation]  Logs the error why the specified pods were terminated and fails the pod for the specified reason 
+    [Documentation]  Logs the error why the specified pods were terminated and fails the pod for the specified reason
     ...    Args:
     ...        pods_info(list(dict)): List of Dictionaries containing the information of the pods
-    ...        fail_reason(str): Reason for failing the pods 
+    ...        fail_reason(str): Reason for failing the pods
     [Arguments]    ${pods_info}    ${fail_reason}
     FOR    ${pod_info}    IN    @{pods_info}
         &{operator_pod_info_dict}=    Set Variable    ${pod_info}
         ${reason}=    Set Variable    ${operator_pod_info_dict.status.containerStatuses[0].lastState.terminated.reason}
         ${exit_code}=    Set Variable    ${operator_pod_info_dict.status.containerStatuses[0].lastState.terminated.exitCode}
-        Log    ${fail_reason}. Reason: ${reason} Exit Code: ${exit_code}  
+        Log    ${fail_reason}. Reason: ${reason} Exit Code: ${exit_code}
         Fail   ${fail_reason}
     END
-    
 
 
-    
+

--- a/tests/Tests/100__deploy/100__installation/109__operator.robot
+++ b/tests/Tests/100__deploy/100__installation/109__operator.robot
@@ -31,7 +31,7 @@ Verify That The Operator Pod Does Not Get Stuck After Upgrade
     ...       ODS-818
     ${operator_pod_info}=    Fetch operator Pod Info
     ${length}=    Get length    ${operator_pod_info}
-    IF    ${length} == 1
+    IF    ${length} == 2
         ${crashloopbackoff}=    Verify Operator Pods Have CrashLoopBackOff Status After upgrade    ${operator_pod_info}
         IF   ${crashloopbackoff}
             Log Error And Fail Pods When Pods Were Terminated    ${operator_pod_info}    Opertator Pod Stuck

--- a/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
+++ b/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
@@ -1,8 +1,9 @@
 *** Settings ***
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Page/OCPDashboard/OCPDashboard.resource
-
-Suite Setup         Set Library Search Order  SeleniumLibrary
+Resource            ../../../Resources/RHOSi.resource
+Suite Setup         Rbac Suite Setup
+Suite Teardown      Rbac Suite Teardown
 
 
 *** Test Cases ***
@@ -46,3 +47,12 @@ Set Default Access Groups And Close Browser
     Set Standard RHODS Groups Variables
     Set Default Access Groups Settings
     Close Browser
+
+Rbac Suite Setup
+    [Documentation]    Suite setup
+    Set Library Search Order  SeleniumLibrary
+    RHOSi Setup
+
+Rbac Suite Teardown
+    [Documentation]    Suite teardown
+    RHOSi Teardown

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/130__rhods_operator.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/130__rhods_operator.robot
@@ -4,12 +4,15 @@ Library         RequestsLibrary
 Library         Collections
 Resource        ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
 Resource        ../../../../Resources/Common.robot
+Resource        ../../../../Resources/RHOSi.resource
 Suite Setup     RHODS Operator Suite Setup
-Suite Teardown  Close Browser
+Suite Teardown  RHODS Operator Suite Teardown
+
 
 *** Variables ***
 #Commercial variable to verify if the URL pregent for RHODS is commercial or not
 ${commercial_url}              https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-data-science
+
 
 *** Test Cases ***
 Verify RHODS operator information
@@ -31,8 +34,8 @@ Verify RHODS operator information
 
   Run Keyword IF     "mailto:undefined" not in $temp_list     FAIL    There shouldn't be reference to maintainers email
 
-*** Keywords ***
 
+*** Keywords ***
 Get HTTP Status Code
     [Arguments]  ${link_to_check}
     ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any
@@ -40,5 +43,11 @@ Get HTTP Status Code
     Log To Console    HTTP status For The '${link_to_check}' is '${response.status_code}'
 
 RHODS Operator Suite Setup
+    [Documentation]    Suite setup
     Set Library Search Order  SeleniumLibrary
     RHOSi Setup
+
+RHODS Operator Suite Teardown
+    [Documentation]    Suite teardown
+    Close Browser
+    RHOSi Teardown

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/132__traefik-proxy_restart_verification.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/132__traefik-proxy_restart_verification.robot
@@ -8,7 +8,10 @@ Documentation       132 - RHODS_TRAEFIK_PROXY_CONTAINER_RESTART_VERIFICATION
 ...                 | LABEL_SELECTOR    | Required |    Label selector for traefik proxy|
 
 Resource            ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
+Resource            ../../../../Resources/RHOSi.resource
 Suite Setup         RHOSi Setup
+Suite Teardown         RHOSi Teardown
+
 
 *** Variables ***
 ${NAMESPACE}            redhat-ods-applications

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/135__rhods_operator_logs_verification.robot
@@ -1,24 +1,26 @@
 *** Settings ***
-Documentation   135 - RHODS_OPERATOR_LOGS_VERIFICATION
-...             Verify that rhods operator log is clean and doesn't contain any error regarding resource kind
+Documentation     135 - RHODS_OPERATOR_LOGS_VERIFICATION
+...               Verify that rhods operator log is clean and doesn't contain any error regarding resource kind
 ...
-...             = Variables =
-...             | Namespace                | Required |        RHODS Namespace/Project for RHODS operator POD |
-...             | REGEX_PATTERN            | Required |        Regular Expression Pattern to match the erro msg in capture log|
+...               = Variables =
+...               | Namespace                | Required |        RHODS Namespace/Project for RHODS operator POD |
+...               | REGEX_PATTERN            | Required |        Regular Expression Pattern to match the erro msg in capture log|
 
-Resource      ../../../../Resources/RHOSi.resource
+Resource          ../../../../Resources/RHOSi.resource
 
-Library        Collections
-Library        OpenShiftCLI
-Library        OperatingSystem
-Library        String
+Library           Collections
+Library           OpenShiftCLI
+Library           OperatingSystem
+Library           String
 
-Suite Setup     RHOSi Setup
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
 
 
 *** Variables ***
 ${namespace}           redhat-ods-operator
 ${regex_pattern}       level=([Ee]rror).*|([Ff]ailed) to list .*
+
 
 *** Test Cases ***
 Verify RHODS Operator log

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/138__rhods_operator_oom_kill_verification.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/138__rhods_operator_oom_kill_verification.robot
@@ -14,6 +14,7 @@ Resource            ../../../../Resources/Page/OCPDashboard/OCPDashboard.resourc
 Resource            ../../../../Resources/Common.robot
 
 Suite Setup         RHOSi Setup
+Suite Teardown      RHOSi Teardown
 
 
 *** Variables ***

--- a/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__rhods_kfdef_event.robot
+++ b/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__rhods_kfdef_event.robot
@@ -1,16 +1,18 @@
 *** Settings ***
-Documentation   139 - KFDEF_EVENT_VERIFICATION
-...             Verify kfdef event is streaming for redhat-ods-application namespace
+Documentation     139 - KFDEF_EVENT_VERIFICATION
+...               Verify kfdef event is streaming for redhat-ods-application namespace
 ...
-...             = Variables =
-...             | Namespace                | Required |        RHODS Namespace/Project |
-...             | Resource_kind            | Required |        Object resource kind |
+...               = Variables =
+...               | Namespace                | Required |        RHODS Namespace/Project |
+...               | Resource_kind            | Required |        Object resource kind |
 
-Library        Collections
-Resource       ../../../../Resources/Page/OCPDashboard/Events/Events.resource
-Resource       ../../../../Resources/RHOSi.resource
+Library           Collections
+Resource          ../../../../Resources/Page/OCPDashboard/Events/Events.resource
+Resource          ../../../../Resources/RHOSi.resource
 
-Suite Setup     RHOSi Setup
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+
 
 *** Variables ***
 ${NAMESPACE}           redhat-ods-applications

--- a/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -1,12 +1,13 @@
 *** Settings ***
-Resource        ../../../Resources/ODS.robot
+Documentation       Test suite testing ODS Metrics
+Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/ODS.robot
+Library             DateTime
+Suite Setup         RHOSi Setup
+Suite Teardown      RHOSi Teardown
 Test Setup          Begin Metrics Web Test
 Test Teardown       End Metrics Web Test
 
-Suite Setup     RHOSi Setup
-Resource    ../../../Resources/ODS.robot
-Library     DateTime
 
 *** Variables ***
 @{RECORD_GROUPS}    Availability Metrics    SLOs - JupyterHub    SLOs - ODH Dashboard    SLOs - RHODS Operator    SLOs - Traefik Proxy    Usage Metrics
@@ -16,13 +17,13 @@ Library     DateTime
 *** Test Cases ***
 Test Existence of Prometheus Alerting Rules
     [Tags]    Smoke
-    ...       Sanity
+    ...       Tier1
     ...       ODS-509
     Check Prometheus Alerting Rules
 
 Test Existence of Prometheus Recording Rules
     [Tags]    Smoke
-    ...       Sanity
+    ...       Tier1
     ...       ODS-510
     Check Prometheus Recording Rules
 

--- a/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -1,4 +1,5 @@
 *** Settings ***
+Documentation       Test suite testing ODS Metrics related to billing
 Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Common.robot
@@ -9,7 +10,8 @@ Resource            ../../../Resources/OCP.resource
 Library             JupyterLibrary
 Library             SeleniumLibrary
 
-Suite Setup          Billing Metrics Suite Setup
+Suite Setup         Billing Metrics Suite Setup
+Suite Teardown      RHOSi Teardown
 
 
 *** Variables ***
@@ -22,7 +24,7 @@ ${METRIC_RHODS_UNDEFINED}           cluster:usage:consumption:rhods:undefined:se
 Verify OpenShift Monitoring Results Are Correct When Running Undefined Queries
     [Documentation]     Verifies openshift monitoring results are correct when firing undefined queries
     [Tags]    Smoke
-    ...       Sanity
+    ...       Tier1
     ...       ODS-173
     Run OpenShift Metrics Query    ${METRIC_RHODS_UNDEFINED}    retry_attempts=1
     Metrics.Verify Query Results Dont Contain Data
@@ -31,7 +33,7 @@ Verify OpenShift Monitoring Results Are Correct When Running Undefined Queries
 Test Billing Metric (Notebook Cpu Usage) On OpenShift Monitoring
     [Documentation]     Run notebook for 5 min and checks CPU usage is greater than zero
     [Tags]    Smoke
-    ...       Sanity
+    ...       Tier1
     ...       ODS-175
     Run Jupyter Notebook For 5 Minutes
     Verify Previus CPU Usage Is Greater Than Zero

--- a/tests/Tests/200__monitor_and_manage/200__metrics/204__check_pager_duty.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/204__check_pager_duty.robot
@@ -16,7 +16,7 @@ Library        OpenShiftCLI
 Resource       ../../../Resources/RHOSi.resource
 
 Suite Setup     RHOSi Setup
-
+Suite Teardown  RHOSi Teardown
 
 
 *** Variables ***
@@ -36,10 +36,11 @@ PagerDuty Dummy Secret Verification
      ${secret_key}    Get PagerDuty Key From Secrets
      Should Be Equal As Strings    ${service_key}   ${secret_key}   foo-bar
 
+
 *** Keywords ***
 Get PagerDuty Key From Alertmanager ConfigMap
      [Documentation]    Get Service Key From Alertmanager ConfigMap
-     ${c_data}   OpenShiftCLI.Get  kind=ConfigMap  namespace=${NAMESPACE}   field_selector=metadata.name==${CONFIGMAP_NAME}
+     ${c_data}   OpenShiftCLI.Get  kind=ConfigMap  namespace=${NAMESPACE}   field_selector=metadata.name==${CONFIGMAP_NAME}    #robocop:disable
      ${a_data}    Set Variable     ${c_data[0]['data']['alertmanager.yml']}
      ${match_list}      Get Regexp Matches   ${a_data}     service_key(:).*
      ${key}       Split String    ${match_list[0]}
@@ -51,4 +52,3 @@ Get PagerDuty Key From Secrets
      ${body}    Set Variable    ${new[0]['data']['PAGERDUTY_KEY']}
      ${string}  Evaluate    base64.b64decode('${body}').decode('ascii')      modules=base64
      [Return]   ${string}
-

--- a/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation       RHODS monitoring alerts test suite
 
+Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Common.robot
 Resource            ../../../Resources/Page/OCPDashboard/Builds/Builds.robot

--- a/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
@@ -11,6 +11,7 @@ Library             JupyterLibrary
 Library             OpenShiftCLI
 
 Suite Setup         Alerts Suite Setup
+Suite Teardown      RHOSi Teardown
 
 
 *** Variables ***

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -1,20 +1,22 @@
 *** Settings ***
-Library         OpenShiftCLI
-Library         OpenShiftLibrary
-Resource        ../../Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
-Resource        ../../Resources/ODS.robot
-Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
-Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
-Resource        ../../Resources/Page/ODH/AiApps/Rhosak.resource
-Resource        ../../Resources/Page/ODH/AiApps/Anaconda.resource
-Resource        ../../Resources/Page/LoginPage.robot
-Resource        ../../Resources/Page/OCPLogin/OCPLogin.robot
-Resource        ../../Resources/Common.robot
-Resource        ../../Resources/Page/OCPDashboard/Pods/Pods.robot
-Resource        ../../Resources/Page/OCPDashboard/Builds/Builds.robot
-Suite Setup     Dashboard Suite Setup
-Test Setup      Dashboard Test Setup
-Test Teardown   Dashboard Test Teardown
+Library           OpenShiftCLI
+Library           OpenShiftLibrary
+Resource          ../../Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
+Resource          ../../Resources/RHOSi.resource
+Resource          ../../Resources/ODS.robot
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+Resource          ../../Resources/Page/ODH/AiApps/Rhosak.resource
+Resource          ../../Resources/Page/ODH/AiApps/Anaconda.resource
+Resource          ../../Resources/Page/LoginPage.robot
+Resource          ../../Resources/Page/OCPLogin/OCPLogin.robot
+Resource          ../../Resources/Common.robot
+Resource          ../../Resources/Page/OCPDashboard/Pods/Pods.robot
+Resource          ../../Resources/Page/OCPDashboard/Builds/Builds.robot
+Suite Setup       Dashboard Suite Setup
+Suite Teardown    RHOSi Teardown
+Test Setup        Dashboard Test Setup
+Test Teardown     Dashboard Test Teardown
 
 
 *** Variables ***

--- a/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
+++ b/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
@@ -39,6 +39,7 @@ Verify That "Usage Data Collection" Can Be Set In "Cluster Settings"
     [Tags]    Tier1
     ...       Sanity
     ...       ODS-1218
+    ...       FlakyTest
     Open ODS Dashboard With Admin User
     Verify Cluster Settings Is Available
     ODHDashboard.Enable "Usage Data Collection"

--- a/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
+++ b/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
@@ -3,9 +3,11 @@ Documentation       Tests features in ODS Dashboard "Settings" section
 
 Library             SeleniumLibrary
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
+Resource            ../../Resources/RHOSi.resource
 Resource            ../../Resources/ODS.robot
 
 Suite Setup         Dashboard Settings Suite Setup
+Suite Teardown      RHOSi Teardown
 
 
 *** Test Cases ***

--- a/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
+++ b/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
@@ -11,12 +11,14 @@ Documentation       PVC_CHANGE_VERIFICATION
 #
 Library         SeleniumLibrary
 Library         JupyterLibrary
-Resource         ../../Resources/ODS.robot
+Resource        ../../Resources/RHOSi.resource
+Resource        ../../Resources/ODS.robot
 Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource        ../../Resources/Page/ODH/JupyterHub/ODHJupyterhub.resource
 Suite Setup     RHOSi Setup
 Suite Teardown  PVC Size Suite Teadrown
 Test Setup      PVC Size Test Setup
+
 
 *** Variables ***
 ${NAMESPACE}    redhat-ods-applications
@@ -114,6 +116,7 @@ PVC Size Suite Teadrown
     ${status}    ${pvc_name}    Run Keyword And Ignore Error
     ...     Get User Notebook PVC Name    ${TEST_USER.USERNAME}
     May Be Delete PVC     ${pvc_name}
+    RHOSi Teardown
 
 Verify PVC change using UI
    [Documentation]   Basic PVC change verification

--- a/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -1,12 +1,15 @@
 *** Settings ***
-Library         OpenShiftCLI
-Resource        ../../Resources/ODS.robot
+Library           OpenShiftCLI
+Resource          ../../Resources/RHOSi.resource
+Resource          ../../Resources/ODS.robot
 Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
-Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
-Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
-Resource        ../../Resources/Page/LoginPage.robot
-Test Setup      Resources Test Setup
-Test Teardown   Resources Test Teardown
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+Resource          ../../Resources/Page/LoginPage.robot
+Suite Setup       RHOSi Setup
+Suite Teardown    RHOSi Teardown
+Test Setup        Resources Test Setup
+Test Teardown     Resources Test Teardown
 
 
 *** Test Cases ***
@@ -44,7 +47,6 @@ Verify Resource Link HTTP Status Code
 *** Keywords ***
 Resources Test Setup
     Set Library Search Order    SeleniumLibrary
-    RHOSi Setup
     Launch Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
     ...    ${ODH_DASHBOARD_URL}    ${BROWSER.NAME}    ${BROWSER.OPTIONS}
     Click Link      Resources


### PR DESCRIPTION
- Adds keywords to obtain average availability for a time period
- In `RHOSi Setup`, stores an availability checkpoint (availability for the last 2m, 15m, 1h and 3h)
- In `RHOSi Teardown`,   obtains current availability and compares with the values stored in the RHOSi Setup checkpoint. Logs a WARN message in case it decreased, and an INFO message if it's the same or better
  - Example:
   `Suite Teardown: Tests.Ods Dashboard.Ods Dashboard Settings Pvc Size: Average Availability decreased since previous checkpoint: (2m: 100.0 vs 100.0; 15m: 100.0 vs 100.0; 1h: 99.17 vs 99.44; 3h: 99.26 vs 99.44)`  
- Calls `RHOSi Setup` and `RHOSi Teardown` from the test suites  under these folders (to be added more in other PRs):
  - 100__deploy
  - 200__monitor_and_managage
  - 400__ods_dashboard