### PR TITLE
Add header to GET request

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -94,7 +94,8 @@ Wait Until HTTP Status Code Is
 Check HTTP Status Code
     [Documentation]     Verifies Status Code of URL Matches Expected Status Code
     [Arguments]  ${link_to_check}  ${expected}=200
-    ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any
+    ${headers}=    Create Dictionary    User-Agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
+    ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any    headers=${headers}   timeout=10
     Run Keyword And Continue On Failure  Status Should Be  ${expected}
     [Return]  ${response.status_code}
 

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -99,7 +99,7 @@ Check HTTP Status Code
     Run Keyword And Continue On Failure  Status Should Be  ${expected}
     [Return]  ${response.status_code}
 
-URLs HTTP Status Code Should Be Equal
+URLs HTTP Status Code Should Be Equal To
     [Documentation]    Given a list of link web elements, extracts the URLs and
     ...                checks if the http status code expected one is equal to the
     [Arguments]    ${link_elements}    ${expected_status}=200    ${timeout}=20

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -93,11 +93,22 @@ Wait Until HTTP Status Code Is
 
 Check HTTP Status Code
     [Documentation]     Verifies Status Code of URL Matches Expected Status Code
-    [Arguments]  ${link_to_check}  ${expected}=200
+    [Arguments]  ${link_to_check}    ${expected}=200    ${timeout}=20
     ${headers}=    Create Dictionary    User-Agent=Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/102.0.0.0 Safari/537.36
-    ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any    headers=${headers}   timeout=10
+    ${response}=    RequestsLibrary.GET  ${link_to_check}   expected_status=any    headers=${headers}   timeout=${timeout}
     Run Keyword And Continue On Failure  Status Should Be  ${expected}
     [Return]  ${response.status_code}
+
+URLs HTTP Status Code Should Be Equal
+    [Documentation]    Given a list of link web elements, extracts the URLs and
+    ...                checks if the http status code expected one is equal to the
+    [Arguments]    ${link_elements}    ${expected_status}=200    ${timeout}=20
+    FOR    ${idx}    ${ext_link}    IN ENUMERATE    @{link_elements}    start=1
+        ${href}=    Get Element Attribute    ${ext_link}    href
+        ${status}=    Run Keyword And Continue On Failure    Check HTTP Status Code    link_to_check=${href}
+        ...                                                                            expected=${expected_status}
+        Log To Console    ${idx}. ${href} gets status code ${status}
+    END
 
 Get List Of Atrributes
     [Documentation]    Returns the list of attributes

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -88,3 +88,11 @@ Current Step In QuickStart Should Be
     # ELSE
     #     Element Text Should Be      //span[@class="pfext-quick-start-task-header__subtitle"]    ${n_steps-1} of ${n_steps}
     # END
+
+Get Link Web Elements From Resource Page
+    [Documentation]    Returns the link web elements from Resources page which redirects users to
+    ...                external websites. It excludes Quick Starts items
+    ${link_elements}=    Get WebElements    //a[@class="odh-card__footer__link" and not(starts-with(@href, '#'))]
+    ${len}=    Get Length    ${link_elements}
+    Log To Console    ${len} Links found\n
+    [Return]    ${link_elements}

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -67,11 +67,7 @@ Verify Resource Link HTTP Status Code
     ${link_elements}=    Get WebElements    //a[@class="odh-card__footer__link" and not(starts-with(@href, '#'))]
     ${len}=    Get Length    ${link_elements}
     Log To Console    ${len} Links found\n
-    FOR    ${idx}    ${ext_link}    IN ENUMERATE    @{link_elements}    start=1
-        ${href}=    Get Element Attribute    ${ext_link}    href
-        ${status}=    Run Keyword And Continue On Failure    Check HTTP Status Code    link_to_check=${href}
-        Log To Console    ${idx}. ${href} gets status code ${status}
-    END
+    URLs HTTP Status Code Should Be Equal     link_elements=${link_elements}    expected_status=200
 
 Verify Content In RHODS Explore Section
     [Documentation]    It verifies if the content present in Explore section of RHODS corresponds to expected one.

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -69,7 +69,7 @@ Verify Resource Link HTTP Status Code
     Log To Console    ${len} Links found\n
     FOR    ${idx}    ${ext_link}    IN ENUMERATE    @{link_elements}    start=1
         ${href}=    Get Element Attribute    ${ext_link}    href
-        ${status}=    Check HTTP Status Code    link_to_check=${href}
+        ${status}=    Run Keyword And Continue On Failure    Check HTTP Status Code    link_to_check=${href}
         Log To Console    ${idx}. ${href} gets status code ${status}
     END
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -59,16 +59,6 @@ Verify That Login Page Is Shown When Reaching The RHODS Page
     RHODS Dahsboard Pod Should Contain OauthProxy Container
     Check OpenShift Login Visible
 
-Verify Resource Link HTTP Status Code
-    [Tags]    Sanity
-    ...       ODS-531    ODS-507
-    Click Link    Resources
-    Sleep    5
-    ${link_elements}=    Get WebElements    //a[@class="odh-card__footer__link" and not(starts-with(@href, '#'))]
-    ${len}=    Get Length    ${link_elements}
-    Log To Console    ${len} Links found\n
-    URLs HTTP Status Code Should Be Equal     link_elements=${link_elements}    expected_status=200
-
 Verify Content In RHODS Explore Section
     [Documentation]    It verifies if the content present in Explore section of RHODS corresponds to expected one.
     ...    It compares the actual data with the one registered in a JSON file. The checks are about:

--- a/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -21,6 +21,14 @@ Verify Quick Starts Work As Expected
     Verify Quick Starts Work As Expected When At Least One Step Is Skipped      deploy-python-model
     Verify Quick Starts Work As Expected When One Step Is Marked As No  openvino-inference-notebook
 
+Verify Resource Link HTTP Status Code
+    [Tags]    Sanity
+    ...       ODS-531    ODS-507
+    Click Link    Resources
+    Sleep    5
+    ${link_elements}=     Get Link Web Elements From Resource Page
+    URLs HTTP Status Code Should Be Equal     link_elements=${link_elements}    expected_status=200
+
 
 *** Keywords ***
 Resources Test Setup

--- a/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -22,6 +22,8 @@ Verify Quick Starts Work As Expected
     Verify Quick Starts Work As Expected When One Step Is Marked As No  openvino-inference-notebook
 
 Verify Resource Link HTTP Status Code
+    [Documentation]    Verifies the how-to, documentation and tutorial cards in Resource page
+    ...                redirects users to working URLs (i.e., http status must be 200)
     [Tags]    Sanity
     ...       ODS-531    ODS-507
     Click Link    Resources

--- a/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -29,7 +29,7 @@ Verify Resource Link HTTP Status Code
     Click Link    Resources
     Sleep    5
     ${link_elements}=     Get Link Web Elements From Resource Page
-    URLs HTTP Status Code Should Be Equal     link_elements=${link_elements}    expected_status=200
+    URLs HTTP Status Code Should Be Equal To     link_elements=${link_elements}    expected_status=200
 
 
 *** Keywords ***


### PR DESCRIPTION
From recent running of our CI, we noticed ODS-507 started getting stuck while checking the HTTP status of a particular URL. This PR tries to fixes the TC by explicitly setting the HTTP header in the GET request.

Signed-off-by: bdattoma <bdattoma@redhat.com>