### PR TITLE
Fix RHOSAK teardown 

### DIFF
--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -247,6 +247,8 @@ Clean Up RHOSAK
     Delete Kafka Stream Instance    stream_name=${stream_to_delete}
     Capture Page Screenshot    after deleting_stream.png
     Click Link    Service Accounts
+    Run Keyword And Ignore Error    Wait For HCC Splash Page
+    Maybe Skip RHOSAK Tour
     Delete Service Account By Client ID    client_id_delete=${sa_clientid_to_delete}
     Close All Browsers
     Launch Dashboard  ocp_user_name=${TEST_USER.USERNAME}  ocp_user_pw=${TEST_USER.PASSWORD}  ocp_user_auth_type=${TEST_USER.AUTH_TYPE}


### PR DESCRIPTION
RHOSAK teardown is failing because a "Tour" dialog window appears when switching to Service Accounts page. This PR handles that situation. 

Signed-off-by: bdattoma <bdattoma@redhat.com>