### PR TITLE
moving PVC size verification TCs out of smoke

### DIFF
--- a/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
+++ b/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
@@ -30,9 +30,7 @@ ${SIZE_CODE}    import subprocess;
 Verify User Can Spawn Notebook After Changing PVC Size Using Backend
     [Documentation]   Verify if user can spawn notebook
     ...    for supported PVC size got changed
-    [Tags]    Smoke
-    ...       Sanity
-    ...       Tier1
+    [Tags]    Tier2
     ...       ODS-1221
     Change And Apply PVC size    ${S_SIZE}Gi
     Run Keyword And Warn On Failure   Verify Notebook Size     600s    ${S_SIZE}
@@ -53,8 +51,7 @@ Verify User Can Spawn Notebook After Changing PVC Size Using UI
     [Documentation]   Verify if dedicated admin user able to chnage PVC
     ...    and RHODS user is able to spawn notebook for supported PVC
     ...    and verify PVC size
-    [Tags]    Smoke
-    ...       Sanity
+    [Tags]    Sanity
     ...       Tier1
     ...       ODS-1220    ODS-1222
     Verify PVC change using UI     ${S_SIZE}

--- a/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
+++ b/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
@@ -41,6 +41,7 @@ Verify User Can Spawn Notebook After Changing PVC Size Using Backend
 Verify User Cannot Set An Unsupported PVC Size Using Backend
     [Documentation]   Verify if user should not able to
     ...    spawn notebook for supported PVC change
+    ...    ProductBug:RHODS-3258
     [Tags]    Tier2
     ...       ODS-1229
     ...       ProductBug


### PR DESCRIPTION
It is suitable to move back end pvc size verification to Tier2 and UI to sanity. Removing both the TC(ODS-1220,1221) out of smoke.
Signed-off-by: Tarun Kumar <takumar@redhat.com>