### PR TITLE
Run "Suite Availability Setup" only on RHODS Managed

### DIFF
--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -171,17 +171,13 @@ Run Keyword If RHODS Is Managed
     [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Managed (Cloud Version)
     [Arguments]    ${name}    @{arguments}
     ${is_self_managed}=    Is RHODS Self-Managed
-    IF    ${is_self_managed} == False
-        Run Keyword    ${name}    @{arguments}
-    END
+    IF    ${is_self_managed} == False    Run Keyword    ${name}    @{arguments}
 
 Run Keyword If RHODS Is Self-Managed
     [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Self-Managed
     [Arguments]    ${name}    @{arguments}
     ${is_self_managed}=    Is RHODS Self-Managed
-    IF    ${is_self_managed} == True
-        Run Keyword    ${name}    @{arguments}
-    END
+    IF    ${is_self_managed} == True    Run Keyword    ${name}    @{arguments}
 
 Get Domain From Current URL
     [Documentation]    Gets the lowest level domain from the current URL (i.e. everything before the first dot in the URL)

--- a/tests/Resources/Common.robot
+++ b/tests/Resources/Common.robot
@@ -167,6 +167,22 @@ Skip If RHODS Is Self-Managed
        Skip If    condition=${is_self_managed}==True    msg=This test is skipped for Self-managed RHODS
     END
 
+Run Keyword If RHODS Is Managed
+    [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Managed (Cloud Version)
+    [Arguments]    ${name}    @{arguments}
+    ${is_self_managed}=    Is RHODS Self-Managed
+    IF    ${is_self_managed} == False
+        Run Keyword    ${name}    @{arguments}
+    END
+
+Run Keyword If RHODS Is Self-Managed
+    [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Self-Managed
+    [Arguments]    ${name}    @{arguments}
+    ${is_self_managed}=    Is RHODS Self-Managed
+    IF    ${is_self_managed} == True
+        Run Keyword    ${name}    @{arguments}
+    END
+
 Get Domain From Current URL
     [Documentation]    Gets the lowest level domain from the current URL (i.e. everything before the first dot in the URL)
     ...    e.g. https://console-openshift-console.apps.<cluster>.rhods.ccitredhat.com -> https://console-openshift-console

--- a/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -117,7 +117,7 @@ Fail If Average Availability For Time Range Breached SLA
 
 Suite Availability Setup
     [Documentation]    Obtains and stores Average Availability for the last 2m, 15m, 1h and 3h
-    ...    Log a WARN message if availability is under 99.95
+    ...    Log a WARN message if availability is under 99.95 or an alert is firing
     [Arguments]    ${pm_url}    ${pm_token}
     Run Keyword And Warn On Failure
     ...    Create Suite Availability Checkpoint    pm_url=${pm_url}    pm_token=${pm_token}
@@ -127,7 +127,7 @@ Suite Availability Setup
 
 Suite Availability Teardown
     [Documentation]    Compare current Average Availability with the values stored in Suite Availability.
-    ...    Logs a WARN message if the current values are lower
+    ...    Logs a WARN message if the current values are lower or an alert is firing
     [Arguments]    ${pm_url}    ${pm_token}
     Run Keyword And Warn On Failure
     ...    Log If Availability Decreased Since Suite Availability Checkpoint     pm_url=${pm_url}    pm_token=${pm_token}

--- a/tests/Resources/RHOSi.resource
+++ b/tests/Resources/RHOSi.resource
@@ -4,6 +4,7 @@ Documentation       Applies RHOSi settings to run the test suites
 Library             RPA.RobotLogListener
 Resource            Page/ODH/Monitoring/Monitoring.resource
 Resource            Page/OCPDashboard/InstalledOperators/InstalledOperators.robot
+Resource    Common.robot
 
 
 *** Variables ***
@@ -43,7 +44,8 @@ RHOSi Setup
     ...                Do Not extend this keyword for high-level setup, e.g., don't open browser
     Protect Sensitive Variables In Keywords
     Initialize Global Variables
-    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
+    Run Keyword If RHODS Is Managed
+    ...    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
     # TO DO: oc login
 
 RHOSi Teardown
@@ -51,7 +53,8 @@ RHOSi Teardown
     ...                stored at RHOSi setup
     ...                The suggested usage of this keyword is to call it inside all the Suite Teardown keywords.
     ...                Do Not extend this keyword for high-level setup, e.g., don't close browser
-    Suite Availability Teardown    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
+    Run Keyword If RHODS Is Managed
+    ...    Suite Availability Teardown    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
 
 Protect Sensitive Variables In Keywords
     [Documentation]    Register keywords which use sensitive data as "Protected"


### PR DESCRIPTION
"Suite Availability Setup" is failing on RHODS Self-Managed because most of the monitoring stack is not deployed now on Self-Managed, making most of the tests to fail. This PR disables calling it on Self-Managed

I'll send another PR to skip individual monitoring tests for Self-Managed

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>