### PR TITLE
Add some checks on RHODS Self-managed in Dashboard tests

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -127,6 +127,14 @@ Verify Service Is Available In The Explore Page
   Capture Page Screenshot
   Page Should Contain Element    //article//*[.='${app_name}']
 
+Verify Service Is Not Available In The Explore Page
+  [Documentation]   Verify the service appears in Applications > Explore
+  [Arguments]  ${app_name}
+  Menu.Navigate To Page    Applications    Explore
+  Wait Until Page Contains    Jupyter  timeout=30
+  Capture Page Screenshot
+  Page Should Not Contain Element    //article//*[.='${app_name}']
+
 Remove Disabled Application From Enabled Page
    [Documentation]  The keyword let you re-enable or remove the card from Enabled page
    ...              for those application whose license is expired. You can control the action type

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -123,7 +123,7 @@ Verify Service Is Available In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    Jupyter  timeout=30
+  Wait Until Cards Are Loaded
   Capture Page Screenshot
   Page Should Contain Element    //article//*[.='${app_name}']
 
@@ -131,7 +131,7 @@ Verify Service Is Not Available In The Explore Page
   [Documentation]   Verify the service appears in Applications > Explore
   [Arguments]  ${app_name}
   Menu.Navigate To Page    Applications    Explore
-  Wait Until Page Contains    Jupyter  timeout=30
+  Wait Until Cards Are Loaded
   Capture Page Screenshot
   Page Should Not Contain Element    //article//*[.='${app_name}']
 

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -14,8 +14,7 @@ Verify RHOAM Is Available In RHODS Dashboard Explore Page
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait for RHODS Dashboard to Load
-  Verify Service Is Available In The Explore Page    OpenShift API Management
-  Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
+  Verify RHOAM Availability Based On RHODS Installation Type
 
 
 *** Keywords ***
@@ -25,6 +24,15 @@ RHOAM Suite Setup
 
 RHOAM Suite Teardown
   Close All Browsers
+
+Verify RHOAM Availability Based On RHODS Installation Type
+    ${is_self_managed}=    Is RHODS Self-Managed
+    IF    ${is_self_managed} == ${TRUE}
+        Verify Service Is Not Available In The Explore Page    OpenShift API Management
+    ELSE
+        Verify Service Is Available In The Explore Page    OpenShift API Management
+        Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
+    END
 
 
 

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
@@ -46,6 +46,7 @@ RHOAM Install Suite Setup
 
 RHOAM Suite Teardown
     [Documentation]    RHOAM Suite teardown. It triggers RHOAM Uninstallation
+    Skip If RHODS Is Self-Managed
     Log To Console    Starting uninstallation of RHOAM Addon...
     Uninstall Rhoam Using Addon Flow    cluster_name=${CLUSTER_NAME}
     Log To Console    RHOAM Addon has been uninstalled!

--- a/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
+++ b/tests/Tests/600__ai_apps/640__rhoam/640__rhoam_installation.robot
@@ -26,6 +26,7 @@ Verify RHODS Can Be Uninstalled When RHOAM Is Installed
     ...     ODS-1136
     ...     DestructiveTest
     ...     Execution-Time-Over-2h
+    Skip If RHODS Is Self-Managed
     Verify RHOAM Is Enabled In RHODS Dashboard
     Uninstall RHODS From OSD Cluster    clustername=${CLUSTER_NAME}
     Wait Until RHODS Uninstallation Is Completed
@@ -35,6 +36,7 @@ Verify RHODS Can Be Uninstalled When RHOAM Is Installed
 RHOAM Install Suite Setup
     [Documentation]    RHOAM Suite setup
     Set Library Search Order  OpenShiftLibrary  SeleniumLibrary
+    Skip If RHODS Is Self-Managed
     ${cluster_id}=   Get Cluster ID
     ${CLUSTER_NAME}=   Get Cluster Name By Cluster ID     cluster_id=${cluster_id}
     Set Suite Variable     ${CLUSTER_NAME}


### PR DESCRIPTION
This PR is adding the check on RHODS Self managed for the following tests:
- ODS-1226
- ODS-271
- ODS-1310
- ODS-1136

Plus:
- it improves "Verify Service Is Available In The Explore Page" to wait until cards are loaded (i noticed that sometimes the check passes but the cards are not fully loaded)
- add "Verify Service Is Not Available In The Explore Page"