### PR TITLE
Fix sidebar checks for RHODS  v1.22

### DIFF
--- a/tests/Resources/Page/ODH/AiApps/Anaconda.resource
+++ b/tests/Resources/Page/ODH/AiApps/Anaconda.resource
@@ -34,9 +34,8 @@ Enable Anaconda
     [Arguments]    ${license_key}    ${license_validity}=${TRUE}
     Menu.Navigate To Page    Applications    Explore
     Verify Page Contain Anaconda Based On Version
-    Click Element    xpath://*[@id='${ANACONDA_APPNAME}']
-    Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}    timeout=10
-    ...    error=${ANACONDA_APPNAME} does not have sidebar with information in the Explore page of ODS Dashboard
+    ${status}=    Open Get Started Sidebar And Return Status    card_locator=//*[@id='${ANACONDA_APPNAME}']
+    Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${TRUE}
     Page Should Contain Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}
     ...    message=${ANACONDA_APPNAME} does not have a "Enable" button in ODS Dashboard
     Click Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}

--- a/tests/Resources/Page/ODH/AiApps/Rhosak.robot
+++ b/tests/Resources/Page/ODH/AiApps/Rhosak.robot
@@ -35,9 +35,8 @@ Enable RHOSAK
     [Documentation]    Perfors the RHOSAK activation though RHODS Dashboard
     Menu.Navigate To Page    Applications    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
-    Click Element    xpath://*[@id='${RHOSAK_REAL_APPNAME}']
-    Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}    timeout=10
-    ...    error=${RHOSAK_REAL_APPNAME} does not have sidebar with information in the Explore page of ODS Dashboard
+    ${status}=    Open Get Started Sidebar And Return Status    card_locator=//*[@id='${RHOSAK_REAL_APPNAME}']
+    Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${TRUE}
     Page Should Contain Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}
     ...    message=${RHOSAK_REAL_APPNAME} does not have a "Enable" button in ODS Dashboard
     Click Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -10,7 +10,6 @@ Library       JupyterLibrary
 
 
 *** Variables ***
-${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}=                //*[@class="pf-c-drawer__panel-main"]//div[@class="odh-get-started__header"]/h1
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //article[contains(@class, 'pf-c-card')]
@@ -174,9 +173,9 @@ Verify Service Provides "Enable" Button In The Explore Page
   Menu.Navigate To Page    Applications    Explore
   Wait Until Page Contains    Jupyter  timeout=30
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..
-  Click Element     xpath://article//*[.='${app_name}']/../..
+  ${status}=    Open Get Started Sidebar And Return Status    card_locator=//article//*[.='${app_name}']/../..
   Capture Page Screenshot
-  Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}   timeout=10   error=${app_name} does not have sidebar with information in the Explore page of ODS Dashboard
+  Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${TRUE}
   Page Should Contain Button    ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}   message=${app_name} does not have a "Enable" button in ODS Dashboard
 
 Verify Service Provides "Get Started" Button In The Explore Page
@@ -185,9 +184,9 @@ Verify Service Provides "Get Started" Button In The Explore Page
   Menu.Navigate To Page    Applications    Explore
   Wait Until Page Contains    Jupyter  timeout=30
   Page Should Contain Element    xpath://article//*[.='${app_name}']/../..
-  Click Element     xpath://article//*[.='${app_name}']/../..
+  ${status}=    Open Get Started Sidebar And Return Status    card_locator=//article//*[.='${app_name}']/../..
   Capture Page Screenshot
-  Wait Until Page Contains Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}   timeout=10   error=${app_name} does not have sidebar with information in the Explore page of ODS Dashboard
+  Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${TRUE}
   Page Should Contain Element    ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}   message=${app_name} does not have a "Get started" button in ODS Dashboard
 
 Go To RHODS Dashboard


### PR DESCRIPTION
The PR wants to fix tests which leverage on `${ODH_DASHBOARD_SIDEBAR_HEADER_TITLE}` XPath. The new code replaces the check on that XPath with the keywords:
```
    ${status}=    Open Get Started Sidebar And Return Status    card_locator=//*[@id='${ANACONDA_APPNAME}']
    Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${TRUE}
```

The change is intended to be retro-compatible with 1.21

Signed-off-by: bdattoma <bdattoma@redhat.com>