### PR TITLE
Fix test checking Active_Users metrics not to skip when active_users > 0

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Monitoring/Metrics.robot
+++ b/tests/Resources/Page/OCPDashboard/Monitoring/Metrics.robot
@@ -21,27 +21,34 @@ Verify Query Results Dont Contain Data
   Should Be True   not ${metrics_query_results_contain_data}
 
 Run Query
-  [Arguments]  ${query}  ${retry-attempts}=10
+  [Arguments]  ${query}  ${retry_attempts}=10
   Wait Until Page Contains Element    ${METRICS_QUERY_TEXTAREA}  timeout=30
   Input Text   ${METRICS_QUERY_TEXTAREA}  ${query}
 
-  ${end-range}=   Evaluate    ${retry-attempts} + 1
+  ${end-range}=   Evaluate    ${retry_attempts} + 1
   FOR    ${counter}    IN RANGE    1    ${end-range}
       Press Keys   ${METRICS_QUERY_TEXTAREA}    ENTER
       Sleep  5  reason=Wait for query results
       ${metrics_query_results_contain_data} =  Run Keyword and Return Status   Verify Query Results Contain Data
       Capture Page Screenshot
       Exit For Loop If   ${metrics_query_results_contain_data}
-      Exit For Loop If   ${counter} == ${retry-attempts}
+      Exit For Loop If   ${counter} == ${retry_attempts}
       Sleep  60  reason=Wait until metrics are available
   END
 
-
 Get Query Results
-  ${metrics_query_results_contain_data} =  Run Keyword and Return Status   Verify Query Results Contain Data
-  IF  ${metrics_query_results_contain_data}
+    [Documentation]    After having run a query in OpenShift Console > Observe > Metrics, returns the obtained value.
+    ...    If ${return_zero_if_result_empty} is True, returns a zero when the result is empty
+    [Arguments]    ${return_zero_if_result_empty}=False
+
+    ${metrics_query_results_contain_data} =  Run Keyword And Return Status   Verify Query Results Contain Data
+    IF  ${metrics_query_results_contain_data}
       ${metrics_query_result_row1_value} =   Get Text  ${METRICS_QUERY_RESULTS_TABLE_ROW1_VALUE_ELEMENT}
-  ELSE
-       ${metrics_query_result_row1_value} =   Set Variable  ${EMPTY}
-  END
-  [Return]  ${metrics_query_result_row1_value}
+    ELSE
+        IF  ${return_zero_if_result_empty}==True
+            ${metrics_query_result_row1_value} =   Set Variable  0
+        ELSE
+            ${metrics_query_result_row1_value} =   Set Variable  ${EMPTY}
+        END
+    END
+    [Return]  ${metrics_query_result_row1_value}


### PR DESCRIPTION
Instead of skipping if active users > 0 at the start of the tests, now the tests checks if active users increased the expected amount of users at the end of the test.

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>