### PR TITLE
Improve keyword to wait for dashboard and remove Seldon folder

### DIFF
--- a/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
+++ b/tests/Resources/Page/HybridCloudConsole/Rhosak.robot
@@ -226,7 +226,7 @@ Clean Up RHOSAK
     [Documentation]    Cleans up all the RHOSAK created resources from RHOSAK and RHODS UI
     [Arguments]    ${stream_to_delete}    ${topic_to_delete}    ${sa_clientid_to_delete}  ${rhosak_app_id}
     ${window_title}=    Get Title
-    IF    $window_title == "Streams for Apache Kafka | Red Hat OpenShift Application Services"
+    IF    $window_title == "Streams for Apache Kafka | Red Hat OpenShift Application Services" or $window_title == "Red Hat OpenShift Streams for Apache Kafka"
         Maybe Skip RHOSAK Tour
         ${modal_exists}=     Run Keyword And Return Status   Wait Until Page Contains Element    xpath=//*[contains(@class, "modal")]
         IF    ${modal_exists}==${TRUE}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -82,8 +82,10 @@ Logout From RHODS Dashboard
 
 Wait for RHODS Dashboard to Load
     [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"    ${wait_for_cards}=${TRUE}
+    ...          ${expected_page}=Enabled
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=15s
+    Wait Until Page Contains Element    xpath://h1[text()="${expected_page}"]
     IF    ${wait_for_cards} == ${TRUE}
         Wait Until Cards Are Loaded
     END

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -129,7 +129,8 @@ Verify Service Is Available In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    Jupyter  timeout=30
+  # Wait Until Page Contains    Jupyter  timeout=30
+  Wait for RHODS Dashboard to Load    expected_page=Explore
   Capture Page Screenshot
   Page Should Contain Element    //article//*[.='${app_name}']
 

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -49,9 +49,10 @@ ${RHODS_LOGO_XPATH}=    //img[@alt="Red Hat OpenShift Data Science Logo"]
 *** Keywords ***
 Launch Dashboard
   [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}  ${dashboard_url}  ${browser}  ${browser_options}
+  ...          ${expected_page}=Enabled
   Open Browser  ${dashboard_url}  browser=${browser}  options=${browser_options}
   Login To RHODS Dashboard  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
-  Wait for RHODS Dashboard to Load
+  Wait for RHODS Dashboard to Load    expected_page=${expected_page}
 
 Authorize rhods-dashboard service account
   Wait Until Page Contains  Authorize Access
@@ -85,7 +86,9 @@ Wait for RHODS Dashboard to Load
     ...          ${expected_page}=Enabled
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=15s
-    Wait Until Page Contains Element    xpath://h1[text()="${expected_page}"]
+    IF    "${expected_page}" != "${NONE}"
+        Wait Until Page Contains Element    xpath://h1[text()="${expected_page}"]        
+    END
     IF    ${wait_for_cards} == ${TRUE}
         Wait Until Cards Are Loaded
     END

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -49,10 +49,11 @@ ${RHODS_LOGO_XPATH}=    //img[@alt="Red Hat OpenShift Data Science Logo"]
 *** Keywords ***
 Launch Dashboard
   [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}  ${dashboard_url}  ${browser}  ${browser_options}
-  ...          ${expected_page}=Enabled
+  ...          ${expected_page}=Enabled    ${wait_for_cards}=${TRUE}
   Open Browser  ${dashboard_url}  browser=${browser}  options=${browser_options}
   Login To RHODS Dashboard  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
   Wait for RHODS Dashboard to Load    expected_page=${expected_page}
+  ...    wait_for_cards=${wait_for_cards}
 
 Authorize rhods-dashboard service account
   Wait Until Page Contains  Authorize Access

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -81,9 +81,13 @@ Logout From RHODS Dashboard
     Wait Until Page Contains  Log in with OpenShift
 
 Wait for RHODS Dashboard to Load
-    [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"
+    [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"    ${wait_for_cards}=${TRUE}
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=15s
+    IF    ${wait_for_cards} == ${TRUE}
+        Wait Until Cards Are Loaded
+    END
+    
 
 Wait Until RHODS Dashboard ${dashboard_app} Is Visible
   # Ideally the timeout would be an arg but Robot does not allow "normal" and "embedded" arguments
@@ -185,7 +189,8 @@ Load Expected Data Of RHODS Explore Section
     [Return]  ${apps_dict_obj}
 
 Wait Until Cards Are Loaded
-    Wait Until Page Contains Element    xpath://div[contains(@class,'odh-explore-apps__gallery')]
+    Wait Until Page Contains Element    xpath://div[contains(@class,'-apps__gallery')]
+    
 
 Get App ID From Card
     [Arguments]  ${card_locator}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -22,10 +22,11 @@ ${SPAWNER_LINK}=        xpath=//a[text()="Launch Jupyter"]
 *** Keywords ***
 Open Data Science Projects Home Page
     [Documentation]    Verifies submenu Settings > "Data Science Projects" is visible
-    Page Should Contain    Data Science Projects
+    # Page Should Contain    Data Science Projects
     Click Link      Data Science Projects
+    Wait for RHODS Dashboard to Load    wait_for_cards=${FALSE}    expected_page=Data science projects
     Wait Until Page Contains    View your existing projects or create new projects.    timeout=30
-    Wait Until Page Contains Element    ${DS_PROJECT_XP}    timeout=30
+    # Wait Until Page Contains Element    ${DS_PROJECT_XP}    timeout=30
     Maybe Wait For Dashboard Loading Spinner Page
 
 Is Data Science Projects Page Open

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -103,9 +103,10 @@ Set Custom Access Groups
 Check New Access Configuration Works As Expected
     [Documentation]    Checks if the new access configuration (using two custom groups)
     ...                works as expected in JH
-    Launch Dashboard   ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ...   ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
-    ...   ${expected_page}=${NONE}
+    Launch Dashboard   ocp_user_name=${TEST_USER.USERNAME}  ocp_user_pw=${TEST_USER.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
+    ...    browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
+    ...    expected_page=${NONE}
     ${version_check}=    Is RHODS Version Greater Or Equal Than    1.20.0
     IF    ${version_check} == True
         ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link
@@ -126,6 +127,7 @@ Check New Access Configuration Works As Expected
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}
     Wait for RHODS Dashboard to Load    expected_page=Start a notebook server
+    ...    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure   Verify Jupyter Access Level     expected_result=user
     Capture Page Screenshot    perm_user_custom.png
     Logout From RHODS Dashboard
@@ -140,7 +142,8 @@ Check Standard Access Configuration Works As Expected
     Capture Page Screenshot    perm_admin_std.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_4.USERNAME}  ${TEST_USER_4.PASSWORD}  ${TEST_USER_4.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait for RHODS Dashboard to Load    expected_page=Start a notebook server
+    ...    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=user
     Capture Page Screenshot    perm_user_std.png
     Logout From RHODS Dashboard

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -106,7 +106,7 @@ Check New Access Configuration Works As Expected
     Launch Dashboard   ocp_user_name=${TEST_USER.USERNAME}  ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
     ...    browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
-    ...    expected_page=${NONE}
+    ...    expected_page=${NONE}    wait_for_cards=${FALSE}
     ${version_check}=    Is RHODS Version Greater Or Equal Than    1.20.0
     IF    ${version_check} == True
         ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link

--- a/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -105,6 +105,7 @@ Check New Access Configuration Works As Expected
     ...                works as expected in JH
     Launch Dashboard   ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     ...   ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
+    ...   ${expected_page}=${NONE}
     ${version_check}=    Is RHODS Version Greater Or Equal Than    1.20.0
     IF    ${version_check} == True
         ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link
@@ -124,7 +125,7 @@ Check New Access Configuration Works As Expected
     Capture Page Screenshot    perm_admin_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait for RHODS Dashboard to Load    expected_page=Start a notebook server
     Run Keyword And Continue On Failure   Verify Jupyter Access Level     expected_result=user
     Capture Page Screenshot    perm_user_custom.png
     Logout From RHODS Dashboard

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -14,7 +14,6 @@ Verify RHOAM Is Available In RHODS Dashboard Explore Page
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
-  Maybe Wait For Dashboard Loading Spinner Page
   Verify Service Is Available In The Explore Page    OpenShift API Management
   Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
 

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -14,6 +14,7 @@ Verify RHOAM Is Available In RHODS Dashboard Explore Page
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
+  Maybe Wait For Dashboard Loading Spinner Page
   Verify Service Is Available In The Explore Page    OpenShift API Management
   Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
 


### PR DESCRIPTION
we've notice some rare failures in waiting until the dashboard is loaded (the RHODS log was loaded but the rest of the page like cards were not).

The PR is adding 2 fixes:
1. Wait until the expected page title (h1) is loaded, e.g., Explore.
2. Wait until the applications' cards are loaded - OPTIONAL