### PR TITLE
Bump upload-artifact to v3 in dryrun action

### DIFF
--- a/.github/workflows/dry_run.yml
+++ b/.github/workflows/dry_run.yml
@@ -19,7 +19,7 @@ jobs:
           mkdir -p ./pr
           cp -r test-output ./pr/test-output
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: pr
           path: pr/


### PR DESCRIPTION
upload-artifact v2 is using an old version of Node and issuing a Warning. Bumping to v3 should fix the issue without any other changes required.