### PR TITLE
In RHOSi Setup and Teardown, warn if alerts are firing or pending

### DIFF
--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -123,6 +123,7 @@ Suite Availability Setup
     ...    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
     Run Keyword And Warn On Failure    Alerts Should Not Be Firing
     ...    pm_url=${pm_url}    pm_token=${pm_token}    expected-firing-alert=DeadManSnitch
+    ...    message_prefix=Suite Setup: ${SUITE NAME}:
 
 Suite Availability Teardown
     [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
@@ -130,6 +131,7 @@ Suite Availability Teardown
     [Arguments]    ${pm_url}    ${pm_token}
     Run Keyword And Warn On Failure
     ...    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
-    ...    message_prefix=Suite Teardown: ${SUITE NAME}:
+    ...    message_prefix=Suite Trdwn: ${SUITE NAME}:
     Run Keyword And Warn On Failure    Alerts Should Not Be Firing
     ...    pm_url=${pm_url}    pm_token=${pm_token}    expected-firing-alert=DeadManSnitch
+    ...    message_prefix=Suite Trdwn: ${SUITE NAME}:

--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -119,12 +119,17 @@ Suite Availability Setup
     [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
     ...    Log a WARN message if availability is under 99.95
     [Arguments]    ${pm_url}    ${pm_token}
-    Run Keyword And Warn On Failure    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
+    Run Keyword And Warn On Failure
+    ...    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
+    Run Keyword And Warn On Failure    Alerts Should Not Be Firing
+    ...    pm_url=${pm_url}    pm_token=${pm_token}    expected-firing-alert=DeadManSnitch
 
 Suite Availability Teardown
     [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
     ...    Logs a WARN message if the current values are lower
     [Arguments]    ${pm_url}    ${pm_token}
-
-    Run Keyword And Warn On Failure    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
+    Run Keyword And Warn On Failure
+    ...    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}
     ...    message_prefix=Suite Teardown: ${SUITE NAME}:
+    Run Keyword And Warn On Failure    Alerts Should Not Be Firing
+    ...    pm_url=${pm_url}    pm_token=${pm_token}    expected-firing-alert=DeadManSnitch

--- a/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
+++ b/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
@@ -130,10 +130,10 @@ Alert Should Be Firing    # robocop: disable:too-many-calls-in-keyword
     END
 
 Alerts Should Not Be Firing    #robocop: disable:too-many-calls-in-keyword
-    [Documentation]    Fails if any Prometheus alert is firing, excluding alert
-    ...    with name = ${expected-firing-alert}
+    [Documentation]    Fails if any Prometheus alert is in pending or firing state,
+    ...  excluding alert with name = ${expected-firing-alert}
     [Arguments]    ${pm_url}    ${pm_token}    ${expected-firing-alert}=${EMPTY}     ${message_prefix}=${EMPTY}
-
+    
     ${all_rules}=    Get Rules    ${pm_url}    ${pm_token}    alert
     ${all_rules}=    Get From Dictionary    ${all_rules['data']}    groups
     @{alerts_firing}=    Create List
@@ -145,9 +145,9 @@ Alerts Should Not Be Firing    #robocop: disable:too-many-calls-in-keyword
             ${state}=    Get From Dictionary    ${sub_rule}    state
             ${name}=    Get From Dictionary    ${sub_rule}    name
             ${duration}=    Get From Dictionary    ${sub_rule}    duration
-            IF    '${state}' == 'firing'
+            IF    '${state}' in ['firing','pending']
                 IF    '${name}' != '${expected-firing-alert}'
-                    ${alert_info}=    Set Variable    ${name} (for:${duration})
+                    ${alert_info}=    Set Variable    ${name} (for:${duration}, state:${state})
                     Append To List    ${alerts_firing}    ${alert_info}
                 END
             END

--- a/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
+++ b/tests/Resources/Page/ODH/Prometheus/Prometheus.robot
@@ -128,6 +128,28 @@ Alert Should Be Firing    # robocop: disable:too-many-calls-in-keyword
         Fail    msg=Alert "${alert} ${alert-duration}" was not found in Prometheus
     END
 
+Alerts Should Not Be Firing
+    [Documentation]    Fails if any Prometheus alert is firing, excluding alert
+    ...    with name = ${expected-firing-alert}
+    [Arguments]    ${pm_url}    ${pm_token}    ${expected-firing-alert}=${EMPTY}
+
+    ${all_rules}=    Get Rules    ${pm_url}    ${pm_token}    alert
+    ${all_rules}=    Get From Dictionary    ${all_rules['data']}    groups
+    FOR    ${rule}    IN    @{all_rules}
+        ${rule_name}=    Get From Dictionary    ${rule}    name
+        ${rules_list}=    Get From Dictionary    ${rule}    rules
+        FOR    ${sub_rule}    IN    @{rules_list}
+            ${state}=    Get From Dictionary    ${sub_rule}    state
+            ${name}=    Get From Dictionary    ${sub_rule}    name
+            ${duration}=    Get From Dictionary    ${sub_rule}    duration
+            IF    '${state}' == 'firing'
+                    IF    '${name}' != '${expected-firing-alert}'
+                        Fail    msg=Alert ${name} (for=${duration}) should not be firing
+                    END
+            END
+        END
+    END
+
 Alert Severity Should Be    # robocop: disable:too-many-calls-in-keyword
     [Documentation]    Fails if a given Prometheus alert does not have the expected severity
     [Arguments]    ${pm_url}    ${pm_token}    ${rule_group}    ${alert}    ${alert-severity}    ${alert-duration}=${EMPTY}    #robocop:disable


### PR DESCRIPTION
In RHOSi Setup and RHOSi Teardown, add a warning to the Robot Framework log if any alert except for DeadManSnitch is firing 

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>