### PR TITLE
Self-Managed: skip monitoring tests requiring RHODS prometheus

### DIFF
--- a/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -114,6 +114,7 @@ Verify That Blackbox-exporter Image Is A CPaaS Built Image
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-735
+    Skip If RHODS Is Self-Managed
     ${pod} =    Find First Pod By Name    namespace=redhat-ods-monitoring    pod_start_with=blackbox-exporter-
     Container Image Url Should Contain    redhat-ods-monitoring    ${pod}    blackbox-exporter
     ...    quay.io/integreatly/prometheus-blackbox-exporter
@@ -123,6 +124,7 @@ Verify That Alert Manager Image Is A CPaaS Built Image
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-733
+    Skip If RHODS Is Self-Managed
     ${pod} =    Find First Pod By Name    namespace=redhat-ods-monitoring    pod_start_with=prometheus-
     Container Image Url Should Contain    redhat-ods-monitoring    ${pod}    alertmanager
     ...    registry.redhat.io/openshift4/ose-prometheus-alertmanager
@@ -158,6 +160,7 @@ Verify That Blackbox-exporter Is Protected With Auth-proxy
     [Tags]  Sanity
     ...     Tier1
     ...     ODS-1090
+    Skip If RHODS Is Self-Managed
     Verify BlackboxExporter Includes Oauth Proxy
     Verify Authentication Is Required To Access BlackboxExporter
 

--- a/tests/Tests/100__deploy/100__installation/105__prometheus.robot
+++ b/tests/Tests/100__deploy/100__installation/105__prometheus.robot
@@ -13,6 +13,7 @@ Verify Prometheus Is Shipped And Enabled Within ODS
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-232
+    Skip If RHODS Is Self-Managed
     @{prometheus_pods_info} =    Fetch Prometheus Pods Info
     @{prometheus_deployment_info} =    Fetch Prometheus Deployments Info
     @{prometheus_services_info} =    Fetch Prometheus Services Info

--- a/tests/Tests/100__deploy/100__installation/106__blackbox_exporter.robot
+++ b/tests/Tests/100__deploy/100__installation/106__blackbox_exporter.robot
@@ -13,6 +13,7 @@ Verify Blackbox Exporter Is Shipped And Enabled Within ODS
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-235
+    Skip If RHODS Is Self-Managed
     @{blackbox_exporter_pods_info} =    Fetch Blackbox Exporter Pods Info
     @{blackbox_exporter_deployment_info} =    Fetch Blackbox Exporter Deployments Info
     @{blackbox_exporter_services_info} =    Fetch Blackbox Exporter Services Info

--- a/tests/Tests/100__deploy/100__installation/107__alert_manager.robot
+++ b/tests/Tests/100__deploy/100__installation/107__alert_manager.robot
@@ -13,6 +13,7 @@ Verify Alert Manager Is Shipped And Enabled Within ODS
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-238
+    Skip If RHODS Is Self-Managed
     @{alertmanager_services_info} =    Fetch Alert Manager Services Info
     @{alertmanager_routes_info} =    Fetch Alert Manager Routes Info
     OpenShift Resource Field Value Should Be Equal As Strings    spec.ports[0].name    alertmanager    @{alertmanager_services_info}

--- a/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -27,6 +27,7 @@ Test Existence of Prometheus Alerting Rules
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-509
+    Skip If RHODS Is Self-Managed
     Check Prometheus Alerting Rules
 
 Test Existence of Prometheus Recording Rules
@@ -34,6 +35,7 @@ Test Existence of Prometheus Recording Rules
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-510
+    Skip If RHODS Is Self-Managed
     Check Prometheus Recording Rules
 
 Test Metric "Notebook CPU Usage" On ODS Prometheus
@@ -41,6 +43,7 @@ Test Metric "Notebook CPU Usage" On ODS Prometheus
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-178
+    Skip If RHODS Is Self-Managed
     ${cpu_usage_before} =    Read Current CPU Usage
     Run Jupyter Notebook For 5 Minutes
     Wait Until Keyword Succeeds    10 times   30s
@@ -52,6 +55,7 @@ Test Metric "Rhods_Total_Users" On ODS Prometheus
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-628
+    Skip If RHODS Is Self-Managed
     # Note: the expression ends with "step=1" to obtain the value for current second
     ${expression} =    Set Variable    rhods_total_users&step=1
     ${rhods_total_users} =    Prometheus.Run Query    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
@@ -76,6 +80,7 @@ Test Metric Existence For "Rhods_Aggregate_Availability" On ODS Prometheus
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-636
+    Skip If RHODS Is Self-Managed
     ${expression} =    Set Variable    rhods_aggregate_availability&step=1
     ${resp} =    Prometheus.Run Query    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    ${expression}
     Log    rhods_aggregate_availability: ${resp.json()["data"]["result"][0]["value"][-1]}

--- a/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -44,6 +44,7 @@ Test Metric "Rhods_Total_Users" On Cluster Monitoring Prometheus
     [Tags]    Sanity
     ...       ODS-634
     ...       Tier1
+    Skip If RHODS Is Self-Managed
     ${value} =    Run OpenShift Metrics Query    query=rhods_total_users
     ${value_from_promothues} =    Fire Query On RHODS Prometheus And Return Value    query=rhods_total_users
     Should Be Equal    ${value_from_promothues}    ${value}
@@ -54,6 +55,7 @@ Test Metric "Rhods_Aggregate_Availability" On Cluster Monitoring Prometheus
     [Tags]    Sanity
     ...       ODS-637
     ...       Tier1
+    Skip If RHODS Is Self-Managed
     ${value} =    Run OpenShift Metrics Query    query=rhods_aggregate_availability
     ${value_from_promothues} =    Fire Query On RHODS Prometheus And Return Value    query=rhods_aggregate_availability
     Should Be Equal    ${value_from_promothues}    ${value}

--- a/tests/Tests/200__monitor_and_manage/200__metrics/204__check_pager_duty.robot
+++ b/tests/Tests/200__monitor_and_manage/200__metrics/204__check_pager_duty.robot
@@ -14,6 +14,7 @@ Library        String
 Library        OpenShiftLibrary
 
 Resource       ../../../Resources/RHOSi.resource
+Resource       ../../../Resources/Common.robot
 
 Suite Setup     RHOSi Setup
 Suite Teardown  RHOSi Teardown
@@ -32,6 +33,7 @@ PagerDuty Dummy Secret Verification
      ...     Tier1
      ...     ODS-737
      ...     Deployment-Cli
+     Skip If RHODS Is Self-Managed
      ${service_key}   Get PagerDuty Key From Alertmanager ConfigMap
      ${secret_key}    Get PagerDuty Key From Secrets
      Should Be Equal As Strings    ${service_key}   ${secret_key}   foo-bar

--- a/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
+++ b/tests/Tests/200__monitor_and_manage/210__alerts/210__alerts.robot
@@ -11,7 +11,7 @@ Library             SeleniumLibrary
 Library             JupyterLibrary
 
 Suite Setup         Alerts Suite Setup
-Suite Teardown      RHOSi Teardown
+Suite Teardown      Alerts Suite Teardown
 
 
 *** Variables ***
@@ -431,7 +431,13 @@ Verify That MT-SRE Are Not Paged For Alerts In Clusters Used For Development Or 
 Alerts Suite Setup
     [Documentation]    Test suite configuration
     Set Library Search Order    SeleniumLibrary
+    Skip If RHODS Is Self-Managed
     RHOSi Setup
+
+Alerts Suite Teardown
+    [Documentation]    Test suite teardown
+    Skip If RHODS Is Self-Managed
+    RHOSi Teardown
 
 Teardown PVC Alert Test
     [Documentation]    Deletes user notebook files using the new "Clean Up User Notebook"


### PR DESCRIPTION
RHODS prometheus is no longer deployed on Self-Managed

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>