### PR TITLE
Spawn Notebook With Arguments:  correctly initialize ${spawn_fail} variable

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -139,7 +139,7 @@ Spawn Notebook With Arguments  # robocop: disable
    ...              e.g. &{test-dict}  Create Dictionary  name=robot  password=secret
    [Arguments]  ${retries}=1  ${retries_delay}=0 seconds  ${image}=s2i-generic-data-science-notebook  ${size}=Small
    ...    ${spawner_timeout}=600 seconds  ${gpus}=0  ${refresh}=${False}  &{envs}
-   ${spawn_fail} =  True
+   ${spawn_fail} =  Set Variable  True
    FOR  ${index}  IN RANGE  0  1+${retries}
       ${spawner_ready} =    Run Keyword And Return Status    Wait Until JupyterHub Spawner Is Ready
       IF  ${spawner_ready}==True


### PR DESCRIPTION


Fixes https://github.com/red-hat-data-services/ods-ci/pull/469