### PR TITLE
Fix "Save changes" keyword and ODS-488

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -335,10 +335,10 @@ Check Sidebar Header Text
     [Arguments]  ${app_id}  ${expected_data}
     ${h1}=  Get Text    xpath://div[contains(@class,'odh-markdown-view')]/h1
     Run Keyword And Continue On Failure  Should Be Equal  ${h1}  ${expected_data}[${app_id}][sidebar_h1]
-    ${getstarted_title}=  Get Text  xpath://div[contains(@class,'pf-c-drawer__panel-main')]//div[@class='odh-get-started__header']/h1[contains(@class, 'title')]
-    ${getstarted_provider}=  Get Text  xpath://div[contains(@class,'pf-c-drawer__panel-main')]//div[@class='odh-get-started__header']//span[contains(@class, 'provider')]
-    Run Keyword And Continue On Failure  Should Be Equal   ${getstarted_title}  ${expected_data}[${app_id}][title]
-    Run Keyword And Continue On Failure  Should Be Equal   ${getstarted_provider}  ${expected_data}[${app_id}][provider]
+    ${getstarted_title}=  Get Text  xpath://div[contains(@class,'pf-c-drawer__head')]
+    ${titles}=    Split String    ${getstarted_title}   separator=\n    max_split=1
+    Run Keyword And Continue On Failure  Should Be Equal   ${titles[0]}  ${expected_data}[${app_id}][title]
+    Run Keyword And Continue On Failure  Should Be Equal   ${titles[1]}  ${expected_data}[${app_id}][provider]
 
 Check Get Started Sidebar
     [Arguments]  ${card_locator}  ${card_badges}  ${app_id}  ${expected_data}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -118,7 +118,7 @@ Save Changes In Cluster Settings
     Wait Until Page Contains Element    xpath://button[.="Save changes"][@aria-disabled="false"]    timeout=15s
     Click Button    Save changes
     ${clicked}=    Run Keyword And Return Status
-    ...    Page Should Contain Element    xpath://button[.="Save changes"][@aria-disabled="true"]
+    ...    Wait Until Page Contains Element    xpath://button[.="Save changes"][@aria-disabled="true"]
     IF    ${clicked} == ${FALSE}
         Capture Page Screenshot
         Click Button    Save changes


### PR DESCRIPTION
PR to fix 2 automation bugs found in 1.22 run:
1. kw to fetch header text from sidebars (ODS-488)
2. kw to save dashboard settings (affecting many TCs)