### PR TITLE
[KFNBC] Adapt different TCs to work with KFNBC and without old config maps

### DIFF
--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -106,24 +106,21 @@ Set Standard RHODS Groups Variables
 Apply Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
     ...                and rolls out JH to make the changes effecting in Jupyter
-    [Arguments]     ${admins_group}   ${users_group}    ${groups_modified_flag}
-    Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}    groups_modified_flag=${groups_modified_flag}
-    Rollout JupyterHub
+    [Arguments]     ${admins_group}   ${users_group}
+    Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}
+    Sleep    40     reason=Wait for Dashboard to get the updated configuration...
 
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
-    [Arguments]     ${admins_group}   ${users_group}    ${groups_modified_flag}
-    OpenShiftCLI.Patch    kind=ConfigMap
-    ...                   src={"data":{"admin_groups": "${admins_group}","allowed_groups": "${users_group}"}}
-    ...                   name=rhods-groups-config   namespace=redhat-ods-applications  type=merge
-    OpenShiftCLI.Patch    kind=ConfigMap
-    ...                   src={"metadata":{"labels": {"opendatahub.io/modified": "${groups_modified_flag}"}}}
-    ...                   name=rhods-groups-config   namespace=redhat-ods-applications  type=merge
+    [Arguments]     ${admins_group}   ${users_group}
+    OpenShiftCLI.Patch    kind=OdhDashboardConfig
+    ...                   src={"spec": {"groupsConfig": {"adminGroups": "${admins_group}","allowedGroups": "${users_group}"}}}
+    ...                   name=odh-dashboard-config   namespace=redhat-ods-applications  type=merge
 
 Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map
     Apply Access Groups Settings     admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=${STANDARD_GROUPS_MODIFIED}
+    ...     users_group=${STANDARD_USERS_GROUP}
 
 Uninstall RHODS From OSD Cluster
     [Documentation]    Selects the cluster type and triggers the RHODS uninstallation

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -108,7 +108,7 @@ Apply Access Groups Settings
     ...                and rolls out JH to make the changes effecting in Jupyter
     [Arguments]     ${admins_group}   ${users_group}
     Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}
-    Sleep    60     reason=Wait for Dashboard to get the updated configuration...
+    Sleep    90     reason=Wait for Dashboard to get the updated configuration...
 
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -108,7 +108,7 @@ Apply Access Groups Settings
     ...                and rolls out JH to make the changes effecting in Jupyter
     [Arguments]     ${admins_group}   ${users_group}
     Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}
-    Sleep    50     reason=Wait for Dashboard to get the updated configuration...
+    Sleep    60     reason=Wait for Dashboard to get the updated configuration...
 
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -108,7 +108,7 @@ Apply Access Groups Settings
     ...                and rolls out JH to make the changes effecting in Jupyter
     [Arguments]     ${admins_group}   ${users_group}
     Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}
-    Sleep    90     reason=Wait for Dashboard to get the updated configuration...
+    Sleep    120     reason=Wait for Dashboard to get the updated configuration...
 
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -108,7 +108,7 @@ Apply Access Groups Settings
     ...                and rolls out JH to make the changes effecting in Jupyter
     [Arguments]     ${admins_group}   ${users_group}
     Set Access Groups Settings    admins_group=${admins_group}   users_group=${users_group}
-    Sleep    40     reason=Wait for Dashboard to get the updated configuration...
+    Sleep    50     reason=Wait for Dashboard to get the updated configuration...
 
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration

--- a/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -16,13 +16,11 @@ Create Group
     [Documentation]     Creates a user group in OCP
     [Arguments]   ${group_name}
     OpenShiftCLI.Create  kind=Group   src={"metadata": {"name": "${group_name}"}, "users": null}
-    # Run   oc adm groups new ${group_name}
 
 Delete Group
     [Documentation]     Deletes a user group in OCP
     [Arguments]   ${group_name}
     OpenShiftCLI.Delete  kind=Group   name=${group_name}
-    # Run   oc delete group ${group_name}
 
 Add User To Group
     [Documentation]     Add a user to a given OCP user group
@@ -37,12 +35,12 @@ Remove User From Group
 Check User Is In A Group
     [Documentation]     Check if a user is present in OCP user group using UI
     [Arguments]  ${username}  ${group_name}
-    Go To ${group_name} Group Page
-    Page Should Contain Element    xpath://a[text()="${username}"]
+    ${users_in_group}=    OpenshiftLibrary.Oc Get    kind=Group   name=${group_name}    fields=['users']
+    List Should Contain Value    ${users_in_group}[0][users]    ${username}
 
 Check User Is Not In A Group
     [Documentation]     Check if a user is not present in OCP user group using UI
     [Arguments]  ${username}  ${group_name}
-    Go To ${group_name} Group Page
-    Page Should Not Contain Element    xpath://a[text()="${username}"]
+    ${users_in_group}=    OpenshiftLibrary.Oc Get    kind=Group   name=${group_name}    fields=['users']
+    List Should Not Contain Value    ${users_in_group}[0][users]    ${username}
 

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -296,26 +296,25 @@ Fix Spawner Status
 
 User Is Allowed
    [Documentation]  Checks if the user is allowed
-   JupyterHub Spawner Is Visible
-   Page Should Not Contain  403 : Forbidden
    ${spawner_ready} =    Run Keyword And Return Status    Wait Until JupyterHub Spawner Is Ready
    IF  ${spawner_ready}==False
       Fail    Spawner page was not ready
    END
+   Page Should Not Contain  Page Not Found
 
 User Is Not Allowed
    [Documentation]  Checks if the user is not allowed
-   JupyterHub Spawner Is Visible
-   Page Should Contain  403 : Forbidden
+   Wait Until Page Contains  Page Not Found     timeout=10
+   # Page Should Contain  403 : Forbidden
 
 User Is JupyterHub Admin
    [Documentation]  Checks if the user is an admin
-   JupyterHub Spawner Is Visible
+   Wait Until JupyterHub Spawner Is Ready
    Page Should Contain  Administration
 
 User Is Not JupyterHub Admin
    [Documentation]  Checks if the user is not an admin
-   JupyterHub Spawner Is Visible
+   Wait Until JupyterHub Spawner Is Ready
    Page Should Not Contain  Administration
 
 Logout Via Button

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -311,12 +311,12 @@ User Is Not Allowed
 User Is JupyterHub Admin
    [Documentation]  Checks if the user is an admin
    JupyterHub Spawner Is Visible
-   Page Should Contain  Admin
+   Page Should Contain  Administration
 
 User Is Not JupyterHub Admin
    [Documentation]  Checks if the user is not an admin
    JupyterHub Spawner Is Visible
-   Page Should Not Contain  Admin
+   Page Should Not Contain  Administration
 
 Logout Via Button
    [Documentation]  Logs out from JupyterHub

--- a/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
@@ -23,11 +23,8 @@ Authorize jupyterhub service account
   Checkbox Should Be Selected  user:info
   Click Element  approve
 
-Login Verify Access Level
+Verify Jupyter Access Level
    [Arguments]  ${username}  ${password}  ${auth}  ${expected_result}
-   Login To Jupyterhub  ${username}  ${password}  ${auth}
-   ${authorization_required} =  Is Service Account Authorization Required
-   Run Keyword If  ${authorization_required}  Authorize jupyterhub service Account
    IF  '${expected_result}'=='none'
      User Is Not Allowed
    ELSE IF  '${expected_result}'=='admin'

--- a/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
@@ -24,7 +24,7 @@ Authorize jupyterhub service account
   Click Element  approve
 
 Verify Jupyter Access Level
-   [Arguments]  ${username}  ${password}  ${auth}  ${expected_result}
+   [Arguments]    ${expected_result}
    IF  '${expected_result}'=='none'
      User Is Not Allowed
    ELSE IF  '${expected_result}'=='admin'
@@ -32,4 +32,3 @@ Verify Jupyter Access Level
    ELSE IF  '${expected_result}'=='user'
      User Is Not JupyterHub Admin
    END
-   Capture Page Screenshot  verify-access-level-{$expected_result}.png

--- a/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
+++ b/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
@@ -40,7 +40,7 @@ Verify User Is Unable To Spawn Notebook
     [Documentation]    Verifies User is unable to access notebooks in jupyterhub
     Launch Dashboard    ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}  ${ODH_DASHBOARD_URL}  ${BROWSER.NAME}  ${BROWSER.OPTIONS}
     Launch Jupyter From RHODS Dashboard Link
-    Login Verify Access Level    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}    none
+    Verify Jupyter Access Level    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}    none
 
 Set Default Access Groups And Close Browser
     [Documentation]  Sets values of RHODS Groups to Default Values and closes browser

--- a/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
+++ b/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
@@ -17,12 +17,12 @@ Verify Default Access Groups Settings And JupyterLab Notebook Access
     [Teardown]  End Web Test
 
 Verify Empty Group Doesnt Allow Users To Spawn Notebooks
-    [Documentation]   Verifies that User is unable to Access Jupyterhub after setting Access Groups in rhods-groups-config to Empty
+    [Documentation]   Verifies that User is unable to Access Jupyterhub after setting Access Groups OdhDashboardConfig CRD to Empty
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-572
     ...       FlakyTest
-    Apply Access Groups Settings    admins_group=    users_group=    groups_modified_flag=true
+    Apply Access Groups Settings    admins_group=    users_group=
     Verify User Is Unable To Spawn Notebook
     [Teardown]   Set Default Access Groups And Close Browser
 

--- a/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
+++ b/tests/Tests/100__deploy/110__auth_providers_and_rbac/110__rbac.robot
@@ -40,7 +40,7 @@ Verify User Is Unable To Spawn Notebook
     [Documentation]    Verifies User is unable to access notebooks in jupyterhub
     Launch Dashboard    ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}  ${ODH_DASHBOARD_URL}  ${BROWSER.NAME}  ${BROWSER.OPTIONS}
     Launch Jupyter From RHODS Dashboard Link
-    Verify Jupyter Access Level    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}    none
+    Verify Jupyter Access Level    expected_result=none
 
 Set Default Access Groups And Close Browser
     [Documentation]  Sets values of RHODS Groups to Default Values and closes browser

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -253,7 +253,7 @@ Verify Error Message In Logs When A RHODS Group Is Empty
     ...     ODS-1408
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an empty group
-    ...                 is set as admin in "rhods-group-config" ConfigMap
+    ...                 is set as admin in OdhDashboardConfig CRD
     [Setup]     Set Variables For Group Testing
     Create Group    group_name=${CUSTOM_EMPTY_GROUP}
     ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
@@ -270,7 +270,7 @@ Verify Error Message In Logs When A RHODS Group Does Not Exist
     ...     ODS-1494
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when an inexistent group
-    ...                 is set as admin in "rhods-group-config" ConfigMap
+    ...                 is set as admin in OdhDashboardConfig CRD
     [Setup]     Set Variables For Group Testing
     ${lengths_dict_before}=     Get Lengths Of Dashboard Pods Logs
     Set RHODS Admins Group To Inexistent Group
@@ -285,7 +285,7 @@ Verify Error Message In Logs When A RHODS Group Does Not Exist
 Verify Error Message In Logs When All Authenticated Users Are Set As RHODS Admins
     [Documentation]     Verifies the messages printed out in the logs of
     ...                 dashboard pods are the ones expected when 'system:authenticated'
-    ...                 is set as admin in "rhods-group-config" ConfigMap
+    ...                 is set as admin in OdhDashboardConfig CRD
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-1500
@@ -412,31 +412,31 @@ Set RHODS Admins Group Empty Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
+    ...     users_group=${STANDARD_USERS_GROUP}
 
 Set RHODS Admins Group To system:authenticated    # robocop:disable
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=system:authenticated
-    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
+    ...     users_group=${STANDARD_USERS_GROUP}
 
 Set RHODS Users Group Empty Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_EMPTY_GROUP}   groups_modified_flag=true
+    ...     users_group=${CUSTOM_EMPTY_GROUP}
 
 Set RHODS Admins Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
     Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
+    ...     users_group=${STANDARD_USERS_GROUP}
 
 Set RHODS Users Group To Inexistent Group
     [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
     ...                 to the given inexistent group
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_INEXISTENT_GROUP}   groups_modified_flag=true
+    ...     users_group=${CUSTOM_INEXISTENT_GROUP}
 
 Set Default Groups And Check Logs Do Not Change
     [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
@@ -444,7 +444,7 @@ Set Default Groups And Check Logs Do Not Change
     [Arguments]     ${delete_group}=${FALSE}
     ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}   groups_modified_flag=true
+    ...     users_group=${STANDARD_USERS_GROUP}
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
     IF  "${delete_group}" == "${TRUE}"
         Delete Group    group_name=${CUSTOM_EMPTY_GROUP}

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -35,6 +35,7 @@ Verify User Can Set Custom RHODS Groups
     Remove Test Users From RHODS Standard Groups
     Set Custom Access Groups
     Check New Access Configuration Works As Expected
+    # add notebook spawning check
     [Teardown]   Restore Standard RHODS Groups Configuration
 
 
@@ -106,20 +107,17 @@ Check New Access Configuration Works As Expected
     Launch Dashboard   ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ...   ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
     Launch Jupyter From RHODS Dashboard Link
-    Run Keyword And Continue On Failure   Verify Jupyter Access Level  ${TEST_USER.USERNAME}
-    ...                                   ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}    none
+    Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=none
     Capture Page Screenshot    perm_denied_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_2.USERNAME}  ${TEST_USER_2.PASSWORD}  ${TEST_USER_2.AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Run Keyword And Continue On Failure   Verify Jupyter Access Level    ${TEST_USER_2.USERNAME}
-    ...                                   ${TEST_USER_2.PASSWORD}    ${TEST_USER_2.AUTH_TYPE}    admin
+    Run Keyword And Continue On Failure   Verify Jupyter Access Level    expected_result=admin
     Capture Page Screenshot    perm_admin_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Run Keyword And Continue On Failure   Verify Jupyter Access Level    ${TEST_USER_3.USERNAME}
-    ...                                   ${TEST_USER_3.PASSWORD}    ${TEST_USER_3.AUTH_TYPE}    user
+    Run Keyword And Continue On Failure   Verify Jupyter Access Level     expected_result=user
     Capture Page Screenshot    perm_user_custom.png
     Logout From RHODS Dashboard
 
@@ -129,14 +127,12 @@ Check Standard Access Configuration Works As Expected
     Launch Dashboard   ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ...   ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
     Launch Jupyter From RHODS Dashboard Link
-    Run Keyword And Continue On Failure   Verify Jupyter Access Level  ${TEST_USER_2.USERNAME}
-    ...                                   ${TEST_USER_2.PASSWORD}    ${TEST_USER_2.AUTH_TYPE}    admin
+    Run Keyword And Continue On Failure   Verify Jupyter Access Level  expected_result=admin
     Capture Page Screenshot    perm_admin_std.png
     Logout From RHODS Dashboard
-    Login To RHODS Dashboard  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}
+    Login To RHODS Dashboard  ${TEST_USER_4.USERNAME}  ${TEST_USER_4.PASSWORD}  ${TEST_USER_4.AUTH_TYPE}
     Wait for RHODS Dashboard to Load
-    Run Keyword And Continue On Failure   Verify Jupyter Access Level    ${TEST_USER_4.USERNAME}
-    ...                                   ${TEST_USER_4.PASSWORD}    ${TEST_USER_4.AUTH_TYPE}    user
+    Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=user
     Capture Page Screenshot    perm_user_std.png
     Logout From RHODS Dashboard
 


### PR DESCRIPTION
ODS-293 "Verify User Can Set Custom RHODS Groups" is still using the old config map way to set RHODS Access settings, instead of the new Dashboard CRD. This PR wants to fix the TC to work with the CRD.

Besides it fixes the compatibility issues between the TC and KFNBC

**UPDATE**:
In addition, the PR adapt ODS-1408,1494,1500 which used to read the configmap.
The PR leaves outside ODS-1495 which will need to be updated, but I'll do in another PR

Signed-off-by: bdattoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)