### PR TITLE
Slim down Sanity moving some tests to Tier2 (execution time > 15 mins)

### DIFF
--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -163,8 +163,9 @@ Verify "Notebook Images Are Building" Is Not Shown When No Images Are Building
 
 Verify Notifications Appears When Notebook Builds Finish And Atleast One Failed
     [Documentation]    Verifies that Notifications are shown when Notebook Builds are finished and atleast one fails
-    [Tags]    Sanity
+    [Tags]    Tier2
     ...       ODS-470  ODS-718
+    ...       Execution-Time-Over-30m
     ...       FlakyTest
     Clear Dashboard Notifications
     ${build_name}=  Search Last Build  namespace=redhat-ods-applications    build_name_includes=pytorch

--- a/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -32,12 +32,14 @@ Iterative Testing Classifiers
   END
 
 Iterative Testing Clustering
-  [Tags]  Sanity  POLARION-ID-Clustering
+  [Tags]  Tier2  POLARION-ID-Clustering
   ...     ODS-923  ODS-924
+  ...     Execution-Time-Over-15m
   &{DICTIONARY} =  Evaluate  ${python_dict}
   FOR  ${sublist}  IN  @{DICTIONARY}[clustering]
     Run Keyword And Continue On Failure  Iterative Image Test  ${sublist}[0]  ${sublist}[1]  ${sublist}[2]
   END
+
 
 *** Keywords ***
 Iterative Image Test

--- a/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
+++ b/tests/Tests/500__jupyterhub/long-running-test-generic-ds.robot
@@ -1,35 +1,37 @@
 *** Settings ***
-Resource         ../../Resources/ODS.robot
-Resource         ../../Resources/Common.robot
-Resource         ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
-Resource         ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
-Library          DebugLibrary
-Library          JupyterLibrary
-Suite Setup      Begin Web Test
-Suite Teardown   End Web Test
-Force Tags       JupyterHub
+Resource            ../../Resources/ODS.robot
+Resource            ../../Resources/Common.robot
+Resource            ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+Resource            ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+Library             DebugLibrary
+Library             JupyterLibrary
+
+Suite Setup         Begin Web Test
+Suite Teardown      End Web Test
+
+Force Tags          JupyterHub
+
 
 *** Test Cases ***
-Launch JupyterLab
-  [Tags]  Sanity
-  Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
-  ${version-check} =  Is RHODS Version Greater Or Equal Than  1.4.0
-  IF  ${version-check}==True
-    Launch JupyterHub From RHODS Dashboard Link
-  ELSE
-    Launch JupyterHub From RHODS Dashboard Dropdown
-  END
-  Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  ${authorization_required} =  Is Service Account Authorization Required
-  Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
-  Fix Spawner Status
-  Spawn Notebooks And Set S3 Credentials    image=s2i-generic-data-science-notebook
-
 Long Running Test Case
-  Run Repo and Clean  https://github.com/lugi0/minimal-nb-image-test  minimal-nb-image-test/minimal-nb.ipynb
-  Run Repo and Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/CCFraud-clustering.ipynb
-  Run Repo and Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/customer-segmentation-k-means-analysis.ipynb
-  Run Repo and Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/CCFraud-clustering-S3.ipynb
-  Run Repo and Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
-  Run Repo and Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
+    [Tags]    Tier2
+    ...       Execution-Time-Over-15m
+    Launch JupyterLab
+    Run Repo And Clean  https://github.com/lugi0/minimal-nb-image-test  minimal-nb-image-test/minimal-nb.ipynb
+    Run Repo And Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/CCFraud-clustering.ipynb
+    Run Repo And Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/customer-segmentation-k-means-analysis.ipynb
+    Run Repo And Clean  https://github.com/lugi0/clustering-notebook  clustering-notebook/CCFraud-clustering-S3.ipynb
+    Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
+    Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
+
+
+*** Keywords ***
+Launch JupyterLab
+    Login To RHODS Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
+    Wait For RHODS Dashboard To Load
+    Launch JupyterHub From RHODS Dashboard Link
+    Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
+    ${authorization_required} =    Is Service Account Authorization Required
+    Run Keyword If    ${authorization_required}    Authorize jupyterhub service account
+    Fix Spawner Status
+    Spawn Notebooks And Set S3 Credentials    image=s2i-generic-data-science-notebook

--- a/tests/Tests/500__jupyterhub/notebook_size_verification.robot
+++ b/tests/Tests/500__jupyterhub/notebook_size_verification.robot
@@ -30,10 +30,11 @@ ${CUSTOME_SIZE}     {"limits":{"cpu":"6","memory":"9gi"},"requests":{"cpu":"2","
 
 
 *** Test Cases ***
-Verify Spwaned Notebook Size
+Verify Spawned Notebook Size
     [Documentation]    Check the available container size spec
-    ...    with actual assign to spwaned notebook pod
-    [Tags]    Sanity
+    ...    with actual assign to spawned notebook pod
+    [Tags]    Tier2
+    ...       Execution-Time-Over-15m
     ...       FlakyTest
     ...       ODS-1072
     Launch JupyterHub Spawner From Dashboard

--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -39,8 +39,9 @@ Verify Culler Timeout Can Be Updated
 Verify Culler Kills Inactive Server
     [Documentation]    Verifies that the culler kills an inactive
     ...    server after timeout has passed.
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier2
     ...       ODS-1254
+    ...       Execution-Time-Over-15m
     ...       ProductBug
     Spawn Minimal Image
     Clone Git Repository And Run    https://github.com/redhat-rhods-qe/ods-ci-notebooks-main    ods-ci-notebooks-main/notebooks/500__jupyterhub/notebook-culler/Inactive.ipynb
@@ -66,8 +67,9 @@ Verify Culler Kills Inactive Server
 Verify Culler Does Not Kill Active Server
     [Documentation]    Verifies that the culler does not kill an active
     ...    server even after timeout has passed.
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier2
     ...       ODS-1253
+    ...       Execution-Time-Over-15m
     Spawn Minimal Image
     Clone Git Repository And Open    https://github.com/redhat-rhods-qe/ods-ci-notebooks-main    ods-ci-notebooks-main/notebooks/500__jupyterhub/notebook-culler/Active.ipynb
     Open With JupyterLab Menu    Run    Run All Cells
@@ -79,8 +81,9 @@ Verify Culler Does Not Kill Active Server
 
 Verify Do Not Stop Idle Notebooks
     [Documentation]    Disables the culler (default configuration) and verifies nb is not culled
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier2
     ...       ODS-1230
+    ...       Execution-Time-Over-15m
     Disable Notebook Culler
     Close Browser
     Spawn Minimal Image
@@ -106,6 +109,7 @@ Verify That "Stop Idle Notebook" Setting Is Not Overwritten After Restart Of Ope
     IF    ${status}==False
         Fail    Restart of operator pod causing 'Stop Idle Notebook' setting to change in RHODS dashboard
     END
+
 
 *** Keywords ***
 Spawn Minimal Image

--- a/tests/Tests/800__culler/culler.robot
+++ b/tests/Tests/800__culler/culler.robot
@@ -19,7 +19,7 @@ ${CUSTOM_CULLER_TIMEOUT} =     600
 *** Test Cases ***
 Verify Default Culler Timeout
     [Documentation]    Checks default culler timeout
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier2
     ...       ODS-1255
     Disable Notebook Culler
     ${current_timeout} =  Get And Verify Notebook Culler Timeout
@@ -28,7 +28,7 @@ Verify Default Culler Timeout
 
 Verify Culler Timeout Can Be Updated
     [Documentation]    Verifies culler timeout can be updated
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier2
     ...       ODS-1231
     Modify Notebook Culler Timeout    ${CUSTOM_CULLER_TIMEOUT}
     ${current_timeout} =  Get And Verify Notebook Culler Timeout


### PR DESCRIPTION
After agreement on Google Chat, this PR is moving some tests from Sanity/Tier1 to Tier2 because they need more than 15 mins to execute