### PR TITLE
Add notebook spawning with basic user in Smoke suite

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -29,9 +29,10 @@ Begin Web Test
     Go To  ${ODH_DASHBOARD_URL}
 
 End Web Test
+    [Arguments]    ${username}=${TEST_USER.USERNAME}
     ${server}=  Run Keyword and Return Status  Page Should Contain Element  //div[@id='jp-top-panel']//div[contains(@class, 'p-MenuBar-itemLabel')][text() = 'File']
     IF  ${server}==True
-        Clean Up Server
+        Clean Up Server    username=${username}
         Stop JupyterLab Notebook Server
         Capture Page Screenshot
     END

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -14,16 +14,15 @@ Begin Web Test
     [Documentation]  This keyword should be used as a Suite Setup; it will log in to the
     ...              ODH dashboard, checking that the spawner is in a ready state before
     ...              handing control over to the test suites.
-
+    [Arguments]    ${username}=${TEST_USER.USERNAME}    ${password}=${TEST_USER.PASSWORD}
+    ...            ${auth_type}=${TEST_USER.AUTH_TYPE}
     Set Library Search Order  SeleniumLibrary
     RHOSi Setup
-
-
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
-    Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Login To RHODS Dashboard  ${username}  ${password}  ${auth_type}
     Wait for RHODS Dashboard to Load
     Launch Jupyter From RHODS Dashboard Link
-    Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
+    Login To Jupyterhub  ${username}  ${password}  ${auth_type}
     ${authorization_required} =  Is Service Account Authorization Required
     Run Keyword If  ${authorization_required}  Authorize jupyterhub service account
     Fix Spawner Status

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -517,8 +517,10 @@ Handle Bad Gateway Page
 Verify Image Can Be Spawned
     [Documentation]    Verifies that an image with given arguments can be spawned
     [Arguments]    ${retries}=1    ${retries_delay}=0 seconds    ${image}=s2i-generic-data-science-notebook    ${size}=Small
-    ...    ${spawner_timeout}=600 seconds    ${gpus}=0    ${refresh}=${False}    &{envs}
-    Begin Web Test
+    ...    ${spawner_timeout}=600 seconds    ${gpus}=0    ${refresh}=${False}    
+    ...    ${username}=${TEST_USER.USERNAME}    ${password}=${TEST_USER.PASSWORD}
+    ...    ${auth_type}=${TEST_USER.AUTH_TYPE}    &{envs}
+    Begin Web Test    username=${username}    password=${password}    auth_type=${auth_type}
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments    retries=${retries}   retries_delay=${retries_delay}    image=${image}    size=${size}
     ...    spawner_timeout=${spawner_timeout}    gpus=${gpus}    refresh=${refresh}    envs=&{envs}

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -524,7 +524,7 @@ Verify Image Can Be Spawned
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments    retries=${retries}   retries_delay=${retries_delay}    image=${image}    size=${size}
     ...    spawner_timeout=${spawner_timeout}    gpus=${gpus}    refresh=${refresh}    envs=&{envs}
-    End Web Test
+    End Web Test    username=${username}
 
 Verify Library Version Is Greater Than
     [Arguments]     ${library}      ${target}

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -517,7 +517,7 @@ Handle Bad Gateway Page
 Verify Image Can Be Spawned
     [Documentation]    Verifies that an image with given arguments can be spawned
     [Arguments]    ${retries}=1    ${retries_delay}=0 seconds    ${image}=s2i-generic-data-science-notebook    ${size}=Small
-    ...    ${spawner_timeout}=600 seconds    ${gpus}=0    ${refresh}=${False}    
+    ...    ${spawner_timeout}=600 seconds    ${gpus}=0    ${refresh}=${False}
     ...    ${username}=${TEST_USER.USERNAME}    ${password}=${TEST_USER.PASSWORD}
     ...    ${auth_type}=${TEST_USER.AUTH_TYPE}    &{envs}
     Begin Web Test    username=${username}    password=${password}    auth_type=${auth_type}

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -145,7 +145,11 @@ Verify That CUDA Build Chain Succeeds
     Skip If RHODS Version Greater Or Equal Than  1.20.0  CUDA build chain removed in v1.20
     Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
     Verify Image Can Be Spawned    image=pytorch  size=Small
+    ...    username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
+    ...    auth_type=${TEST_USER_3.AUTH_TYPE}
     Verify Image Can Be Spawned    image=tensorflow  size=Small
+    ...    username=${TEST_USER.USERNAME}    password=${TEST_USER.PASSWORD}
+    ...    auth_type=${TEST_USER.AUTH_TYPE}
 
 Verify That Blackbox-exporter Is Protected With Auth-proxy
     [Documentation]    Vrifies the blackbok-exporter inludes 2 containers one for application and second for oauth proxy

--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -142,8 +142,10 @@ Verify That CUDA Build Chain Succeeds
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-316    ODS-481
-    Skip If RHODS Version Greater Or Equal Than  1.20.0  CUDA build chain removed in v1.20
-    Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
+    ${version_check}=  Is RHODS Version Greater Or Equal Than  1.20.0
+    IF  ${version_check}==False
+        Wait Until All Builds Are Complete    namespace=redhat-ods-applications    build_timeout=45m
+    END
     Verify Image Can Be Spawned    image=pytorch  size=Small
     ...    username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     ...    auth_type=${TEST_USER_3.AUTH_TYPE}


### PR DESCRIPTION
Modifying `Verify That CUDA Build Chain Succeeds` to try spawning a notebook with a basic user istead of admin.
Signed-off-by: bdattoma [bdattoma@redhat.com](mailto:bdattoma@redhat.com)