### PR TITLE
Fix some failing smoke tests due to JH to Jupyter migration

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -139,7 +139,7 @@ Verify Service Provides "Enable" Button In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore and, after clicking on the tile, the sidebar opens and there is an "Enable" button
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    JupyterHub  timeout=30
+  Wait Until Page Contains    Jupyter  timeout=30
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..
   Click Element     xpath://article//*[.='${app_name}']/../..
   Capture Page Screenshot
@@ -150,7 +150,7 @@ Verify Service Provides "Get Started" Button In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore and, after clicking on the tile, the sidebar opens and there is a "Get Started" button
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    JupyterHub  timeout=30
+  Wait Until Page Contains    Jupyter  timeout=30
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..
   Click Element     xpath://article//*[.='${app_name}']/../..
   Capture Page Screenshot

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -11,7 +11,7 @@ ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}=                //*[@class="pf-c-drawer__p
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //article[contains(@class, 'pf-c-card')]
-${JUPYTER_CARD_XP}=   //article[@id="jupyter"]
+${SAMPLE_APP_CARD_XP}=   //article[@id="pachyderm"]
 ${HEADER_XP}=  div[@class='pf-c-card__header']
 ${TITLE_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "title")]
 ${PROVIDER_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "provider")]

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -11,7 +11,7 @@ ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}=                //*[@class="pf-c-drawer__p
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //article[contains(@class, 'pf-c-card')]
-${JH_CARDS_XP}=   //article[@id="jupyterhub"]
+${JUPYTER_CARD_XP}=   //article[@id="jupyter"]
 ${HEADER_XP}=  div[@class='pf-c-card__header']
 ${TITLE_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "title")]
 ${PROVIDER_XP}=  div[@class='pf-c-card__title']//span[contains(@class, "provider")]
@@ -116,7 +116,7 @@ Verify Service Is Available In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    JupyterHub  timeout=30
+  Wait Until Page Contains    Jupyter  timeout=30
   Capture Page Screenshot
   Page Should Contain Element    //article//*[.='${app_name}']
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -122,7 +122,7 @@ Verify CSS Style Of Getting Started Descriptions
     ...       ODS-1165
     Click Link    Explore
     Wait Until Cards Are Loaded
-    Open Get Started Sidebar And Return Status    card_locator=${JH_CARDS_XP}
+    Open Get Started Sidebar And Return Status    card_locator=${JUPYTER_CARD_XP}
     Capture Page Screenshot    get_started_sidebar.png
     Verify JupyterHub Card CSS Style
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -122,7 +122,7 @@ Verify CSS Style Of Getting Started Descriptions
     ...       ODS-1165
     Click Link    Explore
     Wait Until Cards Are Loaded
-    Open Get Started Sidebar And Return Status    card_locator=${JUPYTER_CARD_XP}
+    Open Get Started Sidebar And Return Status    card_locator=${SAMPLE_APP_CARD_XP}
     Capture Page Screenshot    get_started_sidebar.png
     Verify Jupyter Card CSS Style
 

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -124,7 +124,7 @@ Verify CSS Style Of Getting Started Descriptions
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status    card_locator=${JUPYTER_CARD_XP}
     Capture Page Screenshot    get_started_sidebar.png
-    Verify JupyterHub Card CSS Style
+    Verify Jupyter Card CSS Style
 
 Verify Documentation Link HTTP Status Code
     [Documentation]    It verifies the documentation link present in question mark and
@@ -535,7 +535,7 @@ RHODS Dahsboard Pod Should Contain OauthProxy Container
         List Should Contain Value    ${container_name}    oauth-proxy
     END
 
-Verify JupyterHub Card CSS Style
+Verify Jupyter Card CSS Style
     [Documentation]    Compare the some CSS properties of the Explore page
     ...    with the expected ones. The expected values change based
     ...    on the RHODS version


### PR DESCRIPTION
The PR fixes:
1. TC `Verify CSS Style Of Getting Started Descriptions` which is pointing to JupyterHub card in Explore page
2. KW `Verify Service Is Available In The Explore Page` which is pointing to JupyterHub in Enabled page

Signed-off-by: bdattoma <bdattoma@redhat.com>