### PR TITLE
Adapt API Access tests after new changes in dashboard endpoints

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
@@ -16,7 +16,7 @@ Perform Request
     ...                hiding the oauth proxy data from logs and producing a custom log string.
     [Arguments]     ${request_type}   &{request_args}
     Set Log Level    NONE
-    ${response}=    Run Keyword     RequestsLibrary.${request_type}   &{request_args}
+    ${response}=   Run Keyword And Continue On Failure     RequestsLibrary.${request_type}   &{request_args}
     Remove OAuth Token From Header   headers=${response.request.headers}    token=${request_args}[headers][Cookie]
     Remove OAuth Token From Header   headers=${response.headers}    token=${request_args}[headers][Cookie]
     Set Log Level    INFO

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
@@ -15,7 +15,6 @@ Perform Request
     [Documentation]    Generic keyword to perform API call. It implements the log security by
     ...                hiding the oauth proxy data from logs and producing a custom log string.
     [Arguments]     ${request_type}   &{request_args}
-    Set Log Level    NONE
     &{LOG_DICT}=    Create Dictionary   url=${EMPTY}   headers=${EMPTY}
     ...                                 body=${EMPTY}    status_code=${EMPTY}
     &{LOG_RESP_DICT}=    Create Dictionary   url=${EMPTY}   headers=${EMPTY}   body=${EMPTY}
@@ -37,9 +36,12 @@ Perform Dashboard API Endpoint GET Call
     ...                 on the given token (i.e., user)
     [Arguments]     ${endpoint}     ${token}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}
-    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}-wrt/${endpoint}   expected_status=any
     ...             headers=${headers}   timeout=5  verify=${False}
-    ${response}=    Perform Request     GET     &{args}
+    ${response}=    Run Keyword And Continue On Failure     Perform Request     GET     &{args}
+    IF    ${response} == ${NONE}
+        Log    msg=HTTP response is empty. The request may have failed to be performed  level=ERROR
+    END
     [Return]    ${response}
 
 Perform Dashboard API Endpoint PUT Call
@@ -50,7 +52,10 @@ Perform Dashboard API Endpoint PUT Call
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
     &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
-    ${response}=    Perform Request     PUT     &{args}
+    ${response}=    Run Keyword And Continue On Failure     Perform Request     PUT     &{args}
+    IF    ${response} == ${NONE}
+        Log    msg=HTTP response is empty. The request may have failed to be performed  level=ERROR
+    END
 
 Perform Dashboard API Endpoint POST Call
     [Documentation]     Runs a PUT call to the given API endpoint. Result may change based
@@ -60,7 +65,10 @@ Perform Dashboard API Endpoint POST Call
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
     &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
-    ${response}=    Perform Request     POST     &{args}
+    ${response}=    Run Keyword And Continue On Failure     Perform Request     POST     &{args}
+    IF    ${response} == ${NONE}
+        Log    msg=HTTP response is empty. The request may have failed to be performed  level=ERROR
+    END
 
 Perform Dashboard API Endpoint PATCH Call
     [Documentation]     Runs a PATCH call to the given API endpoint. Result may change based
@@ -70,7 +78,10 @@ Perform Dashboard API Endpoint PATCH Call
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
     &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
-    ${response}=    Perform Request     PATCH     &{args}
+    ${response}=    Run Keyword And Continue On Failure     Perform Request     PATCH     &{args}
+    IF    ${response} == ${NONE}
+        Log    msg=HTTP response is empty. The request may have failed to be performed  level=ERROR
+    END
 
 Perform Dashboard API Endpoint DELETE Call
     [Documentation]     Runs a GET call to the given API endpoint. Result may change based
@@ -79,7 +90,10 @@ Perform Dashboard API Endpoint DELETE Call
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}
     &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   timeout=5  verify=${False}
-    ${response}=    Perform Request     DELETE     &{args}
+    ${response}=    Run Keyword And Continue On Failure     Perform Request     DELETE     &{args}
+    IF    ${response} == ${NONE}
+        Log    msg=HTTP response is empty. The request may have failed to be performed  level=ERROR
+    END
 
 Operation Should Be Allowed
     [Documentation]     Checks if the API call returns an HTTP code 200 (SUCCESS)

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
@@ -16,16 +16,19 @@ Perform Request
     ...                hiding the oauth proxy data from logs and producing a custom log string.
     [Arguments]     ${request_type}   &{request_args}
     Set Log Level    NONE
+    &{LOG_DICT}=    Create Dictionary   url=${EMPTY}   headers=${EMPTY}
+    ...                                 body=${EMPTY}    status_code=${EMPTY}
+    &{LOG_RESP_DICT}=    Create Dictionary   url=${EMPTY}   headers=${EMPTY}   body=${EMPTY}
+    ...                                      status_code=${EMPTY}   reason=${EMPTY}
     ${response}=   Run Keyword And Continue On Failure     RequestsLibrary.${request_type}   &{request_args}
     Remove OAuth Token From Header   headers=${response.request.headers}    token=${request_args}[headers][Cookie]
     Remove OAuth Token From Header   headers=${response.headers}    token=${request_args}[headers][Cookie]
     Set Log Level    INFO
-    &{LOG_DICT}=    Create Dictionary   url=${response.request.url}   headers=${response.request.headers}
+    Set To Dictionary    ${LOG_DICT}     url=${response.request.url}   headers=${response.request.headers}
     ...                                 body=${response.request.headers}    status_code=${response.status_code}
     Log     ${request_type} Request: ${LOG_DICT}
-    &{LOG_RESP_DICT}=    Create Dictionary   url=${response.url}   headers=${response.headers}   body=${response.text}
+    Set To Dictionary    ${LOG_RESP_DICT}      url=${response.url}   headers=${response.headers}   body=${response.text}
     ...                                      status_code=${response.status_code}   reason=${response.reason}
-    Set To Dictionary    dictionary=&{LOG_DICT}     url=${response.url}   headers=${response.headers}   body=${response.text}
     Log     ${request_type} Response: ${LOG_RESP_DICT}
     [Return]    ${response.json()}
 

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
@@ -11,13 +11,32 @@ ${WARN_MSG_500}=    Accepting HTTP code 500 as "allowed". If the user wouldn't h
 
 
 *** Keywords ***
+Perform Request
+    [Documentation]    Generic keyword to perform API call. It implements the log security by
+    ...                hiding the oauth proxy data from logs and producing a custom log string.
+    [Arguments]     ${request_type}   &{request_args}
+    Set Log Level    NONE
+    ${response}=    Run Keyword     RequestsLibrary.${request_type}   &{request_args}
+    Remove OAuth Token From Header   headers=${response.request.headers}    token=${request_args}[headers][Cookie]
+    Remove OAuth Token From Header   headers=${response.headers}    token=${request_args}[headers][Cookie]
+    Set Log Level    INFO
+    &{LOG_DICT}=    Create Dictionary   url=${response.request.url}   headers=${response.request.headers}
+    ...                                 body=${response.request.headers}    status_code=${response.status_code}
+    Log     ${request_type} Request: ${LOG_DICT}
+    &{LOG_RESP_DICT}=    Create Dictionary   url=${response.url}   headers=${response.headers}   body=${response.text}
+    ...                                      status_code=${response.status_code}   reason=${response.reason}
+    Set To Dictionary    dictionary=&{LOG_DICT}     url=${response.url}   headers=${response.headers}   body=${response.text}
+    Log     ${request_type} Response: ${LOG_RESP_DICT}
+    [Return]    ${response.json()}
+
 Perform Dashboard API Endpoint GET Call
     [Documentation]     Runs a GET call to the given API endpoint. Result may change based
     ...                 on the given token (i.e., user)
     [Arguments]     ${endpoint}     ${token}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}
-    ${response}=    RequestsLibrary.GET  ${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   timeout=5  verify=${False}
+    ${response}=    Perform Request     GET     &{args}
     [Return]    ${response}
 
 Perform Dashboard API Endpoint PUT Call
@@ -26,8 +45,9 @@ Perform Dashboard API Endpoint PUT Call
     [Arguments]     ${endpoint}     ${token}    ${body}     ${str_to_json}=${TRUE}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}   Content-type=application/json
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
-    ${response}=    RequestsLibrary.Put  ${ODH_DASHBOARD_URL}/${endpoint}    expected_status=any
-    ...             headers=${headers}    json=${payload}   timeout=5  verify=${False}
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
+    ${response}=    Perform Request     PUT     &{args}
 
 Perform Dashboard API Endpoint POST Call
     [Documentation]     Runs a PUT call to the given API endpoint. Result may change based
@@ -35,8 +55,9 @@ Perform Dashboard API Endpoint POST Call
     [Arguments]     ${endpoint}     ${token}    ${body}    ${str_to_json}=${TRUE}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}   Content-type=application/json
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
-    ${response}=    RequestsLibrary.Post  ${ODH_DASHBOARD_URL}/${endpoint}    expected_status=any
-    ...             headers=${headers}    json=${payload}   timeout=5  verify=${False}
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
+    ${response}=    Perform Request     POST     &{args}
 
 Perform Dashboard API Endpoint PATCH Call
     [Documentation]     Runs a PATCH call to the given API endpoint. Result may change based
@@ -44,16 +65,18 @@ Perform Dashboard API Endpoint PATCH Call
     [Arguments]     ${endpoint}     ${token}    ${body}     ${str_to_json}=${TRUE}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}   Content-type=application/json
     ${payload}=     Prepare Payload     body=${body}    str_to_json=${str_to_json}
-    ${response}=    RequestsLibrary.Patch  ${ODH_DASHBOARD_URL}/${endpoint}    expected_status=any
-    ...             headers=${headers}    json=${payload}   timeout=5  verify=${False}
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    ...             headers=${headers}   json=${payload}    timeout=5  verify=${False}
+    ${response}=    Perform Request     PATCH     &{args}
 
 Perform Dashboard API Endpoint DELETE Call
     [Documentation]     Runs a GET call to the given API endpoint. Result may change based
     ...                 on the given token (i.e., user)
     [Arguments]     ${endpoint}     ${token}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}
-    ${response}=    RequestsLibrary.DELETE  ${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   timeout=5  verify=${False}
+    ${response}=    Perform Request     DELETE     &{args}
 
 Operation Should Be Allowed
     [Documentation]     Checks if the API call returns an HTTP code 200 (SUCCESS)
@@ -86,3 +109,14 @@ Prepare Payload
         ${payload}=     Set Variable    ${body}
     END
     [Return]    ${payload}
+
+Remove OAuth Token From Header
+    [Documentation]     Hides oauth proxy from header
+    [Arguments]     ${headers}   ${token}
+    ${oauth_present}=       Run Keyword And Return Status    Dictionary Should Contain Key
+    ...                                                      dictionary=${headers}    key=Cookie
+    ${token}=    Replace String    string=${token}    search_for=_oauth_proxy=    replace_with=${EMPTY}
+    IF    ${oauth_present} == ${TRUE}
+         ${cookies}=    Replace String    string=${headers}[Cookie]     search_for=${token}     replace_with=***hidden***
+         Set To Dictionary    dictionary=${headers}   Cookie=${cookies}
+    END

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
@@ -36,7 +36,7 @@ Perform Dashboard API Endpoint GET Call
     ...                 on the given token (i.e., user)
     [Arguments]     ${endpoint}     ${token}
     ${headers}=    Create Dictionary     Cookie=_oauth_proxy=${token}
-    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}-wrt/${endpoint}   expected_status=any
+    &{args}=       Create Dictionary     url=${ODH_DASHBOARD_URL}/${endpoint}   expected_status=any
     ...             headers=${headers}   timeout=5  verify=${False}
     ${response}=    Run Keyword And Continue On Failure     Perform Request     GET     &{args}
     IF    ${response} == ${NONE}

--- a/tests/Resources/RHOSi.resource
+++ b/tests/Resources/RHOSi.resource
@@ -5,6 +5,7 @@ Library             RPA.RobotLogListener
 Resource            Page/ODH/Monitoring/Monitoring.resource
 Resource            Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
 
+
 *** Variables ***
 @{PROTECTED_KEYWORDS}=      Login To RHODS Dashboard
 ...                         Launch Dashboard
@@ -21,6 +22,11 @@ Resource            Page/OCPDashboard/InstalledOperators/InstalledOperators.robo
 ...                         Get Bearer Token
 ...                         Log In As RHODS Admin
 ...                         Log In As RHODS Basic User
+...                         Perform Dashboard API Endpoint GET Call
+...                         Perform Dashboard API Endpoint PUT Call
+...                         Perform Dashboard API Endpoint PATCH Call
+...                         Perform Dashboard API Endpoint POST Call
+...                         Perform Dashboard API Endpoint DELETE Call
 
 
 *** Keywords ***

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -616,10 +616,10 @@ Verify Access to notebooks API Endpoint
     # pATCH with normal user - 403
     ${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}=       Fill In Notebook Payload For Stopping    username=${TEST_USER.USERNAME}
     Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
-    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_BODY}    str_to_json=${TRUE}
+    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
     Operation Should Be Unauthorized
     Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
-    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_BODY}    str_to_json=${TRUE}
+    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
     [Teardown]    Delete Test Notebooks CRs And PVCs From CLI
 

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -242,7 +242,7 @@ Verify Access To pvc API Endpoint
     ${test_pvcs}=   Create List     ${PVC_BASIC_USER}   ${PVC_BASIC_USER_2}
     [Teardown]    Delete Test PVCs     pvc_names=${test_pvcs}
 
-Verify Access To Notebook configmap API Endpoint
+Verify Access To Notebook envs/configmap API Endpoint
     [Documentation]     Verifies the endpoint "configmaps" works as expected
     ...                 based on the permissions of the users who query the endpoint to get
     ...                 the user configmap map of a notebook server.
@@ -292,7 +292,7 @@ Verify Access To Notebook configmap API Endpoint
     Operation Should Be Unavailable
     [Teardown]     Delete Test Notebooks CRs And PVCs From CLI
 
-Verify Access To Notebook secret API Endpoint
+Verify Access To Notebook envs/secret API Endpoint
     [Documentation]     Verifies the endpoint "secrets" works as expected
     ...                 based on the permissions of the users who query the endpoint to get
     ...                 the user secret of a notebook server.
@@ -341,7 +341,7 @@ Verify Access To Notebook secret API Endpoint
     Operation Should Be Unavailable
     [Teardown]     Delete Test Notebooks CRs And PVCs From CLI
 
-Verify Access To Dashboard configmap API Endpoint
+Verify Access To Dashboard envs/configmap API Endpoint
     [Documentation]     Verifies the endpoint "configmaps" works as expected
     ...                 based on the permissions of the users who query the endpoint
     ...                 to get a configmap from the Dashboard namespace.
@@ -394,7 +394,7 @@ Verify Access To Dashboard configmap API Endpoint
     Operation Should Be Unavailable
     [Teardown]      Delete Dummy ConfigMaps
 
-Verify Access To Dashboard secret API Endpoint
+Verify Access To Dashboard envs/secret API Endpoint
     [Documentation]     Verifies the endpoint "secrets" works as expected
     ...                 based on the permissions of the users who query the endpoint
     ...                 to get a secret from the Dashboard namespace.

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -831,8 +831,8 @@ Delete Test PVCs
     [Documentation]     Delets the PVCs received as arguments
     [Arguments]     ${pvc_names}
     FOR   ${pvc}    IN  @{pvc_names}
-        ${present}=     OpenshiftLibrary.Oc Get    kind=PersistentVolumeClaim  namespace=${NOTEBOOK_NS}  name=${pvc}
-        IF    ${present} == ${NONE}
+        ${present}=     Run Keyword And Return Status   OpenshiftLibrary.Oc Get    kind=PersistentVolumeClaim  namespace=${NOTEBOOK_NS}  name=${pvc}
+        IF    ${present} == ${FALSE}
             Continue For Loop
         ELSE
             OpenshiftLibrary.Oc Delete    kind=PersistentVolumeClaim    namespace=${NOTEBOOK_NS}    name=${pvc}

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -30,22 +30,22 @@ ${GPU_ENDPOINT}=        api/gpu
 ${NOTEBOOK_NS}=          rhods-notebooks
 ${DASHBOARD_NS}=         redhat-ods-applications
 ${NOTEBOOK_USERNAME}=    ""
-${CM_ENDPOINT_PT0}=         api/configmaps
+${CM_ENDPOINT_PT0}=         api/configmap
 ${CM_ENDPOINT_PT1}=         ${CM_ENDPOINT_PT0}/${NOTEBOOK_NS}/jupyterhub-singleuser-profile-
 ${CM_ENDPOINT_PT2}=         -envs
-${CM_ENDPOINT_BODY}=            {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"rhods-notebooks"}}
+${CM_ENDPOINT_BODY}=            {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"${NOTEBOOK_NS}"}}
 ${DUMMY_CM_NAME}=           test-dummy-configmap
-${CM_DASHBOARD_ENDPOINT}=         api/configmaps/${DASHBOARD_NS}/${DUMMY_CM_NAME}
+${CM_DASHBOARD_ENDPOINT}=         api/configmap/${DASHBOARD_NS}/${DUMMY_CM_NAME}
 ${CM_DASHBOARD_ENDPOINT_BODY}=         {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"${DUMMY_CM_NAME}","namespace":"${DASHBOARD_NS}"},"data":{"key":"newvalue"}}
 ${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}=         {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"${DUMMY_CM_NAME}","namespace":"redhat-ods-monitoring"},"data":{"key":"newvalue"}}
-${CM_OUTSIDE_DASHBOARD_ENDPOINT}=         api/configmaps/redhat-ods-monitoring/prometheus
+${CM_OUTSIDE_DASHBOARD_ENDPOINT}=         api/configmap/redhat-ods-monitoring/prometheus
 ${DUMMY_SECRET_NAME}=           test-dummy-secret
-${SECRET_DASHBOARD_ENDPOINT}=         api/secrets/${DASHBOARD_NS}/${DUMMY_SECRET_NAME}
-${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}=         api/secrets/redhat-ods-monitoring/${DUMMY_SECRET_NAME}
-${SECRET_ENDPOINT_PT0}=         api/secrets
+${SECRET_DASHBOARD_ENDPOINT}=         api/secret/${DASHBOARD_NS}/${DUMMY_SECRET_NAME}
+${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}=         api/secret/redhat-ods-monitoring/${DUMMY_SECRET_NAME}
+${SECRET_ENDPOINT_PT0}=         api/secret
 ${SECRET_ENDPOINT_PT1}=         ${SECRET_ENDPOINT_PT0}/${NOTEBOOK_NS}/jupyterhub-singleuser-profile-
 ${SECRET_ENDPOINT_PT2}=         -envs
-${SECRET_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"rhods-notebooks"},"type":"Opaque"}
+${SECRET_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"${NOTEBOOK_NS}"},"type":"Opaque"}
 ${SECRET_DASHBOARD_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"${DUMMY_SECRET_NAME}","namespace":"${DASHBOARD_NS}"},"type":"Opaque"}
 ${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"${DUMMY_SECRET_NAME}","namespace":"redhat-ods-monitoring"},"type":"Opaque"}
 
@@ -72,21 +72,23 @@ ${VALIDATE_ISV_RESULT_ENDPOINT}=         api/validate-isv/results?appName=anacon
 ${NB_ENDPOINT_PT0}=      api/notebooks
 ${NB_ENDPOINT_PT1}=      ${NB_ENDPOINT_PT0}/${NOTEBOOK_NS}/
 ${NB_ENDPOINT_PT2}=      /status
-${NB_ENDPOINT_BODY}=      {"apiVersion":"kubeflow.org/v1","kind":"Notebook","metadata":{"labels":{"app":"jupyter-nb-<NB_USERNAME>","opendatahub.io/odh-managed":"true","opendatahub.io/user":"<NB_USERNAME>"},"name":"jupyter-nb-<NB_USERNAME>","namespace":"rhods-notebooks"},"spec":{"template":{"spec":{"enableServiceLinks":false,"containers":[{"image":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07","imagePullPolicy":"Always","workingDir":"/opt/app-root/src","name":"jupyter-nb-<NB_USERNAME>","env":[{"name":"JUPYTER_IMAGE","value":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07"}],"resources":{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}},"volumeMounts":[{"mountPath":"/opt/app-root/src","name":"jupyterhub-nb-<NB_USERNAME>-pvc"}],"ports":[{"name":"notebook-port","containerPort":8888,"protocol":"TCP"}]}],"volumes":[{"name":"jupyterhub-nb-<NB_USERNAME>-pvc","persistentVolumeClaim":{"claimName":"jupyterhub-nb-<NB_USERNAME>-pvc"}}]}}}}
+${NB_ENDPOINT_BODY}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":null,"state":"started","username":"<USERNAME>}
+# ${NB_ENDPOINT_BODY}=      {"apiVersion":"kubeflow.org/v1","kind":"Notebook","metadata":{"labels":{"app":"jupyter-nb-<NB_USERNAME>","opendatahub.io/odh-managed":"true","opendatahub.io/user":"<NB_USERNAME>"},"name":"jupyter-nb-<NB_USERNAME>","namespace":"${NOTEBOOK_NS}"},"spec":{"template":{"spec":{"enableServiceLinks":false,"containers":[{"image":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07","imagePullPolicy":"Always","workingDir":"/opt/app-root/src","name":"jupyter-nb-<NB_USERNAME>","env":[{"name":"JUPYTER_IMAGE","value":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07"}],"resources":{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}},"volumeMounts":[{"mountPath":"/opt/app-root/src","name":"jupyterhub-nb-<NB_USERNAME>-pvc"}],"ports":[{"name":"notebook-port","containerPort":8888,"protocol":"TCP"}]}],"volumes":[{"name":"jupyterhub-nb-<NB_USERNAME>-pvc","persistentVolumeClaim":{"claimName":"jupyterhub-nb-<NB_USERNAME>-pvc"}}]}}}}
 
 ${PVC_ENDPOINT_PT0}=      api/pvc
 ${PVC_ENDPOINT_PT1}=      ${PVC_ENDPOINT_PT0}/${NOTEBOOK_NS}/
-${PVC_ENDPOINT_BODY}=     {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"name":"<PVC_NAME>","namespace":"rhods-notebooks"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
+${PVC_ENDPOINT_BODY}=     {"apiVersion":"v1","kind":"PersistentVolumeClaim","metadata":{"name":"<PVC_NAME>","namespace":"${NOTEBOOK_NS}"},"spec":{"accessModes":["ReadWriteOnce"],"resources":{"requests":{"storage":"2Gi"}},"volumeMode":"Filesystem"},"status":{"phase":"Pending"}}
 
 ${ROLE_BIND_ENDPOINT_PT0}=      api/rolebindings
 ${ROLE_BIND_ENDPOINT_PT1}=      ${ROLE_BIND_ENDPOINT_PT0}/${DASHBOARD_NS}/${NOTEBOOK_NS}-image-pullers
-${ROLE_BIND_ENDPOINT_BODY}=      {"kind":"RoleBinding","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"name":"rhods-notebooks-image-pullers-test","namespace":"${DASHBOARD_NS}"},"subjects":[{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:serviceaccounts:rhods-notebooks"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"system:image-puller"}}
+${ROLE_BIND_ENDPOINT_BODY}=      {"kind":"RoleBinding","apiVersion":"rbac.authorization.k8s.io/v1","metadata":{"name":"${NOTEBOOK_NS}-image-pullers-test","namespace":"${DASHBOARD_NS}"},"subjects":[{"kind":"Group","apiGroup":"rbac.authorization.k8s.io","name":"system:serviceaccounts:${NOTEBOOK_NS}"}],"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"ClusterRole","name":"system:image-puller"}}
 
 ${APP_TO_REMOVE}=                rhosak
 ${COMPONENTS_ENDPOINT_PT0}=      api/components
 ${COMPONENTS_ENDPOINT_PT1}=      ${COMPONENTS_ENDPOINT_PT0}/remove?appName=${APP_TO_REMOVE}
 
 ${HEALTH_ENDPOINT}=     api/health
+
 
 *** Test Cases ***
 Verify Access To cluster-settings API Endpoint
@@ -222,33 +224,33 @@ Verify Access To pvc API Endpoint
     ${create_pvc_body}=     Set Username In PVC Payload     username=${PVC_BASIC_USER}
     Perform Dashboard API Endpoint POST Call   endpoint=${PVC_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${create_pvc_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${PVC_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${PVC_ENDPOINT_BASIC_USER}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     ${PVC_BASIC_USER_2}=   Get User Notebook PVC Name    ${TEST_USER_4.USERNAME}
     ${PVC_ENDPOINT_BASIC_USER_2}=     Set Variable    ${PVC_ENDPOINT_PT1}${PVC_BASIC_USER_2}
     ${create_pvc_body_2}=     Set Username In PVC Payload     username=${PVC_BASIC_USER_2}
     Perform Dashboard API Endpoint POST Call   endpoint=${PVC_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${create_pvc_body_2}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${PVC_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${create_pvc_body_2}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${PVC_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${PVC_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     ${test_pvcs}=   Create List     ${PVC_BASIC_USER}   ${PVC_BASIC_USER_2}
     [Teardown]    Delete Test PVCs     pvc_names=${test_pvcs}
 
-Verify Access To Notebook configmaps API Endpoint
+Verify Access To Notebook configmap API Endpoint
     [Documentation]     Verifies the endpoint "configmaps" works as expected
     ...                 based on the permissions of the users who query the endpoint to get
     ...                 the user configmap map of a notebook server.
     ...                 The syntax to reach this endpoint is:
-    ...                 `configmaps/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
+    ...                 `configmap/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
 
     [Tags]    ODS-1719
     ...       Tier1    Sanity
@@ -263,12 +265,12 @@ Verify Access To Notebook configmaps API Endpoint
     ${cm_basic_user_body}=     Set Username In ConfigMap Payload    notebook_username=${NOTEBOOK_BASIC_USER}
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${cm_basic_user_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${cm_basic_user_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
     ${NOTEBOOK_BASIC_USER_2}=   Get Safe Username    ${TEST_USER_4.USERNAME}
     ${CM_ENDPOINT_BASIC_USER_2}=     Set Variable    ${CM_ENDPOINT_PT1}${NOTEBOOK_BASIC_USER_2}${CM_ENDPOINT_PT2}
@@ -277,28 +279,28 @@ Verify Access To Notebook configmaps API Endpoint
     ${cm_basic_user_2_body}=     Set Username In ConfigMap Payload    notebook_username=${NOTEBOOK_BASIC_USER_2}
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${cm_basic_user_2_body}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${cm_basic_user_2_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${cm_basic_user_2_body}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${cm_basic_user_2_body}
     Operation Should Be Allowed
     [Teardown]     Delete Test Notebooks CRs And PVCs From CLI
 
-Verify Access To Notebook secrets API Endpoint
+Verify Access To Notebook secret API Endpoint
     [Documentation]     Verifies the endpoint "secrets" works as expected
     ...                 based on the permissions of the users who query the endpoint to get
     ...                 the user secret of a notebook server.
     ...                 The syntax to reach this endpoint is:
-    ...                 `secrets/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
+    ...                 `secret/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
 
     [Tags]    ODS-1720
     ...       Tier1    Sanity
@@ -313,12 +315,12 @@ Verify Access To Notebook secrets API Endpoint
     ${secret_basic_user_body}=     Set Username In Secret Payload    notebook_username=${NOTEBOOK_BASIC_USER}
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${secret_basic_user_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${secret_basic_user_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
     ${NOTEBOOK_BASIC_USER_2}=   Get Safe Username    ${TEST_USER_4.USERNAME}
     ${SECRET_ENDPOINT_BASIC_USER_2}=     Set Variable    ${SECRET_ENDPOINT_PT1}${NOTEBOOK_BASIC_USER_2}${SECRET_ENDPOINT_PT2}
@@ -327,28 +329,28 @@ Verify Access To Notebook secrets API Endpoint
     ${secret_basic_user_2_body}=     Set Username In Secret Payload    notebook_username=${NOTEBOOK_BASIC_USER_2}
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${secret_basic_user_2_body}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${secret_basic_user_2_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${secret_basic_user_2_body}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${secret_basic_user_2_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     [Teardown]     Delete Test Notebooks CRs And PVCs From CLI
 
-Verify Access To Dashboard configmaps API Endpoint
+Verify Access To Dashboard configmap API Endpoint
     [Documentation]     Verifies the endpoint "configmaps" works as expected
     ...                 based on the permissions of the users who query the endpoint
     ...                 to get a configmap from the Dashboard namespace.
     ...                 The syntax to reach this endpoint is:
-    ...                 `configmaps/<dashboard_namespace>/<configmap_name>`
+    ...                 `configmap/<dashboard_namespace>/<configmap_name>`
     [Tags]    ODS-1722
     ...       Tier1    Sanity
     ...       Security
@@ -359,20 +361,20 @@ Verify Access To Dashboard configmaps API Endpoint
     Operation Should Be Allowed
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${CM_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${CM_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_DASHBOARD_ENDPOINT}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${CM_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${CM_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Create A Dummy ConfigMap Outside Dashboard Namespace
     Perform Dashboard API Endpoint GET Call   endpoint=${CM_OUTSIDE_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden
@@ -380,28 +382,28 @@ Verify Access To Dashboard configmaps API Endpoint
     Operation Should Be Forbidden
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_OUTSIDE_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${CM_OUTSIDE_DASHBOARD_ENDPOINT}    token=${ADMIN_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     [Teardown]      Delete Dummy ConfigMaps
 
-Verify Access To Dashboard secrets API Endpoint
+Verify Access To Dashboard secret API Endpoint
     [Documentation]     Verifies the endpoint "secrets" works as expected
     ...                 based on the permissions of the users who query the endpoint
     ...                 to get a secret from the Dashboard namespace.
     ...                 The syntax to reach this endpoint is:
-    ...                 `secrets/<namespace>/<secret_name>`
+    ...                 `secret/<namespace>/<secret_name>`
     [Tags]    ODS-1721
     ...       Tier1    Sanity
     ...       Security
@@ -412,20 +414,20 @@ Verify Access To Dashboard secrets API Endpoint
     Operation Should Be Allowed
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${SECRET_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${SECRET_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_DASHBOARD_ENDPOINT}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${SECRET_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${SECRET_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
 
     Create A Dummy Secret Outside Dashboard Namespace
     Perform Dashboard API Endpoint GET Call   endpoint=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
@@ -434,21 +436,20 @@ Verify Access To Dashboard secrets API Endpoint
     Operation Should Be Forbidden
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                       body=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint PUT Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint DELETE Call   endpoint=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}    token=${ADMIN_TOKEN}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${SECRET_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}
-    Operation Should Be Forbidden
-
+    Operation Should Be Unavailable
     [Teardown]      Delete Dummy Secrets
 
 Verify Access To groups-config API Endpoint
@@ -566,7 +567,7 @@ Verify Access to notebooks API Endpoint
     [Tags]    ODS-1729
     ...       Tier1    Sanity
     ...       Security
-    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
+    ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_3.USERNAME}
     ${NB_ENDPOINT_BASIC_USER}=     Set Variable    ${NB_ENDPOINT_PT1}${NB_BASIC_USER}
     ${NB_ENDPOINT_BASIC_USER_STATUS}=     Set Variable    ${NB_ENDPOINT_BASIC_USER}${NB_ENDPOINT_PT2}
@@ -578,12 +579,13 @@ Verify Access to notebooks API Endpoint
     Operation Should Be Allowed
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_BASIC_USER_STATUS}    token=${ADMIN_TOKEN}
     Operation Should Be Allowed
-    ${NOTEBOOK_BASIC_USER}=   Get Safe Username    ${TEST_USER_3.USERNAME}
     ${NB_ENDPOINT_BASIC_USER_BODY}=       Set Username In Notebook Payload    notebook_username=${NOTEBOOK_BASIC_USER}
-    Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
+    ...                                   imagetagname=${IMAGE_TAG_NAME}
+    # POST call for update
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_BODY}
     Operation Should Be Allowed
-    Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
+    ${NB_BASIC_USER_2_SAFENAME}  ${IMAGE_TAG_NAME}=      Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
     ${NB_BASIC_USER_2}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
     ${NB_ENDPOINT_BASIC_USER_2}=     Set Variable    ${NB_ENDPOINT_PT1}${NB_BASIC_USER_2}
     ${NB_ENDPOINT_BASIC_USER_2_STATUS}=     Set Variable    ${NB_ENDPOINT_BASIC_USER_2}${NB_ENDPOINT_PT2}
@@ -595,16 +597,19 @@ Verify Access to notebooks API Endpoint
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_PT1}    token=${ADMIN_TOKEN}
     Operation Should Be Unavailable
-    ${NB_BASIC_USER_2_SAFENAME}=   Get Safe Username    ${TEST_USER_4.USERNAME}
     ${NB_ENDPOINT_BASIC_USER_2_BODY}=       Set Username In Notebook Payload    notebook_username=${NB_BASIC_USER_2_SAFENAME}
-    Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
+    ...                                     imagetagname=${IMAGE_TAG_NAME}
+    # POST call for update
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}
     Operation Should Be Forbidden
-    Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
+    # POST call for update
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}
     Operation Should Be Allowed
     ${NOTEBOOK_BASIC_USER_3}=   Get Safe Username    ${TEST_USER.USERNAME}
     ${NB_ENDPOINT_BASIC_USER_3_BODY}=       Set Username In Notebook Payload    notebook_username=${NOTEBOOK_BASIC_USER_3}
+    ...                                     imagetagname=${IMAGE_TAG_NAME}
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}/    token=${BASIC_USER_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}
     Operation Should Be Forbidden
@@ -639,7 +644,7 @@ Verify Access to rolebindings API Endpoint
     Perform Dashboard API Endpoint POST Call   endpoint=${ROLE_BIND_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${ROLE_BIND_ENDPOINT_BODY}
     Operation Should Be Allowed
-    [Teardown]   OpenshiftLibrary.Oc Delete    kind=RoleBinding  namespace=${DASHBOARD_NS}  name=rhods-notebooks-image-pullers-test
+    [Teardown]   OpenshiftLibrary.Oc Delete    kind=RoleBinding  namespace=${DASHBOARD_NS}  name=${NOTEBOOK_NS}-image-pullers-test
 
 Verify Access To components API Endpoint
     [Documentation]     Verifies the endpoint "components" works as expected
@@ -676,15 +681,15 @@ Verify Access To health API Endpoint
 Endpoint Testing Setup
     [Documentation]     Fetches an access token for both a RHODS admin and basic user
     Set Library Search Order    SeleniumLibrary
-    RHOSi Setup
-    ${ADMIN_TOKEN}=   Log In As RHODS Admin
-    Set Suite Variable    ${ADMIN_TOKEN}
-    ${BASIC_USER_TOKEN}=   Log In As RHODS Basic User
-    Set Suite Variable    ${BASIC_USER_TOKEN}
+    #RHOSi Setup
+    # # ${ADMIN_TOKEN}=   Log In As RHODS Admin
+    # # Set Suite Variable    ${ADMIN_TOKEN}
+    # # ${BASIC_USER_TOKEN}=   Log In As RHODS Basic User
+    # # Set Suite Variable    ${BASIC_USER_TOKEN}
 
 Endpoint Testing Teardown
     [Documentation]     Switches to original OC context
-    RHOSi Teardown
+    #RHOSi Teardown
 
 Log In As RHODS Admin
     [Documentation]     Perfom OC login using a RHODS admin user
@@ -712,6 +717,10 @@ Spawn Minimal Python Notebook Server
     ...    browser_options=${BROWSER.OPTIONS}
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=s2i-minimal-notebook
+    ${safe_username}=   Get Safe Username    ${username}
+    ${status}   ${image_tag_name}=     Run And Return Rc And Output
+    ...     oc get Notebook --field-selector=metadata.name=${safe_username} -n ${NOTEBOOK_NS} -o=jsonpath='{.items[0].metadata.annotations.notebooks\\.opendatahub\\.io/last-image-selection}'
+    [Return]    ${safe_username}    ${image_tag_name}
 
 Create A Dummy Secret In Dashboard Namespace
     [Documentation]     Creates a dummy secret to use in tests to avoid getting sensitive secrets
@@ -778,9 +787,10 @@ Set Username In PVC Payload
 
 Set Username In Notebook Payload
     [Documentation]     Fill in the json body for creating/updating a Notebook with the username
-    [Arguments]     ${notebook_username}
-    ${complete_pvc}=     Replace String    ${NB_ENDPOINT_BODY}    <NB_USERNAME>    ${notebook_username}
-    [Return]    ${complete_pvc}
+    [Arguments]     ${notebook_username}    ${imagetagname}
+    ${complete_body}=     Replace String    ${NB_ENDPOINT_BODY}    <USERNAME>    ${notebook_username}
+    ${complete_body}=     Replace String    ${complete_body}    <IMAGETAGNAME>    ${imagetagname}
+    [Return]    ${complete_body}
 
 Delete Test PVCs
     [Documentation]     Delets the PVCs received as arguments

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -7,7 +7,7 @@ Resource          ../../Resources/Common.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
 Resource          ../../Resources/Page/ODH/AiApps/Rhosak.resource
 Suite Setup       Endpoint Testing Setup
-#Suite Teardown    Endpoint Testing Teardown
+Suite Teardown    Endpoint Testing Teardown
 
 
 *** Variables ***
@@ -72,8 +72,8 @@ ${VALIDATE_ISV_RESULT_ENDPOINT}=         api/validate-isv/results?appName=anacon
 ${NB_ENDPOINT_PT0}=      api/notebooks
 ${NB_ENDPOINT_PT1}=      ${NB_ENDPOINT_PT0}/${NOTEBOOK_NS}/
 ${NB_ENDPOINT_PT2}=      /status
-${NB_ENDPOINT_BODY}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":null,"state":"started","username":"<USERNAME>"}
-# ${NB_ENDPOINT_BODY}=      {"apiVersion":"kubeflow.org/v1","kind":"Notebook","metadata":{"labels":{"app":"jupyter-nb-<NB_USERNAME>","opendatahub.io/odh-managed":"true","opendatahub.io/user":"<NB_USERNAME>"},"name":"jupyter-nb-<NB_USERNAME>","namespace":"${NOTEBOOK_NS}"},"spec":{"template":{"spec":{"enableServiceLinks":false,"containers":[{"image":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07","imagePullPolicy":"Always","workingDir":"/opt/app-root/src","name":"jupyter-nb-<NB_USERNAME>","env":[{"name":"JUPYTER_IMAGE","value":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07"}],"resources":{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}},"volumeMounts":[{"mountPath":"/opt/app-root/src","name":"jupyterhub-nb-<NB_USERNAME>-pvc"}],"ports":[{"name":"notebook-port","containerPort":8888,"protocol":"TCP"}]}],"volumes":[{"name":"jupyterhub-nb-<NB_USERNAME>-pvc","persistentVolumeClaim":{"claimName":"jupyterhub-nb-<NB_USERNAME>-pvc"}}]}}}}
+${NB_ENDPOINT_BODY_A}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started"}
+${NB_ENDPOINT_BODY_B}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started","username":"<USERNAME>"}
 
 ${PVC_ENDPOINT_PT0}=      api/pvc
 ${PVC_ENDPOINT_PT1}=      ${PVC_ENDPOINT_PT0}/${NOTEBOOK_NS}/
@@ -93,7 +93,6 @@ ${ROUTE_ENDPOINT_PT0}=      api/route
 ${ROUTE_ENDPOINT_PT1}=      ${ROUTE_ENDPOINT_PT0}/${NOTEBOOK_NS}
 ${ROUTE_ENDPOINT_PT1B}=     ${ROUTE_ENDPOINT_PT0}/${DASHBOARD_NS}
 ${ROUTE_ENDPOINT_PT2B}=     ${ROUTE_ENDPOINT_PT1B}/rhods-dashboard
-
 
 
 *** Test Cases ***
@@ -117,7 +116,6 @@ Verify Access To cluster-settings API Endpoint
 Verify Access To builds API Endpoint
     [Documentation]     Verifies the endpoint "builds" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1711
     ...       Tier1    Sanity
     ...       Security
@@ -129,7 +127,6 @@ Verify Access To builds API Endpoint
 Verify Access To config API Endpoint
     [Documentation]     Verifies the endpoint "config" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1712
     ...       Tier1    Sanity
     ...       Security
@@ -147,7 +144,6 @@ Verify Access To config API Endpoint
 Verify Access To console-links API Endpoint
     [Documentation]     Verifies the endpoint "console-links" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1713
     ...       Tier1    Sanity
     ...       Security
@@ -159,7 +155,6 @@ Verify Access To console-links API Endpoint
 Verify Access To docs API Endpoint
     [Documentation]     Verifies the endpoint "docs" works as expected
     ...                 based on the permissions of the user who query the endpoint
-
     [Tags]    ODS-1714
     ...       Tier1    Sanity
     ...       Security
@@ -171,7 +166,6 @@ Verify Access To docs API Endpoint
 Verify Access To getting-started API Endpoint
     [Documentation]     Verifies the endpoint "getting_started" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1715
     ...       Tier1    Sanity
     ...       Security
@@ -183,7 +177,6 @@ Verify Access To getting-started API Endpoint
 Verify Access To quickstarts API Endpoint
     [Documentation]     Verifies the endpoint "quickstarts" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1716
     ...       Tier1    Sanity
     ...       Security
@@ -195,7 +188,6 @@ Verify Access To quickstarts API Endpoint
 Verify Access To segment-key API Endpoint
     [Documentation]     Verifies the endpoint "segment-key" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1717
     ...       Tier1    Sanity
     ...       Security
@@ -207,7 +199,6 @@ Verify Access To segment-key API Endpoint
 Verify Access To gpu API Endpoint
     [Documentation]     Verifies the endpoint "gpu" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1718
     ...       Tier1    Sanity
     ...       Security
@@ -307,7 +298,6 @@ Verify Access To Notebook secret API Endpoint
     ...                 the user secret of a notebook server.
     ...                 The syntax to reach this endpoint is:
     ...                 `secret/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
-
     [Tags]    ODS-1720
     ...       Tier1    Sanity
     ...       Security
@@ -461,7 +451,6 @@ Verify Access To Dashboard secret API Endpoint
 Verify Access To groups-config API Endpoint
     [Documentation]     Verifies the endpoint "groups-config" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1723
     ...       Tier1    Sanity
     ...       Security
@@ -479,7 +468,6 @@ Verify Access To groups-config API Endpoint
 Verify Access To images API Endpoint
     [Documentation]     Verifies the endpoint "images" works as expected
     ...                 based on the permissions of the users who query the endpoint
-
     [Tags]    ODS-1724
     ...       Tier1    Sanity
     ...       Security
@@ -573,9 +561,9 @@ Verify Access to notebooks API Endpoint
     [Tags]    ODS-1729
     ...       Tier1    Sanity
     ...       Security
-    ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
-    ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_3.USERNAME}
-    ${NB_ENDPOINT_BASIC_USER}=     Set Variable    ${NB_ENDPOINT_PT1}${NB_BASIC_USER}
+    ${NOTEBOOK_CR_NAME}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
+    ${NB_BASIC_USER}=   Get Safe Username    ${TEST_USER_3.USERNAME}
+    ${NB_ENDPOINT_BASIC_USER}=     Set Variable    ${NB_ENDPOINT_PT1}${NOTEBOOK_CR_NAME}
     ${NB_ENDPOINT_BASIC_USER_STATUS}=     Set Variable    ${NB_ENDPOINT_BASIC_USER}${NB_ENDPOINT_PT2}
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
     Operation Should Be Allowed
@@ -585,15 +573,13 @@ Verify Access to notebooks API Endpoint
     Operation Should Be Allowed
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_BASIC_USER_STATUS}    token=${ADMIN_TOKEN}
     Operation Should Be Allowed
-    ${NB_ENDPOINT_BASIC_USER_BODY}=       Set Username In Notebook Payload    notebook_username=${NOTEBOOK_BASIC_USER}
-    ...                                   imagetagname=${IMAGE_TAG_NAME}
+    ${NB_ENDPOINT_BASIC_USER_BODY}=       Fill In Notebook Payload   imagetagname=${IMAGE_TAG_NAME}
     # POST call for update
-    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER}    token=${BASIC_USER_TOKEN}
-    ...                                        body=${NB_ENDPOINT_BASIC_USER_BODY}
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
+    ...                                        body=${NB_ENDPOINT_BASIC_USER_BODY}  str_to_json=${TRUE}
     Operation Should Be Allowed
-    ${NB_BASIC_USER_2_SAFENAME}  ${IMAGE_TAG_NAME}=      Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
-    ${NB_BASIC_USER_2}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
-    ${NB_ENDPOINT_BASIC_USER_2}=     Set Variable    ${NB_ENDPOINT_PT1}${NB_BASIC_USER_2}
+    ${NOTEBOOK_CR_NAME_USER2}  ${IMAGE_TAG_NAME}=      Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
+    ${NB_ENDPOINT_BASIC_USER_2}=     Set Variable    ${NB_ENDPOINT_PT1}${NOTEBOOK_CR_NAME_USER2}
     ${NB_ENDPOINT_BASIC_USER_2_STATUS}=     Set Variable    ${NB_ENDPOINT_BASIC_USER_2}${NB_ENDPOINT_PT2}
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden
@@ -603,25 +589,24 @@ Verify Access to notebooks API Endpoint
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${NB_ENDPOINT_PT1}    token=${ADMIN_TOKEN}
     Operation Should Be Unavailable
-    ${NB_ENDPOINT_BASIC_USER_2_BODY}=       Set Username In Notebook Payload    notebook_username=${NB_BASIC_USER_2_SAFENAME}
+    ${NB_ENDPOINT_BASIC_USER_2_BODY}=       Fill In Notebook Payload    notebook_username=${TEST_USER_4.USERNAME}
     ...                                     imagetagname=${IMAGE_TAG_NAME}
     # POST call for update
-    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${BASIC_USER_TOKEN}
-    ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}
-    Operation Should Be Forbidden
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
+    ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}    str_to_json=${TRUE}
+    Operation Should Be Unauthorized
     # POST call for update
-    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_BASIC_USER_2}    token=${ADMIN_TOKEN}
-    ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}
+    Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
+    ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
-    ${NOTEBOOK_BASIC_USER_3}=   Get Safe Username    ${TEST_USER.USERNAME}
-    ${NB_ENDPOINT_BASIC_USER_3_BODY}=       Set Username In Notebook Payload    notebook_username=${NOTEBOOK_BASIC_USER_3}
+    ${NB_ENDPOINT_BASIC_USER_3_BODY}=       Fill In Notebook Payload    notebook_username=${TEST_USER.USERNAME}
     ...                                     imagetagname=${IMAGE_TAG_NAME}
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}/    token=${BASIC_USER_TOKEN}
-    ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}
-    Operation Should Be Forbidden
+    ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
+    Operation Should Be Unauthorized
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}/    token=${ADMIN_TOKEN}
-    ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}
-    Operation Should Be Allowed     accept_code_500=${TRUE}
+    ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
+    Operation Should Be Allowed
     [Teardown]    Delete Test Notebooks CRs And PVCs From CLI
 
 Verify Access to rolebindings API Endpoint
@@ -690,15 +675,14 @@ Verify Access To route API Endpoint
     [Tags]    ODS-1806
     ...       Tier1    Sanity
     ...       Security
-    ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
-    ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_3.USERNAME}
-    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NB_BASIC_USER}    token=${BASIC_USER_TOKEN}
+    ${NOTEBOOK_CR_NAME}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NOTEBOOK_CR_NAME}    token=${BASIC_USER_TOKEN}
     Operation Should Be Allowed
-    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NB_BASIC_USER}    token=${ADMIN_TOKEN}
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NOTEBOOK_CR_NAME}    token=${ADMIN_TOKEN}
     Operation Should Be Allowed
     ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
-    ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
-    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NB_BASIC_USER}    token=${BASIC_USER_TOKEN}
+    ${NOTEBOOK_CR_NAME}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NOTEBOOK_CR_NAME}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/    token=${BASIC_USER_TOKEN}
     Operation Should Be Unavailable
@@ -727,7 +711,7 @@ Verify Access To route API Endpoint
 Endpoint Testing Setup
     [Documentation]     Fetches an access token for both a RHODS admin and basic user
     Set Library Search Order    SeleniumLibrary
-    #RHOSi Setup
+    RHOSi Setup
     ${ADMIN_TOKEN}=   Log In As RHODS Admin
     Set Suite Variable    ${ADMIN_TOKEN}
     ${BASIC_USER_TOKEN}=   Log In As RHODS Basic User
@@ -763,10 +747,11 @@ Spawn Minimal Python Notebook Server
     ...    browser_options=${BROWSER.OPTIONS}
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=s2i-minimal-notebook
-    ${safe_username}=   Get Safe Username    ${username}
+    ${cr_name}=   Get User CR Notebook Name    ${username}
     ${status}   ${image_tag_name}=     Run And Return Rc And Output
-    ...     oc get Notebook --field-selector=metadata.name=${safe_username} -n ${NOTEBOOK_NS} -o=jsonpath='{.items[0].metadata.annotations.notebooks\\.opendatahub\\.io/last-image-selection}'
-    [Return]    ${safe_username}    ${image_tag_name}
+    ...     oc get Notebook --field-selector=metadata.name=${cr_name} -n ${NOTEBOOK_NS} -o=jsonpath='{.items[0].metadata.annotations.notebooks\\.opendatahub\\.io/last-image-selection}'
+    ${image_tag_name}=      Split String From Right    string=${image_tag_name}    separator=:  max_split=1
+    [Return]    ${cr_name}    ${image_tag_name[1]}
 
 Create A Dummy Secret In Dashboard Namespace
     [Documentation]     Creates a dummy secret to use in tests to avoid getting sensitive secrets
@@ -831,11 +816,15 @@ Set Username In PVC Payload
     ${complete_pvc}=     Replace String    ${PVC_ENDPOINT_BODY}    <PVC_NAME>    ${username}
     [Return]    ${complete_pvc}
 
-Set Username In Notebook Payload
+Fill In Notebook Payload
     [Documentation]     Fill in the json body for creating/updating a Notebook with the username
-    [Arguments]     ${notebook_username}    ${imagetagname}
-    ${complete_body}=     Replace String    ${NB_ENDPOINT_BODY}    <USERNAME>    ${notebook_username}
-    ${complete_body}=     Replace String    ${complete_body}    <IMAGETAGNAME>    ${imagetagname}
+    [Arguments]     ${imagetagname}     ${notebook_username}=${NONE}
+    IF    "${notebook_username}" == "${NONE}"
+        ${body}=       Set Variable      ${NB_ENDPOINT_BODY_A}
+    ELSE
+        ${body}=       Replace String    ${NB_ENDPOINT_BODY_B}    <USERNAME>    ${notebook_username}
+    END
+    ${complete_body}=     Replace String    ${body}    <IMAGETAGNAME>    ${imagetagname}
     [Return]    ${complete_body}
 
 Delete Test PVCs

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -597,11 +597,9 @@ Verify Access to notebooks API Endpoint
     Operation Should Be Unavailable
     ${NB_ENDPOINT_BASIC_USER_2_BODY}=       Fill In Notebook Payload For Creation/Update    notebook_username=${TEST_USER_4.USERNAME}
     ...                                     imagetagname=${IMAGE_TAG_NAME}
-    # POST call for update
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}    str_to_json=${TRUE}
     Operation Should Be Unauthorized
-    # POST call for update
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_2_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
@@ -613,13 +611,12 @@ Verify Access to notebooks API Endpoint
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}/    token=${ADMIN_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
-    # pATCH with normal user - 403
-    ${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}=       Fill In Notebook Payload For Stopping    username=${TEST_USER.USERNAME}
+    ${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}=       Fill In Notebook Payload For Stopping    username=${TEST_USER_4.USERNAME}
     Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
-    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
+    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}    str_to_json=${TRUE}
     Operation Should Be Unauthorized
     Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
-    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
+    ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
     [Teardown]    Delete Test Notebooks CRs And PVCs From CLI
 

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -461,10 +461,10 @@ Verify Access To groups-config API Endpoint
     ${current_config}=    Perform Dashboard API Endpoint GET Call   endpoint=${GROUPS_CONFIG_ENDPOINT}    token=${ADMIN_TOKEN}
     Operation Should Be Allowed
     Perform Dashboard API Endpoint PUT Call   endpoint=${GROUPS_CONFIG_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    ...                                       body=${current_config.text}
+    ...                                       body=${current_config}    str_to_json=${FALSE}
     Operation Should Be Unauthorized
     Perform Dashboard API Endpoint PUT Call   endpoint=${GROUPS_CONFIG_ENDPOINT}    token=${ADMIN_TOKEN}
-    ...                                       body=${current_config.text}
+    ...                                       body=${current_config}    str_to_json=${FALSE}
     Operation Should Be Allowed
 
 Verify Access To images API Endpoint
@@ -482,14 +482,13 @@ Verify Access To images API Endpoint
     Perform Dashboard API Endpoint GET Call   endpoint=${IMG_ENDPOINT_PT0}/${IMG_ENDPOINT_PT1}   token=${BASIC_USER_TOKEN}
     Operation Should Be Allowed
     ${current_images}=    Perform Dashboard API Endpoint GET Call   endpoint=${IMG_ENDPOINT_PT0}/${IMG_ENDPOINT_PT1}    token=${ADMIN_TOKEN}
-    Log         ${current_images.json()}
-    ${image_id}=    Set Variable         ${current_images.json()[0]['id']}
+    ${image_id}=    Set Variable         ${current_images[0]['id']}
     Operation Should Be Allowed
     Perform Dashboard API Endpoint PUT Call   endpoint=${IMG_ENDPOINT_PT0}/${image_id}    token=${BASIC_USER_TOKEN}
-    ...                                       body=${current_images.json()[0]}  str_to_json=${FALSE}
+    ...                                       body=${current_images[0]}  str_to_json=${FALSE}
     Operation Should Be Unauthorized
     Perform Dashboard API Endpoint PUT Call   endpoint=${IMG_ENDPOINT_PT0}/${image_id}    token=${ADMIN_TOKEN}
-    ...                                       body=${current_images.json()[0]}  str_to_json=${FALSE}
+    ...                                       body=${current_images[0]}  str_to_json=${FALSE}
     Perform Dashboard API Endpoint DELETE Call   endpoint=${IMG_ENDPOINT_PT0}/${image_id}    token=${BASIC_USER_TOKEN}
     Operation Should Be Unauthorized
     Perform Dashboard API Endpoint DELETE Call   endpoint=${IMG_ENDPOINT_PT0}/${image_id}    token=${ADMIN_TOKEN}

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -170,9 +170,9 @@ Verify Access To getting-started API Endpoint
     ...       Tier1    Sanity
     ...       Security
     Perform Dashboard API Endpoint GET Call   endpoint=${GETTING_STARTED_ENDPOINT}    token=${BASIC_USER_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${GETTING_STARTED_ENDPOINT}    token=${ADMIN_TOKEN}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
 
 Verify Access To quickstarts API Endpoint
     [Documentation]     Verifies the endpoint "quickstarts" works as expected

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -702,9 +702,19 @@ Verify Access To route API Endpoint
     Operation Should Be Forbidden
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/    token=${BASIC_USER_TOKEN}
     Operation Should Be Unavailable
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/    token=${ADMIN_TOKEN}
+    Operation Should Be Unavailable
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}    token=${BASIC_USER_TOKEN}
+    Operation Should Be Unavailable
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}    token=${BASIC_USER_TOKEN}
+    Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}/    token=${BASIC_USER_TOKEN}
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}/    token=${ADMIN_TOKEN}
+    Operation Should Be Unavailable
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}    token=${BASIC_USER_TOKEN}
+    Operation Should Be Unavailable
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}    token=${}
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT2B}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -611,7 +611,7 @@ Verify Access to notebooks API Endpoint
     Perform Dashboard API Endpoint POST Call   endpoint=${NB_ENDPOINT_PT0}/    token=${ADMIN_TOKEN}
     ...                                        body=${NB_ENDPOINT_BASIC_USER_3_BODY}    str_to_json=${TRUE}
     Operation Should Be Allowed
-    ${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}=       Fill In Notebook Payload For Stopping    username=${TEST_USER_4.USERNAME}
+    ${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}=       Fill In Notebook Payload For Stopping    notebook_username=${TEST_USER_4.USERNAME}
     Perform Dashboard API Endpoint PATCH Call   endpoint=${NB_ENDPOINT_PT0}    token=${BASIC_USER_TOKEN}
     ...                                        body=${NB_STOP_ENDPOINT_BASIC_USER_4_BODY}    str_to_json=${TRUE}
     Operation Should Be Unauthorized

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -7,7 +7,7 @@ Resource          ../../Resources/Common.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
 Resource          ../../Resources/Page/ODH/AiApps/Rhosak.resource
 Suite Setup       Endpoint Testing Setup
-Suite Teardown    Endpoint Testing Teardown
+#Suite Teardown    Endpoint Testing Teardown
 
 
 *** Variables ***
@@ -30,22 +30,22 @@ ${GPU_ENDPOINT}=        api/gpu
 ${NOTEBOOK_NS}=          rhods-notebooks
 ${DASHBOARD_NS}=         redhat-ods-applications
 ${NOTEBOOK_USERNAME}=    ""
-${CM_ENDPOINT_PT0}=         api/configmap
+${CM_ENDPOINT_PT0}=         api/envs/configmap
 ${CM_ENDPOINT_PT1}=         ${CM_ENDPOINT_PT0}/${NOTEBOOK_NS}/jupyterhub-singleuser-profile-
 ${CM_ENDPOINT_PT2}=         -envs
 ${CM_ENDPOINT_BODY}=            {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"${NOTEBOOK_NS}"}}
 ${DUMMY_CM_NAME}=           test-dummy-configmap
-${CM_DASHBOARD_ENDPOINT}=         api/configmap/${DASHBOARD_NS}/${DUMMY_CM_NAME}
+${CM_DASHBOARD_ENDPOINT}=         ${CM_ENDPOINT_PT0}/${DASHBOARD_NS}/${DUMMY_CM_NAME}
 ${CM_DASHBOARD_ENDPOINT_BODY}=         {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"${DUMMY_CM_NAME}","namespace":"${DASHBOARD_NS}"},"data":{"key":"newvalue"}}
 ${CM_OUTSIDE_DASHBOARD_ENDPOINT_BODY}=         {"kind":"ConfigMap","apiVersion":"v1","metadata":{"name":"${DUMMY_CM_NAME}","namespace":"redhat-ods-monitoring"},"data":{"key":"newvalue"}}
-${CM_OUTSIDE_DASHBOARD_ENDPOINT}=         api/configmap/redhat-ods-monitoring/prometheus
+${CM_OUTSIDE_DASHBOARD_ENDPOINT}=         ${CM_ENDPOINT_PT0}/redhat-ods-monitoring/prometheus
 ${DUMMY_SECRET_NAME}=           test-dummy-secret
-${SECRET_DASHBOARD_ENDPOINT}=         api/secret/${DASHBOARD_NS}/${DUMMY_SECRET_NAME}
-${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}=         api/secret/redhat-ods-monitoring/${DUMMY_SECRET_NAME}
-${SECRET_ENDPOINT_PT0}=         api/secret
+${SECRET_ENDPOINT_PT0}=         api/envs/secret
 ${SECRET_ENDPOINT_PT1}=         ${SECRET_ENDPOINT_PT0}/${NOTEBOOK_NS}/jupyterhub-singleuser-profile-
 ${SECRET_ENDPOINT_PT2}=         -envs
 ${SECRET_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"jupyterhub-singleuser-profile-<NB_USERNAME>-envs","namespace":"${NOTEBOOK_NS}"},"type":"Opaque"}
+${SECRET_DASHBOARD_ENDPOINT}=         ${SECRET_ENDPOINT_PT0}/${DASHBOARD_NS}/${DUMMY_SECRET_NAME}
+${SECRET_OUTSIDE_DASHBOARD_ENDPOINT}=         ${SECRET_ENDPOINT_PT0}/redhat-ods-monitoring/${DUMMY_SECRET_NAME}
 ${SECRET_DASHBOARD_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"${DUMMY_SECRET_NAME}","namespace":"${DASHBOARD_NS}"},"type":"Opaque"}
 ${SECRET_OUTSIDE_DASHBOARD_ENDPOINT_BODY}=        {"kind":"Secret","apiVersion":"v1","metadata":{"name":"${DUMMY_SECRET_NAME}","namespace":"redhat-ods-monitoring"},"type":"Opaque"}
 
@@ -72,7 +72,7 @@ ${VALIDATE_ISV_RESULT_ENDPOINT}=         api/validate-isv/results?appName=anacon
 ${NB_ENDPOINT_PT0}=      api/notebooks
 ${NB_ENDPOINT_PT1}=      ${NB_ENDPOINT_PT0}/${NOTEBOOK_NS}/
 ${NB_ENDPOINT_PT2}=      /status
-${NB_ENDPOINT_BODY}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":null,"state":"started","username":"<USERNAME>}
+${NB_ENDPOINT_BODY}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":null,"state":"started","username":"<USERNAME>"}
 # ${NB_ENDPOINT_BODY}=      {"apiVersion":"kubeflow.org/v1","kind":"Notebook","metadata":{"labels":{"app":"jupyter-nb-<NB_USERNAME>","opendatahub.io/odh-managed":"true","opendatahub.io/user":"<NB_USERNAME>"},"name":"jupyter-nb-<NB_USERNAME>","namespace":"${NOTEBOOK_NS}"},"spec":{"template":{"spec":{"enableServiceLinks":false,"containers":[{"image":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07","imagePullPolicy":"Always","workingDir":"/opt/app-root/src","name":"jupyter-nb-<NB_USERNAME>","env":[{"name":"JUPYTER_IMAGE","value":"image-registry.openshift-image-registry.svc:5000/${DASHBOARD_NS}/s2i-minimal-notebook:py3.8-1.16.0-hotfix-2fada07"}],"resources":{"limits":{"cpu":"2","memory":"8Gi"},"requests":{"cpu":"1","memory":"8Gi"}},"volumeMounts":[{"mountPath":"/opt/app-root/src","name":"jupyterhub-nb-<NB_USERNAME>-pvc"}],"ports":[{"name":"notebook-port","containerPort":8888,"protocol":"TCP"}]}],"volumes":[{"name":"jupyterhub-nb-<NB_USERNAME>-pvc","persistentVolumeClaim":{"claimName":"jupyterhub-nb-<NB_USERNAME>-pvc"}}]}}}}
 
 ${PVC_ENDPOINT_PT0}=      api/pvc
@@ -298,7 +298,7 @@ Verify Access To Notebook configmap API Endpoint
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint POST Call   endpoint=${CM_ENDPOINT_PT0}    token=${ADMIN_TOKEN}
     ...                                       body=${cm_basic_user_2_body}
-    Operation Should Be Allowed
+    Operation Should Be Unavailable
     [Teardown]     Delete Test Notebooks CRs And PVCs From CLI
 
 Verify Access To Notebook secret API Endpoint
@@ -696,8 +696,8 @@ Verify Access To route API Endpoint
     Operation Should Be Allowed
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NB_BASIC_USER}    token=${ADMIN_TOKEN}
     Operation Should Be Allowed
-    ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_2.USERNAME}    password=${TEST_USER_2.PASSWORD}
-    ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_2.USERNAME}
+    ${NOTEBOOK_BASIC_USER}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_4.USERNAME}    password=${TEST_USER_4.PASSWORD}
+    ${NB_BASIC_USER}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/${NB_BASIC_USER}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1}/    token=${BASIC_USER_TOKEN}
@@ -714,7 +714,7 @@ Verify Access To route API Endpoint
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}    token=${BASIC_USER_TOKEN}
     Operation Should Be Unavailable
-    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}    token=${}
+    Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT1B}    token=${ADMIN_TOKEN}
     Operation Should Be Unavailable
     Perform Dashboard API Endpoint GET Call   endpoint=${ROUTE_ENDPOINT_PT2B}    token=${BASIC_USER_TOKEN}
     Operation Should Be Forbidden
@@ -735,7 +735,7 @@ Endpoint Testing Setup
 
 Endpoint Testing Teardown
     [Documentation]     Switches to original OC context
-    #RHOSi Teardown
+    RHOSi Teardown
 
 Log In As RHODS Admin
     [Documentation]     Perfom OC login using a RHODS admin user
@@ -842,5 +842,10 @@ Delete Test PVCs
     [Documentation]     Delets the PVCs received as arguments
     [Arguments]     ${pvc_names}
     FOR   ${pvc}    IN  @{pvc_names}
-        OpenshiftLibrary.Oc Delete    kind=PersistentVolumeClaim    namespace=${NOTEBOOK_NS}    name=${pvc}
+        ${present}=     OpenshiftLibrary.Oc Get    kind=PersistentVolumeClaim  namespace=${NOTEBOOK_NS}  name=${pvc}
+        IF    ${present} == ${NONE}
+            Continue For Loop
+        ELSE
+            OpenshiftLibrary.Oc Delete    kind=PersistentVolumeClaim    namespace=${NOTEBOOK_NS}    name=${pvc}
+        END
     END

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -75,7 +75,7 @@ ${NB_ENDPOINT_PT2}=      /status
 ${NB_ENDPOINT_BODY_A}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started"}
 ${NB_ENDPOINT_BODY_B}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started","username":"<USERNAME>"}
 ${NB_STOP_ENDPOINT_BODY_A}=    {"state":"stopped"}
-${NB_STOP_ENDPOINT_BODY_B}=    {"state":"stopped","username": "ldap-admin17"}
+${NB_STOP_ENDPOINT_BODY_B}=    {"state":"stopped","username": "<USERNAME>"}
 
 ${PVC_ENDPOINT_PT0}=      api/pvc
 ${PVC_ENDPOINT_PT1}=      ${PVC_ENDPOINT_PT0}/${NOTEBOOK_NS}/

--- a/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -804,7 +804,12 @@ Delete Test Notebooks CRs And PVCs From CLI
     ${CR_2}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
     ${test_crs}=   Create List     ${CR_1}   ${CR_2}
     FOR   ${nb_cr}    IN  @{test_crs}
-        OpenshiftLibrary.Oc Delete    kind=Notebook    namespace=${NOTEBOOK_NS}    name=${nb_cr}
+        ${present}=     Run Keyword And Return Status   OpenshiftLibrary.Oc Get    kind=Notebook  namespace=${NOTEBOOK_NS}  name=${nb_cr}
+        IF    ${present} == ${FALSE}
+            Continue For Loop
+        ELSE
+            OpenshiftLibrary.Oc Delete    kind=Notebook    namespace=${NOTEBOOK_NS}    name=${nb_cr}
+        END
     END
     Close All Browsers
     ${PVC_BASIC_USER}=   Get User Notebook PVC Name    ${TEST_USER_3.USERNAME}


### PR DESCRIPTION
Adapting tests after changes introduced by https://issues.redhat.com/browse/RHODS-5388 
Main changes:
- `pvc` endpoint is not reachable anymore: tests expects 404
- `notebooks` endpoints have changed the expected JSON body to create/update/stop notebook servers plus PUT has been removed: tests use POST for both creation and update, while PATCH is used to stop
- `configmaps` and `secrets` endpoints have been replaced by `envs` which should allow GET only

Moreover it adds the test for `route` endpoint which was introduced in v1.16

Signed-off-by: bdattoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)