### PR TITLE
Add further check on doc links from Dashboard in ODS-327

### DIFF
--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -730,6 +730,6 @@ Check And Uninstall Operator In Openshift
     Close All Browsers
 
 Documentation Links Should Be Equal To The Expected Ones
+    [Documentation]   Compare the fetched links from Dashboard with the expected ones
     [Arguments]     ${actual_links}     ${expected_links}
-
     Lists Should Be Equal   ${actual_links}    ${expected_links}    ignore_order=True

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -51,6 +51,9 @@ ${openvino_container_name}    OpenVINO
 ${openvino_operator_name}     OpenVINO Toolkit Operator
 ${CUSTOM_EMPTY_GROUP}                   empty-group
 ${CUSTOM_INEXISTENT_GROUP}              inexistent-group
+@{DOC_LINKS_EXP}        https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science
+...                     https://access.redhat.com/support/cases/#/case/new/open-case?caseCreate=true
+...                     https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science
 
 
 *** Test Cases ***
@@ -127,6 +130,7 @@ Verify Documentation Link HTTP Status Code
     [Tags]    Sanity
     ...       ODS-327    ODS-492
     ${links}=  Get RHODS Documentation Links From Dashboard
+    Documentation Links Should Be Equal To The Expected Ones   actual_links=${links}  expected_links=${DOC_LINKS_EXP}
     Check External Links Status     links=${links}
 
 Verify Logged In Users Are Displayed In The Dashboard
@@ -724,3 +728,8 @@ Check And Uninstall Operator In Openshift
         END
     END
     Close All Browsers
+
+Documentation Links Should Be Equal To The Expected Ones
+    [Arguments]     ${actual_links}     ${expected_links}
+
+    Lists Should Be Equal   ${actual_links}    ${expected_links}    ignore_order=True


### PR DESCRIPTION
The automation of ODS-327 does not check the links are the expected ones. This PR adds this check
Signed-off-by: bdattoma <bdattoma@redhat.com>