### PR TITLE
Fix test-versions tooltip xpath

### DIFF
--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -489,7 +489,6 @@ Fetch Image Tooltip Info
         Append To List    ${tmp_list}    ${item}
     END
     Click Element    xpath://div[@class='pf-c-popover__content']/button[@aria-label="Close"]
-    Click Element    xpath://div[.="Deployment size"]
     [Return]    ${tmp_list}
 
 Spawn Notebooks And Set S3 Credentials

--- a/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -475,21 +475,22 @@ Fetch Image Tooltip Description
     [Return]  ${desc}
 
 Fetch Image Tooltip Info
-    [Documentation]  Fetches libraries in image tooltip text
-    [Arguments]  ${img}
-    ${xpath_img_tooltip} =  Set Variable  //input[contains(@id, "${img}")]/../label/span/*
-    ${xpath_tooltip_items} =  Set Variable  //div[@class='pf-c-popover__body']/p
-    @{tmp_list} =  Create List
-    Click Element  ${xpath_img_tooltip}
-    ${libs} =  Get Element Count  ${xpath_tooltip_items}
-    Log  ${libs}
-    FOR  ${index}  IN RANGE  3  1+${libs}
-        Sleep  0.1s
-        ${item} =  Get Text  ${xpath_tooltip_items}\[${index}]
-        Append To List  ${tmp_list}  ${item}
+    [Documentation]    Fetches libraries in image tooltip text
+    [Arguments]    ${img}
+    ${xpath_img_tooltip} =    Set Variable    //input[contains(@id, "${img}")]/../label//div[@class=""][.=""]
+    ${xpath_tooltip_items} =    Set Variable    //div[@class='pf-c-popover__body']/p
+    @{tmp_list} =    Create List
+    Click Element    ${xpath_img_tooltip}
+    ${libs} =    Get Element Count    ${xpath_tooltip_items}
+    Log    ${libs}
+    FOR    ${index}    IN RANGE    3    1+${libs}
+        Sleep    0.1s
+        ${item} =    Get Text    ${xpath_tooltip_items}\[${index}]
+        Append To List    ${tmp_list}    ${item}
     END
-    Click Element  xpath://div[.="Deployment size"]
-    [Return]  ${tmp_list}
+    Click Element    xpath://div[@class='pf-c-popover__content']/button[@aria-label="Close"]
+    Click Element    xpath://div[.="Deployment size"]
+    [Return]    ${tmp_list}
 
 Spawn Notebooks And Set S3 Credentials
     [Documentation]     Spawn a jupyter notebook server and set the env variables


### PR DESCRIPTION
This fixes the tooltip xpath for the test-versions test suite in Sanity.
Tested locally and all tests pass except for one:
![image](https://user-images.githubusercontent.com/82518733/208083849-75a58a1e-01f2-4d7b-8d2c-29e93afeb695.png)
This will be fixed when https://github.com/red-hat-data-services/odh-manifests/pull/285 is merged