### PR TITLE
Spawn Notebook With Arguments: initialize ${spawn_fail} variable

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -139,6 +139,7 @@ Spawn Notebook With Arguments  # robocop: disable
    ...              e.g. &{test-dict}  Create Dictionary  name=robot  password=secret
    [Arguments]  ${retries}=1  ${retries_delay}=0 seconds  ${image}=s2i-generic-data-science-notebook  ${size}=Small
    ...    ${spawner_timeout}=600 seconds  ${gpus}=0  ${refresh}=${False}  &{envs}
+   ${spawn_fail} =  True
    FOR  ${index}  IN RANGE  0  1+${retries}
       ${spawner_ready} =    Run Keyword And Return Status    Wait Until JupyterHub Spawner Is Ready
       IF  ${spawner_ready}==True


### PR DESCRIPTION
Without this initialization, if the spawner never gets ready, the
`${spawn_fail}` variable is never initialized and the final
`IF  ${spawn_fail} == True` crashes.