### PR TITLE
Minor Fixes

### DIFF
--- a/build/ods-ci.pod.yaml
+++ b/build/ods-ci.pod.yaml
@@ -25,12 +25,13 @@ spec:
   containers:
     - resources:
         limits:
-          cpu: 2
-          memory: 2G
+            cpu: 2
+            memory: 2G
         requests:
-          cpu: 1
-          memory: 800M
-    - image: <INSERT URL TO YOUR BUILT IMAGE>
+            cpu: 1
+            memory:
+                800M
+      image: <INSERT URL TO YOUR BUILT IMAGE>
       imagePullPolicy: Always
       name: ods-ci-testrun
       env:

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -92,7 +92,7 @@ Verify Service Is Enabled
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Enabled
   Wait Until Page Contains    JupyterHub  timeout=30
-  Wait Until Page Contains    ${app_name}  timeout=180
+  Wait Until Page Contains    ${app_name}  timeout=240
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..   message=${app_name} should be enabled in ODS Dashboard
   Page Should Not Contain Element    xpath://article//*[.='${app_name}']/..//div[contains(@class,'enabled-controls')]/span[contains(@class,'disabled-text')]  message=${app_name} is marked as Disabled. Check the license
 
@@ -123,7 +123,7 @@ Remove Disabled Application From Enabled Page
    ${buttons_here}=  Get WebElements    xpath://div[contains(@class,'popover__body')]//button[text()='here']
    Click Element  ${buttons_here}[1]
    Wait Until Page Does Not Contain Element    xpath://article[@id='${app_id}']
-   Capture Page Screenshot  disabled_card_removed.png
+   Capture Page Screenshot  ${app_id}_removed.png
 
 
 Verify Service Provides "Enable" Button In The Explore Page

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -245,7 +245,7 @@ Verify RHODS Dashboard Explore And Enabled Page Has No Message With No Component
     ...     configmap in openshift
     ...     ProductBug:RHODS-4308
     [Setup]   Test Setup For Rhods Dashboard
-    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=rhods-enabled-applications-config    src={"data":null}   #robocop: disable
+    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=odh-enabled-applications-config    src={"data":null}   #robocop: disable
     Delete Dashboard Pods And Wait Them To Be Back
     Reload Page
     Menu.Navigate To Page    Applications   Enabled

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -271,7 +271,7 @@ Test Setup For Rhods Dashboard
 
 Test Teardown For Configmap Changed On RHODS Dashboard
     [Documentation]    Test Teardown for Configmap changes on Rhods Dashboard
-    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=odh-enabled-applications-config    src={"data": {"jupyterhub": "true"}}   #robocop: disable
+    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=odh-enabled-applications-config    src={"data": {"jupyter": "true"}}   #robocop: disable
     Delete Dashboard Pods And Wait Them To Be Back
     Close All Browsers
 

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -241,7 +241,7 @@ Verify RHODS Dashboard Explore And Enabled Page Has No Message With No Component
     ...     ODS-1556
     ...     ProductBug
     [Documentation]   Verify "NO Component Found" message dosen't display
-    ...     on Rhods Dashbord page with data value empty for rhods-enabled-applications-config
+    ...     on Rhods Dashbord page with data value empty for odh-enabled-applications-config
     ...     configmap in openshift
     ...     ProductBug:RHODS-4308
     [Setup]   Test Setup For Rhods Dashboard
@@ -271,7 +271,7 @@ Test Setup For Rhods Dashboard
 
 Test Teardown For Configmap Changed On RHODS Dashboard
     [Documentation]    Test Teardown for Configmap changes on Rhods Dashboard
-    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=rhods-enabled-applications-config    src={"data": {"jupyterhub": "true"}}   #robocop: disable
+    Oc Patch    kind=ConfigMap      namespace=redhat-ods-applications    name=odh-enabled-applications-config    src={"data": {"jupyterhub": "true"}}   #robocop: disable
     Delete Dashboard Pods And Wait Them To Be Back
     Close All Browsers
 

--- a/tests/Tests/500__jupyterhub/test-jupyterhub-api-telemetry.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterhub-api-telemetry.robot
@@ -72,7 +72,7 @@ JupyterHub API Should Exposes SegmentKey
 
 Switch To RHODS Dashboard
     [Documentation]     Switch tab to RHODS dashboard
-    Switch Window    title=Red Hat OpenShift Data Science Dashboard
+    Switch Window    title=Red Hat OpenShift Data Science
     Sleep    1s    msg=Wait for to change tab
 
 Switch To JupyterHub API Tab

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -107,4 +107,4 @@ Verify Anaconda In Kfdef
     FOR    ${application}    IN    @{res[0]['spec']['applications']}
         Append To List    ${applications_names}  ${application['name']}
     END
-    Should Contain  ${applications_names}  rhods-anaconda
+    Run Keyword And Continue On Failure     Should Contain  ${applications_names}  rhods-anaconda

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -93,6 +93,9 @@ Verify User Is Able to Activate Anaconda Professional
   Verify Anaconda Element Present Based On Version
   [Teardown]    Remove Anaconda Component
 
+Test kfdef
+    [Tags]  kfdef
+    Verify Anaconda In Kfdef
 
 *** Keywords ***
 Anaconda Suite Setup
@@ -107,4 +110,4 @@ Verify Anaconda In Kfdef
     FOR    ${application}    IN    @{res[0]['spec']['applications']}
         Append To List    ${applications_names}  ${application['name']}
     END
-    Run Keyword And Continue On Failure     Should Contain  ${applications_names}  rhods-anaconda
+    Run Keyword And Continue On Failure     Should Contain  ${applications_names}  anaconda-ce

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -72,7 +72,7 @@ Verify User Is Able to Activate Anaconda Professional
   ...                                   pod_search_term=anaconda-ce-periodic-validator-job-custom-run
   Log  ${val_result}
   Should Be Equal  ${val_result[0]}  ${VAL_SUCCESS_MSG}
-  Wait Until Keyword Succeeds    1200  1  Check Anaconda CE Image Build Status  Complete
+  Wait Until Keyword Succeeds    400  5s  Check Anaconda CE Image Build Status  Complete
   Go To  ${ODH_DASHBOARD_URL}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Launch JupyterHub Spawner From Dashboard

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -103,8 +103,10 @@ Anaconda Suite Setup
 Verify Anaconda In Kfdef
     [Documentation]  Verifies if Anaconda is present in Kfdef
     ${res}=  Oc Get  kind=KfDef  namespace=redhat-ods-applications
-    @{applications_names} =  Create List
-    FOR    ${application}    IN    @{res[0]['spec']['applications']}
-        Append To List    ${applications_names}  ${application['name']}
+    @{applications_names}=    Create List
+    FOR     ${kfdef}    IN    @{res}
+        FOR    ${application}    IN    @{kfdef['spec']['applications']}
+            Append To List    ${applications_names}  ${application['name']}
+        END
     END
     Run Keyword And Continue On Failure     Should Contain  ${applications_names}  anaconda-ce

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -72,7 +72,7 @@ Verify User Is Able to Activate Anaconda Professional
   ...                                   pod_search_term=anaconda-ce-periodic-validator-job-custom-run
   Log  ${val_result}
   Should Be Equal  ${val_result[0]}  ${VAL_SUCCESS_MSG}
-  Wait Until Keyword Succeeds    400  5s  Check Anaconda CE Image Build Status  Complete
+  Wait Until Keyword Succeeds    400 times  5s  Check Anaconda CE Image Build Status  Complete
   Go To  ${ODH_DASHBOARD_URL}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Launch JupyterHub Spawner From Dashboard

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -107,4 +107,4 @@ Verify Anaconda In Kfdef
     FOR    ${application}    IN    @{res[0]['spec']['applications']}
         Append To List    ${applications_names}  ${application['name']}
     END
-    Should Contain  ${applications_names}  anaconda-ce
+    Should Contain  ${applications_names}  rhods-anaconda

--- a/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
+++ b/tests/Tests/600__ai_apps/600__anaconda_commercial_edition/600__anaconda_commercial_edition.robot
@@ -93,9 +93,6 @@ Verify User Is Able to Activate Anaconda Professional
   Verify Anaconda Element Present Based On Version
   [Teardown]    Remove Anaconda Component
 
-Test kfdef
-    [Tags]  kfdef
-    Verify Anaconda In Kfdef
 
 *** Keywords ***
 Anaconda Suite Setup

--- a/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
+++ b/tests/Tests/600__ai_apps/650__rhosak/650__rhosak.robot
@@ -87,7 +87,7 @@ Verify User Is Able to Produce and Consume Events
   ...                                             topic_to_assign=${TOPIC_NAME_TEST}  cg_to_assign=${CONSUMER_GROUP_TEST}
 
   ## Spawn a notebook with env variables
-  Switch Window  title:Red Hat OpenShift Data Science Dashboard
+  Switch Window  title:Red Hat OpenShift Data Science
   Wait for RHODS Dashboard to Load
   Launch JupyterHub Spawner From Dashboard
   Wait Until Page Contains Element  xpath://input[@name="Standard Data Science"]

--- a/tests/Tests/700__sandbox/700__sandbox.robot
+++ b/tests/Tests/700__sandbox/700__sandbox.robot
@@ -52,7 +52,7 @@ Verify That Idle JupyterLab Servers Are Culled In Sandbox Environment After 24h
     ...        Execution-Time-Over-1d
     Spawn Notebook With Arguments
     ${jl_title}     Get Title
-    Switch Window    title=Red Hat OpenShift Data Science Dashboard
+    Switch Window    title=Red Hat OpenShift Data Science
     Sleep    24h
     Switch Window     title=${jl_title}
     Wait Until Keyword Succeeds    120    2


### PR DESCRIPTION
1) Verify User Is Able to Activate Anaconda Professional. 
The kw which is checking the KfDef takes only the first KfDef instead of looping over all of them. Since in v1.15 Anaconda has its own KfDef, the kw is not able to capture it.

2) Verify Intel AIKIT Operator Can Be Installed Using OpenShift Console. 
Increased the time for checking if the service is available in the dashboard

3) Verify User Is Able to Produce and Consume Events (RHOSAK)
RHODS Dashboard changed Window title in the last release, so this PR changes it in the TC

4) Keyword "Remove Disabled Application From Enabled Page"
screenshot is replaced everytime by the last TC run because it uses static name. PR changes it by appending the ISV app id in the screenshot title

5) ods-ci.pod.yaml
Syntax error fixed

6) test case "Verify That Idle JupyterLab Servers Are Culled In Sandbox Environment After 24h" 
RHODS Dashboard changed Window title in the last release, so this PR changes it in the TC

7) test case "Verify RHODS Dashboard Explore And Enabled Page Has No Message With No Component Found". A config map has changed title breaking the TC. The title will be changed back but for the moment I will patch the TC to work with the new name (bug has been raised)

Signed-off-by: bdattoma <bdattoma@redhat.com>