### PR TITLE
Restore ODS-293 test case

### DIFF
--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -28,7 +28,6 @@ Verify User Can Set Custom RHODS Groups
     ...                different from rhods-admins and rhods-users
     [Tags]  Sanity
     ...     ODS-293    ODS-503
-    ...     ProductBug
     [Setup]      Set Standard RHODS Groups Variables
     Create Custom Groups
     Add Test Users To Custom Groups


### PR DESCRIPTION
Since "Administration" tab will be back in RHODS   v1.20, we can re-enable ODS-293 in Sanity