### PR TITLE
Add test to Verify Culler Settings are not overwritten [RHODS-4336]

### DIFF
--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -91,6 +91,19 @@ Verify Do Not Stop Idle Notebooks
     ${notebook_pod_name} =  Get User Notebook Pod Name  ${TEST_USER.USERNAME}
     OpenShiftLibrary.Search Pods  ${notebook_pod_name}  namespace=rhods-notebooks
 
+Verify That "Stop Idle Notebook" Setting Is Not Overwrite With Restart Of Operator Pod
+    [Documentation]    Restart the operator pod and verify if "Stop Idle Notebook" setting
+    ...   is overwritten or not ProductBug:RHODS-4336
+    [Tags]    Tier2
+    ...       ProductBug
+    ...       polarian-id
+    Modify Notebook Culler Timeout    ${CUSTOM_CULLER_TIMEOUT}
+    Oc Delete    kind=Pod     namespace=redhat-ods-operator    label_selector=name=rhods-operator
+    sleep   5    msg=waiting time for the operator pod to be replaced with new one
+    ${status}    Run Keyword And Return Status    Radio Button Should Not Be Selected  culler-unlimited-time
+    IF    ${status}==False
+        Fail    Restart of operator pod causing 'Stop Idle Notebook' setting to change in RHODS dashboard
+    END
 
 *** Keywords ***
 Spawn Minimal Image

--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -91,13 +91,13 @@ Verify Do Not Stop Idle Notebooks
     ${notebook_pod_name} =  Get User Notebook Pod Name  ${TEST_USER.USERNAME}
     OpenShiftLibrary.Search Pods  ${notebook_pod_name}  namespace=rhods-notebooks
 
-Verify That "Stop Idle Notebook" Setting Is Not Overwrite With Restart Of Operator Pod
+Verify That "Stop Idle Notebook" Setting Is Not Overwritten After Restart Of Operator Pod
     [Documentation]    Restart the operator pod and verify if "Stop Idle Notebook" setting
     ...   is overwritten or not.
     ...   ProductBug:RHODS-4336
     [Tags]    Tier2
     ...       ProductBug
-    ...       polarian-id
+    ...       ODS-1607
     Modify Notebook Culler Timeout    ${CUSTOM_CULLER_TIMEOUT}
     Oc Delete    kind=Pod     namespace=redhat-ods-operator    label_selector=name=rhods-operator
     sleep   5    msg=waiting time for the operator pod to be replaced with new one

--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -101,6 +101,7 @@ Verify That "Stop Idle Notebook" Setting Is Not Overwrite With Restart Of Operat
     Modify Notebook Culler Timeout    ${CUSTOM_CULLER_TIMEOUT}
     Oc Delete    kind=Pod     namespace=redhat-ods-operator    label_selector=name=rhods-operator
     sleep   5    msg=waiting time for the operator pod to be replaced with new one
+    Reload Page
     ${status}    Run Keyword And Return Status    Radio Button Should Not Be Selected  culler-unlimited-time
     IF    ${status}==False
         Fail    Restart of operator pod causing 'Stop Idle Notebook' setting to change in RHODS dashboard

--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -93,7 +93,8 @@ Verify Do Not Stop Idle Notebooks
 
 Verify That "Stop Idle Notebook" Setting Is Not Overwrite With Restart Of Operator Pod
     [Documentation]    Restart the operator pod and verify if "Stop Idle Notebook" setting
-    ...   is overwritten or not ProductBug:RHODS-4336
+    ...   is overwritten or not.
+    ...   ProductBug:RHODS-4336
     [Tags]    Tier2
     ...       ProductBug
     ...       polarian-id


### PR DESCRIPTION
Tc to check if Culler setting is getting changed with operator restart. 
Signed-off-by: Tarun Kumar <takumar@redhat.com>