### PR TITLE
Increase build timeout when waiting for CUDA builds

### DIFF
--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -143,6 +143,7 @@ Verify That CUDA Build Chain Succeeds
     ...       Tier1
     ...       ODS-316    ODS-481
     Wait Until All Builds Are Complete    namespace=redhat-ods-applications
+    ...    build_timeout=45m
     Verify Image Can Be Spawned    image=minimal-gpu    size=Default
     Verify Image Can Be Spawned    image=pytorch        size=Default
     Verify Image Can Be Spawned    image=tensorflow     size=Default


### PR DESCRIPTION
Sometimes builds are in Pending state for 10-15 mins before they start Running. Timeout should be longer in order for this test to pass

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>