### PR TITLE
Restore ODS-1081 and fix Keyword to fetch cluster environment

### DIFF
--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -337,7 +337,7 @@ Fetch ODS Cluster Environment
    ...        Returns:
    ...        Cluster Environment (str)
    ${match}=    Fetch Cluster Platform Type
-   Run Keyword If    '${match}'!='AWS' or '${match}'!='GCP'    FAIL    msg=This keyword should be used only in OSD clusters
+   Run Keyword If    '${match}'!='AWS' and '${match}'!='GCP'    FAIL    msg=This keyword should be used only in OSD clusters
    ${match}  ${status}=    Run Keyword And Ignore Error  Should Contain    ${OCP_CONSOLE_URL}    devshift.org
    IF    "${match}" == "PASS"
        ${cluster_type}=  Set Variable  stage

--- a/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -92,13 +92,13 @@ Verify RHODS Explore Section Contains Only Expected ISVs
 Verify Disabled Cards Can Be Removed
     [Documentation]     Verifies it is possible to remove a disabled card from Enabled page.
     ...                 It uses RHOSAK as example to test the feature
-    ...                 ProductBug: RHODS-2902
+    ...                 ProductBug: RHODS-2902 - still present, but the test will
+    ...                 only trigger warning when issue happens
     [Tags]    Sanity
     ...       ODS-1081    ODS-1092
-    ...       ProductBug
     Enable RHOSAK
     Remove RHOSAK From Dashboard
-    Success Message Should Contain    ${RHOSAK_DISPLAYED_APPNAME}
+    Run Keyword And Warn On Failure    Success Message Should Contain    ${RHOSAK_DISPLAYED_APPNAME}
     Verify Service Is Not Enabled    app_name=${RHOSAK_DISPLAYED_APPNAME}
     Capture Page Screenshot    after_removal.png
 


### PR DESCRIPTION
ODS-1081 has a check failing due to a product bug, but the core of the test is good. So, for sake of completeness of testing, I'm turning the failure into a warning. 

`Fetch ODS Cluster Environment` needs a small fix which is applied here in oder to correctly run in GCP and AWS clusters