### PR TITLE
Verify cuda buildchain in smoke pipeline

### DIFF
--- a/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
+++ b/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
@@ -4,6 +4,7 @@ Library    OpenShiftLibrary
 Resource   ../../OCPDashboard/Page.robot
 Resource   ../../ODH/ODHDashboard/ODHDashboard.robot
 
+
 *** Keywords ***
 Get Build Status
   [Arguments]  ${namespace}  ${build_search_term}
@@ -68,10 +69,20 @@ Get Build Status From Oc
     [Return]    ${status}
 
 Build Status Should Be
-    [Documentation]    Get status and check with ${expected_status}
+    [Documentation]    Gets build status and fails if not equal to  ${expected_status}
     [Arguments]    ${namespace}    ${build_name}    ${expected_status}=Complete
     ${status} =    Get Build Status From Oc    namespace=${namespace}    build_name=${build_name}
-    Should Be Equal    ${status}    ${expected_status}
+    IF    "${status}" != "${expected_status}"
+       Fail    msg=Unexpected Build status for ${build_name} (expected_status: ${expected_status}, status: ${status})
+    END
+
+Build Status Should Not Be
+    [Documentation]    Gets build status and fails if equal to ${unexpected_status}
+    [Arguments]    ${namespace}    ${build_name}    ${unexpected_status}=Error
+    ${status} =    Get Build Status From Oc    namespace=${namespace}    build_name=${build_name}
+    IF    "${status}" == "${unexpected_status}"
+       Fail    msg=Build ${build_name} shoud not have build status ${unexpected_status}
+    END
 
 Wait Until Build Status Is
     [Documentation]    Check status build with ${expected_status} for every min until is succeed or timeout
@@ -80,17 +91,23 @@ Wait Until Build Status Is
     ...    Build Status Should Be    ${namespace}    ${build_name}    ${expected_status}
 
 Wait Until All Builds Are Complete
-    [Documentation]     Obtains the list of builds in ${namespace} and, for each of
-    ...    them,  fails if state is Failed or Error.  If not, waits until state
-    ...    is Complete or ${build_timeout} is reached
+    [Documentation]     Obtains the list of buildsconfigs in ${namespace} and, for each of
+    ...    them,  search the last build with similar name and fails if state is Failed or Error.
+    ...    If not, waits until state is Complete or ${build_timeout} is reached
     [Arguments]    ${namespace}    ${build_timeout}=20 min
-    ${builds_data} =  Oc Get  kind=Build  namespace=${namespace}
-    FOR    ${build_data}    IN    @{builds_data}
-        ${build_name} =     Set Variable    ${build_data['metadata']['name']}
-        ${build_status} =    Set Variable    ${build_data['status']['phase']}
-        IF    "${build_status}" == "Failed" or "${build_status}" == "Error"
-            Fail    msg=Build ${build_name} is in ${build_status} state
+
+    ${buildconfigs_data} =  Oc Get  kind=BuildConfig  namespace=${namespace}
+
+    FOR    ${buildconfig_data}    IN    @{buildconfigs_data}
+        ${buildconfig_name} =     Set Variable    ${buildconfig_data['metadata']['name']}
+        ${build_name} =    Search Last Build    namespace=${namespace}   build_name_includes=${buildconfig_name}
+        IF    "${build_name}" == "${EMPTY}"
+            Log    level=WARN    message=No builds found matching ${buildconfig_name} in ${namespace} namespace
         ELSE
+            Build Status Should Not Be    namespace=${namespace}    build_name=${build_name}
+            ...    unexpected_status=Error
+            Build Status Should Not Be    namespace=${namespace}    build_name=${build_name}
+            ...    unexpected_status=Failed
             Wait Until Build Status Is    namespace=${namespace}    build_name=${build_name}
             ...   expected_status=Complete    timeout=${build_timeout}
         END

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -141,7 +141,7 @@ Verify That CUDA Build Chain Succeeds
     ...    Pytorch and Tensorflow can be spawned successfully
     [Tags]    Smoke
     ...       Tier1
-    ...       ODS-316
+    ...       ODS-316    ODS-481
     Wait Until All Builds Are Complete    namespace=redhat-ods-applications
     Verify Image Can Be Spawned    image=minimal-gpu    size=Default
     Verify Image Can Be Spawned    image=pytorch        size=Default

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -136,14 +136,16 @@ Verify Oath-Proxy Image Is fetched From CPaaS
     Verify Container Image      redhat-ods-applications     ${pod}      oauth-proxy
     ...     "registry.redhat.io/openshift4/ose-oauth-proxy:v4.8"
 
-Verify Pytorch And Tensorflow Can Be Spawned
-    [Documentation]    Check Cuda builds are complete and  Verify Pytorch and Tensorflow can be spawned
-    [Tags]    Sanity
+Verify That CUDA Build Chain Succeeds
+    [Documentation]    Check Cuda builds are complete. Verify CUDA (minimal-gpu),
+    ...    Pytorch and Tensorflow can be spawned successfully
+    [Tags]    Smoke
     ...       Tier1
-    ...       ODS-480  ODS-481
+    ...       ODS-316
     Wait Until All Builds Are Complete    namespace=redhat-ods-applications
-    Verify Image Can Be Spawned    image=pytorch  size=Default
-    Verify Image Can Be Spawned    image=tensorflow  size=Default
+    Verify Image Can Be Spawned    image=minimal-gpu    size=Default
+    Verify Image Can Be Spawned    image=pytorch        size=Default
+    Verify Image Can Be Spawned    image=tensorflow     size=Default
 
 Verify That Blackbox-exporter Is Protected With Auth-proxy
     [Documentation]    Vrifies the blackbok-exporter inludes 2 containers one for application and second for oauth proxy


### PR DESCRIPTION
- Fix keyword `Wait Until All Builds Are Complete` to iterate the buildconfigs instead of the builds
- Add `Verify That CUDA Build Chain Succeeds` to smoke.
    - Previously this test was called `Verify Pytorch And Tensorflow Can Be Spawned` but that test doesn't exist in Polarion anymore and neither the polarion id's ODS-480 and ODS-481