### PR TITLE
Implement CR deletion using OpenshiftLibrary instead of UI

### DIFF
--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -13,7 +13,7 @@ Remove AIKIT Operator
 
 Uninstall AIKIT Operator
     [Documentation]    Uninstall intel aikit operator and it's realted component
-    [Arguments]    ${cr_kind}=AIKitContainers    ${cr_name}=intel-aikit-container
+    [Arguments]    ${cr_kind}=AIKitContainer    ${cr_name}=intel-aikit-container
     ...            ${cr_ns}=redhat-ods-applications
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour

--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -18,7 +18,7 @@ Uninstall AIKIT Operator
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
     Oc Delete    kind=${cr_kind}  name=${cr_name}  namespace=${cr_ns}
-    Move To Installed Operator Page Tab in Openshift    operator_name=${intel_aikit_operator_name}
+    Move To Installed Operator Page Tab In Openshift    operator_name=${intel_aikit_operator_name}
     ...    tab_name=AIKitContainer    namespace=${cr_ns}
     Uninstall Operator    ${intel_aikit_operator_name}
     Oc Delete    kind=ImageStream    namespace=${cr_ns}

--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -13,12 +13,13 @@ Remove AIKIT Operator
 
 Uninstall AIKIT Operator
     [Documentation]    Uninstall intel aikit operator and it's realted component
+    [Arguments]    ${cr_kind}=AIKitContainers    ${cr_name}=intel-aikit-container
+    ...            ${cr_ns}=redhat-ods-applications
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
-    Delete Tabname Instance For Installed Operator    ${intel_aikit_operator_name}    AIKitContainer
-    ...    redhat-ods-applications
+    Oc Delete    kind=${cr_kind}  name=${cr_name}  namespace=${cr_ns}
     Uninstall Operator    ${intel_aikit_operator_name}
-    Oc Delete    kind=ImageStream    namespace=redhat-ods-applications
+    Oc Delete    kind=ImageStream    namespace=${cr_ns}
     ...    label_selector=opendatahub.io/notebook-image=true    field_selector=metadata.name==oneapi-aikit
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}

--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -27,7 +27,7 @@ Uninstall AIKIT Operator
     ...    reason=There is a bug in dashboard showing an error message after ISV uninstall
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
-    ...    browser_options=${BROWSER.OPTIONS}
+    ...    browser_options=${BROWSER.OPTIONS}    wait_for_cards=${FALSE}
     Remove Disabled Application From Enabled Page    app_id=aikit
 
 Verify JupyterHub Can Spawn AIKIT Notebook

--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -23,6 +23,8 @@ Uninstall AIKIT Operator
     Uninstall Operator    ${intel_aikit_operator_name}
     Oc Delete    kind=ImageStream    namespace=${cr_ns}
     ...    label_selector=opendatahub.io/notebook-image=true    field_selector=metadata.name==oneapi-aikit
+    Sleep    30s
+    ...    reason=There is a bug in dashboard showing an error message after ISV uninstall
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}

--- a/tests/Resources/Page/ODH/AiApps/Aikit.robot
+++ b/tests/Resources/Page/ODH/AiApps/Aikit.robot
@@ -18,6 +18,8 @@ Uninstall AIKIT Operator
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
     Oc Delete    kind=${cr_kind}  name=${cr_name}  namespace=${cr_ns}
+    Move To Installed Operator Page Tab in Openshift    operator_name=${intel_aikit_operator_name}
+    ...    tab_name=AIKitContainer    namespace=${cr_ns}
     Uninstall Operator    ${intel_aikit_operator_name}
     Oc Delete    kind=ImageStream    namespace=${cr_ns}
     ...    label_selector=opendatahub.io/notebook-image=true    field_selector=metadata.name==oneapi-aikit

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -29,7 +29,7 @@ Uninstall Openvino Operator
     ...    reason=There is a bug in dashboard showing an error message after ISV uninstall
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
-    ...    browser_options=${BROWSER.OPTIONS}
+    ...    browser_options=${BROWSER.OPTIONS}        wait_for_cards=${FALSE}
     Remove Disabled Application From Enabled Page    app_id=openvino
 
 Delete Openvino Notebook CR

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -37,7 +37,7 @@ Delete Openvino Notebook CR
     ${openvinos}=    Oc Get    api_version=intel.com/v1alpha1    kind=${cr_kind}   namespace=${cr_ns}
     ...            fields=['metadata.name']
     ${n_openvinos}=    Get Length    ${openvinos}
-    IF    "${n_openvinos}" > "${1}"    
+    IF    "${n_openvinos}" > "${1}"
         Log    message=There are more than once instance of Openvino..deleting all of them!
         ...    level=WARN
     END

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -20,6 +20,8 @@ Uninstall Openvino Operator
     ...            ${cr_ns}=redhat-ods-applications
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
+    Move To Installed Operator Page Tab in Openshift    operator_name=${openvino_operator_name}
+    ...    tab_name=Notebook    namespace=${cr_ns}
     Delete Openvino Notebook CR    cr_kind=${cr_kind}    cr_name=${cr_name}
     ...    cr_ns=${cr_ns}
     Uninstall Operator    ${openvino_operator_name}

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -20,7 +20,7 @@ Uninstall Openvino Operator
     ...            ${cr_ns}=redhat-ods-applications
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
-    Move To Installed Operator Page Tab in Openshift    operator_name=${openvino_operator_name}
+    Move To Installed Operator Page Tab In Openshift    operator_name=${openvino_operator_name}
     ...    tab_name=Notebook    namespace=${cr_ns}
     Delete Openvino Notebook CR    cr_kind=${cr_kind}    cr_name=${cr_name}
     ...    cr_ns=${cr_ns}

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -16,14 +16,35 @@ Remove Openvino Operator
 
 Uninstall Openvino Operator
     [Documentation]    Uninstall openvino operator and it's realted component
+    [Arguments]    ${cr_kind}=Notebook    ${cr_name}=v2022.3
+    ...            ${cr_ns}=redhat-ods-applications
     Go To    ${OCP_CONSOLE_URL}
     Maybe Skip Tour
-    Delete Tabname Instance For Installed Operator    ${openvino_operator_name}    Notebook    redhat-ods-applications
+    Delete Openvino Notebook CR    cr_kind=${cr_kind}    cr_name=${cr_name}
+    ...    cr_ns=${cr_ns}
     Uninstall Operator    ${openvino_operator_name}
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}
     Remove Disabled Application From Enabled Page    app_id=openvino
+
+Delete Openvino Notebook CR
+    [Documentation]    Deletes the openvino CRs using OpenshiftLibrary.
+    ...                Temporarily, it deletes all the CRs it finds, but
+    ...                this going to change when installation will be replaces with CLI:
+    ...                at that point the kw will delete a specific CR by name
+    [Arguments]    ${cr_kind}    ${cr_name}    ${cr_ns}
+    ${openvinos}=    Oc Get    api_version=intel.com/v1alpha1    kind=${cr_kind}   namespace=${cr_ns}
+    ...            fields=['metadata.name']
+    ${n_openvinos}=    Get Length    ${openvinos}
+    IF    "${n_openvinos}" > "${1}"    
+        Log    message=There are more than once instance of Openvino..deleting all of them!
+        ...    level=WARN
+    END
+    FOR    ${instance}    IN    @{openvinos}
+        Oc Delete    api_version=intel.com/v1alpha1
+        ...    kind=${cr_kind}  name=${instance}[metadata.name]  namespace=${cr_ns}
+    END
 
 Verify JupyterHub Can Spawn Openvino Notebook
     [Documentation]    Spawn openvino notebook and check if

--- a/tests/Resources/Page/ODH/AiApps/Openvino.robot
+++ b/tests/Resources/Page/ODH/AiApps/Openvino.robot
@@ -25,6 +25,8 @@ Uninstall Openvino Operator
     Delete Openvino Notebook CR    cr_kind=${cr_kind}    cr_name=${cr_name}
     ...    cr_ns=${cr_ns}
     Uninstall Operator    ${openvino_operator_name}
+    Sleep    30s
+    ...    reason=There is a bug in dashboard showing an error message after ISV uninstall
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -56,7 +56,7 @@ Pachyderm Suite Teardown
     Go To    ${OCP_CONSOLE_URL}
     Oc Delete    kind=Pachyderm  name=pachyderm-sample  namespace=pachyderm
     Uninstall Operator    ${pachyderm_operator_name}
-    Delete Project By Name      pachyderm
+    Oc Delete    kind=Project    name=pachyderm
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -45,7 +45,7 @@ Pachyderm Suite Setup
     Login to OCP
     Wait Until OpenShift Console Is Loaded
     Check And Install Operator in Openshift    ${pachyderm_container_name}    ${pachyderm_appname}
-    Create Project      pachyderm
+    Oc Create    kind=Project    pachyderm
     Create Pachyderm AWS-Secret
     Create Tabname Instance For Installed Operator        ${pachyderm_container_name}   ${pachyderm_container_name}     ${pachyderm_appname}
     Wait Until Status Is Running
@@ -54,7 +54,7 @@ Pachyderm Suite Setup
 
 Pachyderm Suite Teardown
     Go To    ${OCP_CONSOLE_URL}
-    Delete Tabname Instance For Installed Operator    ${pachyderm_container_name}   ${pachyderm_container_name}     ${pachyderm_appname}
+    Oc Delete    kind=Pachyderm  name=pachyderm-sample  namespace=pachyderm
     Uninstall Operator    ${pachyderm_operator_name}
     Delete Project By Name      pachyderm
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -56,7 +56,7 @@ Pachyderm Suite Setup
 Pachyderm Suite Teardown
     Go To    ${OCP_CONSOLE_URL}
     Oc Delete    kind=Pachyderm  name=pachyderm-sample  namespace=${pachyderm_ns}
-    Move To Installed Operator Page Tab in Openshift    operator_name=${pachyderm_operator_name}
+    Move To Installed Operator Page Tab In Openshift    operator_name=${pachyderm_operator_name}
     ...    tab_name=Pachyderm    namespace=${pachyderm_ns}
     Uninstall Operator    ${pachyderm_operator_name}
     Oc Delete    kind=Project    name=${pachyderm_ns}

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -45,7 +45,7 @@ Pachyderm Suite Setup
     Login to OCP
     Wait Until OpenShift Console Is Loaded
     Check And Install Operator in Openshift    ${pachyderm_container_name}    ${pachyderm_appname}
-    Oc Create    kind=Project    pachyderm
+    Oc Create    kind=Project    name=pachyderm
     Create Pachyderm AWS-Secret
     Create Tabname Instance For Installed Operator        ${pachyderm_container_name}   ${pachyderm_container_name}     ${pachyderm_appname}
     Wait Until Status Is Running

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -13,6 +13,7 @@ Suite Teardown      Pachyderm Suite Teardown
 ${pachyderm_container_name}     Pachyderm
 ${pachyderm_operator_name}      Pachyderm
 ${pachyderm_appname}            pachyderm
+${pachyderm_ns}                 pachyderm
 
 
 *** Test Cases ***
@@ -45,7 +46,7 @@ Pachyderm Suite Setup
     Login to OCP
     Wait Until OpenShift Console Is Loaded
     Check And Install Operator in Openshift    ${pachyderm_container_name}    ${pachyderm_appname}
-    Oc Create    kind=Project    name=pachyderm
+    Oc Create    kind=Project    name=${pachyderm_ns}
     Create Pachyderm AWS-Secret
     Create Tabname Instance For Installed Operator        ${pachyderm_container_name}   ${pachyderm_container_name}     ${pachyderm_appname}
     Wait Until Status Is Running
@@ -54,13 +55,15 @@ Pachyderm Suite Setup
 
 Pachyderm Suite Teardown
     Go To    ${OCP_CONSOLE_URL}
-    Oc Delete    kind=Pachyderm  name=pachyderm-sample  namespace=pachyderm
+    Oc Delete    kind=Pachyderm  name=pachyderm-sample  namespace=${pachyderm_ns}
+    Move To Installed Operator Page Tab in Openshift    operator_name=${pachyderm_operator_name}
+    ...    tab_name=Pachyderm    namespace=${pachyderm_ns}
     Uninstall Operator    ${pachyderm_operator_name}
-    Oc Delete    kind=Project    name=pachyderm
+    Oc Delete    kind=Project    name=${pachyderm_ns}
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}
-    Remove Disabled Application From Enabled Page    app_id=pachyderm
+    Remove Disabled Application From Enabled Page    app_id=${pachyderm_appname}
     Close All Browsers
 
 Wait Until Status Is Running

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -46,7 +46,7 @@ Pachyderm Suite Setup
     Login to OCP
     Wait Until OpenShift Console Is Loaded
     Check And Install Operator in Openshift    ${pachyderm_container_name}    ${pachyderm_appname}
-    Oc Create    kind=Project    name=${pachyderm_ns}
+    Run    oc new-project ${pachyderm_ns}
     Create Pachyderm AWS-Secret
     Create Tabname Instance For Installed Operator        ${pachyderm_container_name}   ${pachyderm_container_name}     ${pachyderm_appname}
     Wait Until Status Is Running

--- a/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
+++ b/tests/Tests/600__ai_apps/670__pachyderm/670__pachyderm.robot
@@ -60,6 +60,8 @@ Pachyderm Suite Teardown
     ...    tab_name=Pachyderm    namespace=${pachyderm_ns}
     Uninstall Operator    ${pachyderm_operator_name}
     Oc Delete    kind=Project    name=${pachyderm_ns}
+    Sleep    30s
+    ...    reason=There is a bug in dashboard showing an error message after ISV uninstall
     Launch Dashboard    ocp_user_name=${TEST_USER.USERNAME}    ocp_user_pw=${TEST_USER.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}


### PR DESCRIPTION
In Tier2 runs we see often failing the step of deleting ISV's CustomResource, so this PR wants to improve that by replacing UI navigation with CLI for performing that step.
For pachyderm, it also replaces project creation/deletion with OpenshftiLibrary since it is a ery easy and quick change.

This is just a first piece of the final implementation where the install/uninstall process of ISV will be completely done via CLI instead UI.

**A note about openvino**
You'll see the code for Openvino is slightly different, because the default CR name is tide to a version (i.e., v2022.3), so there is an higher probability this could change over time and our teardown would fails. So, until we get to Install using CLI (where we will input the CR name), the Openvino teardown will delete all the CR instances of openvino. In theory, there should be only one which was created by the test itself. 
Adding now the input of a custom CR name (or just fetching the default one from the UI) would add just an additional point of failure in the UI testing which is not very stable over OCP versions
