### PR TITLE
POC: Remove the dependency on `oc` being connected to the cluster

### DIFF
--- a/tasks/Tasks/rhods_olm.robot
+++ b/tasks/Tasks/rhods_olm.robot
@@ -2,7 +2,7 @@
 Documentation    Perform and verify RHODS OLM tasks
 Metadata         RHODS OLM Version    1.0.0
 Resource         ../Resources/RHODS_OLM/RHODS_OLM.resource
-Library          OpenShiftCLI
+
 
 ***Variables***
 ${cluster_type}          OSD

--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation   Collection of keywords to interact with RHOSAK
 Library         SeleniumLibrary
-Library         OpenShiftCLI
+
 Resource        HCCLogin.robot
 Resource        ../Components/Menu.robot
 Resource        ../ODH/ODHDashboard/ODHDashboard.robot

--- a/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
+++ b/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    OpenShiftCLI
+
 Library    OpenShiftLibrary
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot

--- a/tests/Resources/Page/OCPDashboard/ConfigMaps/ConfigMaps.robot
+++ b/tests/Resources/Page/OCPDashboard/ConfigMaps/ConfigMaps.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    OpenShiftCLI
+
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 

--- a/tests/Resources/Page/OCPDashboard/Events/Events.resource
+++ b/tests/Resources/Page/OCPDashboard/Events/Events.resource
@@ -2,7 +2,7 @@
 Documentation       Keyword Suites to work with Openshift Events
 
 Library             Collections
-Library             OpenShiftCLI
+
 
 
 *** Keywords ***

--- a/tests/Resources/Page/OCPDashboard/ImageStream/ImageStream.robot
+++ b/tests/Resources/Page/OCPDashboard/ImageStream/ImageStream.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    OpenShiftCLI
+
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 

--- a/tests/Resources/Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
+++ b/tests/Resources/Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Library  SeleniumLibrary
-Library  OpenShiftCLI
+
 Library  OperatingSystem
 Library  String
 Library  ../../../../libs/Helpers.py

--- a/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -1,6 +1,6 @@
 *** Settings ***
 Documentation       Collection of keywords to work with Pods
-Library             OpenShiftCLI
+
 Resource            ../../OCPDashboard/Page.robot
 Resource            ../../ODH/ODHDashboard/ODHDashboard.robot
 Library             ../../../../libs/Helpers.py

--- a/tests/Resources/Page/OCPDashboard/Secrets/Secrets.robot
+++ b/tests/Resources/Page/OCPDashboard/Secrets/Secrets.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library    OpenShiftCLI
+
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 

--- a/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Library       OpenShiftCLI
+
 Library       OperatingSystem
 Resource      ../../../Page/Components/Components.resource
 

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.robot
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Library     SeleniumLibrary
 Library     ../../../../libs/Helpers.py
-Library     OpenShiftCLI
+
 Resource    ../JupyterHub/JupyterLabLauncher.robot
 Resource    ../../Components/Components.resource
 Resource    ../ODHDashboard/ODHDashboard.robot

--- a/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
@@ -3,7 +3,6 @@ Resource    ../../OCPDashboard/DeploymentConfigs/DeploymentConfigs.robot
 Resource    ../../OCPDashboard/InstalledOperators/InstalledOperators.robot
 Resource    ../../../Common.robot
 Library     Collections
-Library     OpenShiftCLI
 Library     ../../../../libs/Helpers.py
 
 


### PR DESCRIPTION
The `OpenShiftCLI` library requires a valid `KUBECONFIG` to load
properly. Without it, the framework initialization fails because it
cannot access the cluster.

As part of our scale testing, we cannot allow any unnecessary call to
OpenShift, be it `oc login` or resource queries.

This commit is a quick-and-dirty POC showing that we can run our OSD-CI-based scale
test without relying on `OpenShiftCLI`.