### PR TITLE
Update ODS-488 to remove perceptilabs check for Jupyter (instead of JupyterHub)

### DIFF
--- a/tests/Resources/Files/AppsInfoDictionary.json
+++ b/tests/Resources/Files/AppsInfoDictionary.json
@@ -360,26 +360,48 @@
                }
         },
         "starburst": {
-             "badges": ["Partner managed"],
-             "provider": "by Starburst",
-             "title": "Starburst Galaxy",
-             "description": "Starburst Galaxy is a fully managed service to run high-performance queries across your various data sources using SQL.",
-             "image": "/images/starburst.svg",
-             "sidebar_h1": "Starburst Galaxy",
+            "badges": [
+                "Partner managed"
+            ],
+            "provider": "by Starburst",
+            "title": "Starburst Galaxy",
+            "description": "Starburst Galaxy is a fully managed service to run high-performance queries across your various data sources using SQL.",
+            "image": "/images/starburst.svg",
+            "sidebar_h1": "Starburst Galaxy",
+            "sidebar_links": {
+                "0": {
+                    "text": "Get started",
+                    "url": "https://www.starburst.io/platform/starburst-galaxy/",
+                    "matching": ""
+                },
+                "1": {
+                    "text": "Starburst Galaxy",
+                    "url": "https://docs.starburst.io/starburst-galaxy/",
+                    "matching": ""
+                },
+                "2": {
+                    "text": "here",
+                    "url": "https://www.starburst.io/platform/starburst-galaxy/",
+                    "matching": ""
+                }
+            }
+        },
+       "nvidia": {
+             "badges": ["Self-managed"],
+             "provider": "by NVIDIA",
+             "title": "NVIDIA GPU Add-on",
+             "description": "NVIDIA GPU Add-on prepares OpenShift to run GPU-accelerated workloads on a single node or on multiple nodes.",
+             "image": "/images/nvidia.svg",
+             "sidebar_h1": "NVIDIA GPU Add-on",
              "sidebar_links": {
                    "0": {
                          "text": "Get started",
-                         "url": "https://www.starburst.io/platform/starburst-galaxy/",
+                         "url": "https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/enabling-gpu-support-in-openshift-data-science_user-mgmt",
                          "matching": ""
                    },
                    "1": {
-                         "text": "Starburst Galaxy",
-                         "url": "https://docs.starburst.io/starburst-galaxy/",
-                         "matching": ""
-                   },
-                   "2": {
-                         "text": "here",
-                         "url": "https://www.starburst.io/platform/starburst-galaxy/",
+                         "text": "Enabling GPU Support in Openshift Data Science",
+                         "url": "https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/enabling-gpu-support-in-openshift-data-science_user-mgmt",
                          "matching": ""
                    }
                }

--- a/tests/Resources/Files/AppsInfoDictionary_latest.json
+++ b/tests/Resources/Files/AppsInfoDictionary_latest.json
@@ -304,16 +304,6 @@
                    }
                }
         },
-        "perceptiLabs": {
-             "badges": ["Coming soon"],
-             "provider": "by PercetiLabs",
-             "title": "PerceptiLabs",
-             "description": "PerceptiLabs is a visual modeling tool for editing, managing, and monitoring your machine learning models.",
-             "image": "/images/percepti-labs.svg",
-             "sidebar_h1": "PerceptiLabs",
-             "sidebar_links": {}
-
-        },
         "seldon-deploy": {
              "badges": ["Self-managed"],
              "provider": "by Seldon",

--- a/tests/Resources/Files/AppsInfoDictionary_latest.json
+++ b/tests/Resources/Files/AppsInfoDictionary_latest.json
@@ -92,69 +92,24 @@
                    }
                }
         },
-        "jupyterhub": {
+        "jupyter": {
              "badges": ["Red Hat managed"],
              "provider": "by Jupyter",
-             "title": "JupyterHub",
-             "description": "JupyterHub is a multi-user version of the notebook designed for companies, classrooms, and research labs.",
-             "image": "/images/jupyterhub.svg",
-             "sidebar_h1": "JupyterHub",
+             "title": "Jupyter",
+             "description": "A multi-user version of the notebook designed for companies, classrooms and research labs.",
+             "image": "/images/jupyter.svg",
+             "sidebar_h1": "Jupyter",
              "sidebar_links": {
 
                    "0": {
                          "text": "Get started",
-                         "url": "https://jupyterhub.readthedocs.io/en/stable/getting-started/index.html",
+                         "url": "https://jupyterlab.readthedocs.io/en/stable/getting_started/overview.html",
                          "matching": "full"
                    },
                    "1": {
-                         "text": "Python",
-                         "url": "https://www.python.org/downloads/",
-                         "matching": ""
-                   },
-                   "2": {
-                         "text": "pip",
-                         "url": "https://pip.pypa.io/en/stable/",
-                         "matching": ""
-                   },
-                   "3": {
-                         "text": "conda",
-                         "url": "https://conda.io/docs/get-started.html",
-                         "matching": ""
-                   },
-                   "4": {
-                         "text": "nodejs/npm",
-                         "url": "https://www.npmjs.com/",
-                         "matching": ""
-                   },
-                   "5": {
-                         "text": "Install nodejs/npm",
-                         "url": "https://docs.npmjs.com/getting-started/installing-node",
-                         "matching": ""
-                   },
-                   "6": {
-                         "text": "nodejs/npm",
-                         "url": "https://docs.npmjs.com/getting-started/installing-node",
-                         "matching": ""
-                   },
-                   "7": {
-                         "text": "pluggable authentication module (PAM)",
-                         "url": "https://en.wikipedia.org/wiki/Pluggable_authentication_module",
-                         "matching": ""
-                   },
-                   "8": {
-                         "text": "default Authenticator",
-                         "url": "getting-started/authenticators-users-basics.md",
-                         "matching": "partial"
-                   },
-                   "9": {
-                         "text": "Jupyter Notebook",
-                         "url": "https://jupyter.readthedocs.io/en/latest/install.html",
-                         "matching": ""
-                   },
-                   "10": {
-                         "text": "wiki",
-                         "url": "https://github.com/jupyterhub/jupyterhub/wiki/Using-sudo-to-run-JupyterHub-without-root-privileges",
-                         "matching": ""
+                         "text": "Adding users for OpenShift Data Science",
+                         "url": "https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/adding-users-for-openshift-data-science_useradd",
+                         "matching": "full"
                    }
              }
         },

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -75,7 +75,6 @@ Logout From RHODS Dashboard
     Wait Until Page Contains  Log in with OpenShift
 
 Wait for RHODS Dashboard to Load
-  #[Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science Dashboard"   # Temporary workaround to use ODH cluster
   [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"
   Wait For Condition  return document.title == ${dashboard_title}  timeout=15
 

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -75,8 +75,7 @@ Logout From RHODS Dashboard
     Wait Until Page Contains  Log in with OpenShift
 
 Wait for RHODS Dashboard to Load
-  #[Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science Dashboard"
-  # Temporary workaround to use ODH cluster
+  #[Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science Dashboard"   # Temporary workaround to use ODH cluster
   [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"
   Wait For Condition  return document.title == ${dashboard_title}  timeout=15
 
@@ -166,7 +165,7 @@ Go To RHODS Dashboard
   Wait for RHODS Dashboard to Load
 
 Load Expected Data Of RHODS Explore Section
-    ${version-check}=   Is RHODS Version Greater Or Equal Than  1.13.0
+    ${version-check}=   Is RHODS Version Greater Or Equal Than  1.16.0
     IF  ${version-check}==True
         ${apps_dict_obj}=  Load Json File  ${APPS_DICT_PATH_LATEST}
     ELSE


### PR DESCRIPTION
RHODS v1.16 is going to remove Perceptilabs from the applications in "Explore" page. This PR applies the necessary change for ODS-488

It also include a fix for ODS-488 to account new Jupyter tile.

Signed-off-by: bdattoma <bdattoma@redhat.com>