### PR TITLE
Update telemetry configmap and secret for kubeflow. Fix RHOSi Setup when prometheus is not running

### DIFF
--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -50,13 +50,10 @@ Restore Default Deployment Sizes
     END
 
 Verify "Usage Data Collection" Key
-    [Documentation]    Verifies that "Usage Data Collection" is using the expcected segment.io key
-    ${version_check}=    Is RHODS Version Greater Or Equal Than    1.8.0
-    IF    ${version_check}==True
-        ${segment_key}=    ODS.Get "Usage Data Collection" Key
-        Should Be Equal As Strings    ${segment_key}    ${USAGE_DATA_COLLECTION_DEFAULT_SEGMENT_PUBLIC_KEY}
-        ...    msg=Unexpected "Usage Data Collection" Key
-    END
+    [Documentation]    Verifies that "Usage Data Collection" is using the expected segment.io key
+    ${segment_key}=    ODS.Get "Usage Data Collection" Key
+    Should Be Equal As Strings    ${segment_key}    ${USAGE_DATA_COLLECTION_DEFAULT_SEGMENT_PUBLIC_KEY}
+    ...    msg=Unexpected "Usage Data Collection" Key
 
 Get "Usage Data Collection" Key
     [Documentation]    Returns the segment.io key used for usage data collection

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -62,8 +62,8 @@ Get "Usage Data Collection" Key
     [Documentation]    Returns the segment.io key used for usage data collection
 
     ${rc}    ${usage_data_collection_key_base64}=    Run And Return Rc And Output
-    ...    oc get secret rhods-segment-key -n redhat-ods-applications -o jsonpath='{.data.segmentKey}'
-    Should Be Equal As Integers    ${rc}    0    msg=rhods-segment-key secret not found or not having the right format
+    ...    oc get secret odh-segment-key -n redhat-ods-applications -o jsonpath='{.data.segmentKey}'
+    Should Be Equal As Integers    ${rc}    0    msg=odh-segment-key secret not found or not having the right format
 
     ${usage_data_collection_key}=    Evaluate
     ...    base64.b64decode("${usage_data_collection_key_base64}").decode('utf-8')    modules=base64
@@ -71,10 +71,10 @@ Get "Usage Data Collection" Key
     [Return]    ${usage_data_collection_key}
 
 Is Usage Data Collection Enabled
-    [Documentation]    Returns a boolean with the value of configmap rhods-segment-key-config > segmentKeyEnabled
+    [Documentation]    Returns a boolean with the value of configmap odh-segment-key-config > segmentKeyEnabled
     ...    which can be seen also in ODS Dashboard > Cluster Settings > "Usage Data Collection"
     ${usage_data_collection_enabled}=    Run
-    ...    oc get configmap rhods-segment-key-config -n redhat-ods-applications -o jsonpath='{.data.segmentKeyEnabled}'
+    ...    oc get configmap odh-segment-key-config -n redhat-ods-applications -o jsonpath='{.data.segmentKeyEnabled}'
     ${usage_data_collection_enabled}=    Convert To Boolean    ${usage_data_collection_enabled}
     [Return]    ${usage_data_collection_enabled}
 

--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -119,12 +119,12 @@ Suite Availability Setup
     [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
     ...    Log a WARN message if availability is under 99.95
     [Arguments]    ${pm_url}    ${pm_token}
-    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
+    Run Keyword And Warn On Failure    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
 
 Suite Availability Teardown
     [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
     ...    Logs a WARN message if the current values are lower
     [Arguments]    ${pm_url}    ${pm_token}
 
-    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
+    Run Keyword And Warn On Failure    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
     ...    message_prefix=Suite Teardown: ${SUITE NAME}:

--- a/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
+++ b/tests/Tests/400__ods_dashboard/410__ods_dashboard_settings.robot
@@ -36,10 +36,11 @@ Verify That Not Admin Users Can Not Access "Cluster Settings"
 
 Verify That "Usage Data Collection" Can Be Set In "Cluster Settings"
     [Documentation]    Verifies that a user can set the "Usage Data Collection" flag in "Cluster Settings"
+    ...    ProductBug: RHODS-4923
     [Tags]    Tier1
     ...       Sanity
     ...       ODS-1218
-    ...       FlakyTest
+    ...       ProductBug
     Open ODS Dashboard With Admin User
     Verify Cluster Settings Is Available
     ODHDashboard.Enable "Usage Data Collection"


### PR DESCRIPTION
- Update configmap and secret releated to telemetry 
- Modify RHOSi Setup/Teardown to keep running the tests suites even if rhods_aggregate_availability metric is not present. Show a warning in that case