### PR TITLE
Wait for cuda builds in Sanity

### DIFF
--- a/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -5,6 +5,7 @@ Resource         ../../Resources/Common.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/GPU.resource
+Resource         ../../Resources/Page/OCPDashboard/Builds/Builds.robot
 Library          DebugLibrary
 Library          JupyterLibrary
 Suite Setup      Verify PyTorch Image Suite Setup
@@ -84,6 +85,7 @@ Verify PyTorch Image GPU Workload
 *** Keywords ***
 Verify PyTorch Image Suite Setup
     [Documentation]    Suite Setup, spawns pytorch image
+    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small

--- a/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -5,6 +5,7 @@ Resource         ../../Resources/Common.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/GPU.resource
+Resource         ../../Resources/Page/OCPDashboard/Builds/Builds.robot
 Library          Screenshot
 Library          DebugLibrary
 Library          JupyterLibrary
@@ -82,6 +83,7 @@ Verify Tensorflow Image GPU Workload
 *** Keywords ***
 Verify Tensorflow Image Suite Setup
     [Documentation]    Suite Setup, spawns tensorflow image
+    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small

--- a/tests/Tests/500__jupyterhub/test-folder-permissions.robot
+++ b/tests/Tests/500__jupyterhub/test-folder-permissions.robot
@@ -4,17 +4,20 @@ Documentation       Test Suite to check the folder permissions
 Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
 Resource            ../../Resources/Page/ODH/JupyterHub/ODHJupyterhub.resource
+Resource            ../../Resources/Page/OCPDashboard/Builds/Builds.robot
 
 Library             JupyterLibrary
 
 Suite Setup         Load Spawner Page
 Suite Teardown      End Web Test
 
+
 *** Variables ***
 @{LIST_OF_IMAGES} =    s2i-minimal-notebook    s2i-generic-data-science-notebook
 ...                    pytorch    tensorflow    minimal-gpu
 @{EXPECTED_PERMISSIONS} =       0775    0    1001
 @{FOLDER_TO_CHECK} =            /opt/app-root/lib    /opt/app-root/share
+
 
 *** Test Cases ***
 Verify Folder Permissions
@@ -28,6 +31,7 @@ Verify Folder Permissions
 *** Keywords ***
 Load Spawner Page
     [Documentation]    Suite Setup, loads JH Spawner
+    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
 

--- a/tests/Tests/500__jupyterhub/test-jupyterlab-time.robot
+++ b/tests/Tests/500__jupyterhub/test-jupyterlab-time.robot
@@ -3,6 +3,7 @@ Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
 Resource            ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource            ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+Resource            ../../Resources/Page/OCPDashboard/Builds/Builds.robot
 Library             DateTime
 Library             OpenShiftCLI
 Library             DebugLibrary
@@ -16,6 +17,7 @@ Suite Teardown      End Web Test
 ...                     pytorch                 tensorflow    minimal-gpu
 
 ${LIMIT_TIME} =    40
+
 
 *** Test Cases ***
 Verify Average Spawn Time Is Less Than 40 Seconds
@@ -31,6 +33,7 @@ Verify Average Spawn Time Is Less Than 40 Seconds
 *** Keywords ***
 Load Spawner Page
     [Documentation]    Suite Setup, loads JH Spawner
+    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
 

--- a/tests/Tests/500__jupyterhub/test-versions.robot
+++ b/tests/Tests/500__jupyterhub/test-versions.robot
@@ -5,6 +5,7 @@ Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
 Resource            ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource            ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+Resource            ../../Resources/Page/OCPDashboard/Builds/Builds.robot
 Library             JupyterLibrary
 
 Suite Setup         Load Spawner Page
@@ -95,6 +96,7 @@ Verify Libraries In Base Image    # robocop: disable
 
 Load Spawner Page
     [Documentation]    Suite Setup, loads JH Spawner
+    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
 


### PR DESCRIPTION
Some tests were failing if Smoke wasn't run before Sanity in the cluster. This PR should fix that