### PR TITLE
Add optional RHODS_VERSION predefined variable

### DIFF
--- a/tests/Resources/Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
+++ b/tests/Resources/Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
@@ -94,7 +94,11 @@ Get RHODS version
     #@{list} =  OpenShiftCLI.Get  kind=ClusterServiceVersion  label_selector=olm.copiedFrom=redhat-ods-operator
     #&{dict} =  Set Variable  ${list}[0]
     #Log  ${dict.spec.version}
-    ${ver} =  Run  oc get csv -n redhat-ods-operator | grep "rhods-operator" | awk '{print $1}' | sed 's/rhods-operator.//'
+    ${ver} =  Get Environment Variable  RHODS_VERSION  ${None}
+    IF  "${ver}" == "${None}"
+        ${ver} =  Run  oc get csv -n redhat-ods-operator | grep "rhods-operator" | awk '{print $1}' | sed 's/rhods-operator.//'
+    END
+
     Log  ${ver}
     [Return]  ${ver}
 


### PR DESCRIPTION
This PR allows passing `RHODS_VERSION` in the test-variable file, so that the call to `oc get csv` can be avoided.

Signed-off-by: Kevin Pouget <kpouget@redhat.com>