### PR TITLE
Add tests for checking GPU usage in Workbenches

### DIFF
--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -282,7 +282,7 @@ Verify CPU And Memory Requests And Limits Are Defined For Pod Container
     ...        container_info: Container information
     ...    Returns:
     ...        None
-    [Arguments]    ${container_info}
+    [Arguments]    ${container_info}    ${nvidia_gpu}=${FALSE}
     &{container_info_dict} =    Set Variable    ${container_info}
     OpenShift Resource Component Should Contain Field     ${container_info_dict}    resources
     IF   'resources' in ${container_info_dict}
@@ -297,6 +297,12 @@ Verify CPU And Memory Requests And Limits Are Defined For Pod Container
     ...    OpenShift Resource Component Should Contain Field     ${container_info_dict.resources.limits}    cpu
     IF   'limits' in ${container_info_dict.resources}
     ...    OpenShift Resource Component Should Contain Field     ${container_info_dict.resources.limits}    memory
+    IF    ${nvidia_gpu} == ${TRUE}
+        IF   'requests' in ${container_info_dict.resources}
+        ...    OpenShift Resource Component Should Contain Field     ${container_info_dict.resources.requests}    nvidia.com/gpu
+        IF   'limits' in ${container_info_dict.resources}
+        ...    OpenShift Resource Component Should Contain Field     ${container_info_dict.resources.limits}    nvidia.com/gpu
+    END
 
 Fetch Project Pods Info
     [Documentation]    Fetches information of all Pods for the specified Project

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -119,3 +119,11 @@ Get Openshift PVC From Storage
     [Arguments]     ${name}      ${namespace}
     ${rc}  ${pvc_name}=    Run And Return Rc And Output   oc get pvc -n ${namespace} -o jsonpath='{.items[?(@.metadata.annotations.openshift\\.io/display-name=="${name}")].metadata.name}'
     RETURN    ${rc}    ${pvc_name}
+
+Delete PVC From CLI
+    [Documentation]    Deletes a given PVC from CLI
+    [Arguments]    ${pvc_title}    ${project_title}
+    ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${project_title}
+    ${_}  ${cr_name}=    Get Openshift PVC From Storage
+    ...    name=${pvc_title}  namespace=${ns_name}
+    Oc Delete    kind=PersistentVolumeClaim   name=${pvc_title}   namespace=${ns_name}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -198,6 +198,12 @@ Wait Until Workbench Is Started
     Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_RUNNING}
 
+Wait Until Workbench Is Stopped
+    [Documentation]    Waits until workbench status is "RUNNING" in the DS Project details page
+    [Arguments]     ${workbench_title}      ${timeout}=40s
+    Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be
+    ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_STOPPED}
+
 Wait Until Workbench Is Restarting
     [Documentation]    Waits until workbench status is "STARTING" in the DS Project details page
     [Arguments]     ${workbench_title}      ${timeout}=40s
@@ -401,9 +407,14 @@ Edit GPU Number
     [Documentation]    Edit a workbench
     [Arguments]     ${workbench_title}    ${gpus}=1
     Click Action From Actions Menu    item_title=${workbench_title}    item_type=workbench    action=Edit
-    Select Workbench Number Of GPUs    gpus=${gpus}
-    Wait Until Element Is Enabled    ${WORKBENCH_CREATE_BTN_2_XP}
-    Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
+    ${status}=    Run Keyword And Return Status    Select Workbench Number Of GPUs    gpus=${gpus}
+    IF    ${status} == ${FALSE}
+        Click Button    ${GENERIC_CANCEL_BTN_XP}
+        Fail
+    ELSE
+        Wait Until Element Is Enabled    ${WORKBENCH_CREATE_BTN_2_XP}
+        Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
+    END
 
 Delete Workbench From CLI
     [Arguments]    ${workbench_title}    ${project_title}
@@ -411,3 +422,11 @@ Delete Workbench From CLI
     ${_}  ${cr_name}=    Get Openshift Notebook CR From Workbench
     ...    workbench_title=${workbench_title}  namespace=${ns_name}
     Oc Delete    kind=Notebook  name=${cr_name}  namespace=${ns_name}
+
+GPU Dropdown Should Be Disabled
+    [Documentation]    Checks if the GPU dropdown is not able editable
+    [Arguments]     ${workbench_title}
+    Sleep    10s     reason=There is some delay in updating the GPU availability in Dashboard
+    Click Action From Actions Menu    item_title=${workbench_title}    item_type=workbench    action=Edit
+    Wait Until Page Contains Element    ${WORKBENCH_GPU_MENU_BTN_XP}
+    Element Should Be Disabled    ${WORKBENCH_GPU_MENU_BTN_XP}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -404,4 +404,10 @@ Edit GPU Number
     Select Workbench Number Of GPUs    gpus=${gpus}
     Wait Until Element Is Enabled    ${WORKBENCH_CREATE_BTN_2_XP}
     Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
-    
+
+Delete Workbench From CLI
+    [Arguments]    ${workbench_title}    ${project_title}
+    ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${project_title}
+    ${_}  ${cr_name}=    Get Openshift Notebook CR From Workbench
+    ...    workbench_title=${workbench_title}  namespace=${ns_name}
+    Oc Delete    kind=Notebook  name=${cr_name}  namespace=${ns_name}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -16,6 +16,8 @@ ${WORKBENCH_IMAGE_MENU_BTN_XP}=           xpath=//section[@id="notebook-image"]/
 ${WORKBENCH_IMAGE_ITEM_BTN_XP}=           xpath=//ul[@id="workbench-image-stream-selection"]/li/button
 ${WORKBENCH_SIZE_MENU_BTN_XP}=           xpath=//section[@id="deployment-size"]//button[@aria-label="Options menu"]
 ${WORKBENCH_SIZE_ITEM_BTN_XP}=           xpath=//ul[@data-id="container-size-select"]/li/button
+${WORKBENCH_GPU_MENU_BTN_XP}=           xpath=//section[@id="deployment-size"]//button[contains(@aria-labelledby,"gpu-numbers")]
+${WORKBENCH_GPU_ITEM_BTN_XP}=           xpath=//ul[@data-id="gpu-select"]/li/button
 ${WORKBENCH_ADD_VAR_BTN_XP}=           xpath=//button[text()="Add variable"]
 ${WORKBENCH_STATUS_STOPPED}=                  Stopped
 ${WORKBENCH_STATUS_RUNNING}=                  Running
@@ -34,7 +36,7 @@ Create Workbench
     ...                 the DS Project data. It allows to add new or existent PV storage,
     ...                 add Environment variables and select Jupyter image
     [Arguments]     ${workbench_title}  ${workbench_description}  ${prj_title}   ${image_name}   ${deployment_size}
-    ...             ${storage}  ${pv_existent}   ${pv_name}  ${pv_description}  ${pv_size}
+    ...             ${storage}  ${pv_existent}   ${pv_name}  ${pv_description}  ${pv_size}    ${gpus}=${NONE}
     ...             ${press_cancel}=${FALSE}  ${envs}=${NONE}
     Click Element    ${WORKBENCH_CREATE_BTN_XP}
     Wait Until Page Contains Element    ${WORKBENCH_NAME_INPUT_XP}
@@ -44,6 +46,7 @@ Create Workbench
     Run Keyword And Continue On Failure     Element Should Be Disabled    ${WORKBENCH_CREATE_BTN_2_XP}
     Select Workbench Jupyter Image    image_name=${image_name}
     IF    "${deployment_size}" != "${NONE}"    Select Workbench Container Size    size_name=${deployment_size}
+    IF    "${gpus}" != "${NONE}"    Select Workbench Number Of GPUs    gpus=${gpus}
     IF    "${envs}" != "${NONE}"
         ${envs_copy}=    Copy List    ${envs}    deepcopy=${TRUE}
         Add Environment Variables In Workbench    env_variables=${envs_copy}
@@ -195,6 +198,12 @@ Wait Until Workbench Is Started
     Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_RUNNING}
 
+Wait Until Workbench Is Restarting
+    [Documentation]    Waits until workbench status is "STARTING" in the DS Project details page
+    [Arguments]     ${workbench_title}      ${timeout}=40s
+    Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be
+    ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_STARTING}
+
 Start Workbench
     [Documentation]    Starts a workbench from the DS Project details page
     [Arguments]     ${workbench_title}
@@ -269,8 +278,8 @@ Click Action From Actions Menu
     [Documentation]    Clicks an action from Actions menu (3-dots menu on the right)
     [Arguments]    ${item_title}    ${item_type}    ${action}
     Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]/td[@class="pf-c-table__action"]/div/button[@aria-label="Actions"]
-    Wait Until Page Contains Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]/td[@class="pf-c-table__action"]/div/ul/li/button[text()="Delete ${item_type}"]
-    Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]/td[@class="pf-c-table__action"]/div/ul/li/button[text()="Delete ${item_type}"]
+    Wait Until Page Contains Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]/td[@class="pf-c-table__action"]/div/ul/li/button[text()="${action} ${item_type}"]
+    Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]/td[@class="pf-c-table__action"]/div/ul/li/button[text()="${action} ${item_type}"]
 
 Handle Deletion Confirmation Modal
     [Documentation]    Handles confirmation modal on item deletion
@@ -379,3 +388,20 @@ Page Should Contain Event Log
         ...    xpath=//div[contains(@class,"alert")]//h4[contains(text(),"${expected_result_text}")]
     END
     Capture Page Screenshot
+
+Select Workbench Number Of GPUs
+    [Documentation]    Selects the container size in the workbench creation page
+    [Arguments]     ${gpus}
+    Wait Until Page Contains Element    ${WORKBENCH_GPU_MENU_BTN_XP}
+    Click Button    ${WORKBENCH_GPU_MENU_BTN_XP}
+    Wait Until Page Contains Element    ${WORKBENCH_GPU_ITEM_BTN_XP}/self::*[text()="${gpus}"]
+    Click Element    ${WORKBENCH_GPU_ITEM_BTN_XP}/self::*[text()="${gpus}"]
+
+Edit GPU Number
+    [Documentation]    Edit a workbench
+    [Arguments]     ${workbench_title}    ${gpus}=1
+    Click Action From Actions Menu    item_title=${workbench_title}    item_type=workbench    action=Edit
+    Select Workbench Number Of GPUs    gpus=${gpus}
+    Wait Until Element Is Enabled    ${WORKBENCH_CREATE_BTN_2_XP}
+    Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
+    

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -65,6 +65,28 @@ Verify User Can Add GPUs To Workbench
     [Teardown]    Clean Project    workbench_title=${WORKBENCH_TITLE_GPU}
     ...    pvc_title=${PV_NAME_GPU}    project_title=${PRJ_TITLE}
 
+Verify User Can Remove GPUs From Workbench
+    [Documentation]    Verifies user can remove GPUs from an already started workbench
+    [Tags]    Tier1    Sanity
+    ...       ODS-2014
+    Create Workbench    workbench_title=${WORKBENCH_TITLE_GPU}  workbench_description=${EMPTY}
+    ...    prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE_GPU}   deployment_size=Small
+    ...    storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_GPU}
+    ...    pv_description=${EMPTY}  pv_size=${PV_SIZE}    gpus=1
+    Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_GPU}
+    Run Keyword And Continue On Failure    GPU Dropdown Should Be Disabled    workbench_title=${WORKBENCH_TITLE_GPU}
+    Click Button    ${GENERIC_CANCEL_BTN_XP}
+    Stop Workbench    workbench_title=${WORKBENCH_TITLE_GPU}
+    Run Keyword And Continue On Failure    Wait Until Workbench Is Stopped     workbench_title=${WORKBENCH_TITLE_GPU}
+    Wait Until Keyword Succeeds    10 times    5s
+    ...    Edit GPU Number    workbench_title=${WORKBENCH_TITLE_GPU}    gpus=0
+    Wait Until Project Is Open    project_title=${PRJ_TITLE}
+    Start Workbench    workbench_title=${WORKBENCH_TITLE_GPU}
+    Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_GPU}
+    Launch And Access Workbench    workbench_title=${WORKBENCH_TITLE_GPU}
+    Open New Notebook In Jupyterlab Menu
+    Run Keyword And Expect Error    'Using cpu device' does not match 'Using cuda device'    Verify Pytorch Can See GPU
+    
 
 *** Keywords ***
 Project Suite Setup
@@ -76,7 +98,6 @@ Project Suite Setup
     RHOSi Setup
     Launch Data Science Project Main Page
     Open Data Science Projects Home Page
-    # Open Data Science Project Details Page    ${PRJ_TITLE_GPU}
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
     ...    resource_name=${PRJ_RESOURCE_NAME}
 

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -47,12 +47,12 @@ Verify Notebook Tolerations Are Applied To Workbenches When Set Up
     [Teardown]    Restore Tolerations Settings
 
 Verify User Can Add GPUs To Workbench
-    [Documentation]    Verifies user can adds GPUs to an already started workbench
+    [Documentation]    Verifies user can add GPUs to an already started workbench
     [Tags]    Tier1    Sanity
     ...       ODS-2013
     Create Workbench    workbench_title=${WORKBENCH_TITLE_GPU}  workbench_description=${EMPTY}
     ...    prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE_GPU}   deployment_size=Small
-    ...    storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_GPU}  
+    ...    storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_GPU}
     ...    pv_description=${EMPTY}  pv_size=${PV_SIZE}
     Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_GPU}
     Edit GPU Number    workbench_title=${WORKBENCH_TITLE_GPU}    gpus=1
@@ -62,6 +62,8 @@ Verify User Can Add GPUs To Workbench
     Launch And Access Workbench    workbench_title=${WORKBENCH_TITLE_GPU}
     Open New Notebook In Jupyterlab Menu
     Verify Pytorch Can See GPU
+    [Teardown]    Clean Project    workbench_title=${WORKBENCH_TITLE_GPU}
+    ...    pvc_title=${PV_NAME_GPU}    project_title=${PRJ_TITLE}
 
 
 *** Keywords ***
@@ -106,4 +108,12 @@ Restore Tolerations Settings
     Set Pod Toleration Via UI    ${DEFAULT_TOLERATIONS}
     Disable Pod Toleration Via UI
     Save Changes In Cluster Settings
-    
+
+Clean Project
+    [Documentation]    Deletes resources from a test project to free up
+    ...                resources or re-use titles
+    [Arguments]    ${workbench_title}    ${pvc_title}
+    ...            ${project_title}
+    Delete Workbench From CLI    workbench_title=${workbench_title}
+    ...    project_title=${project_title}
+    Delete PVC From CLI    pvc_title=${pvc_title}    project_title=${project_title}


### PR DESCRIPTION
This PR implements ODS-2013 and ODS-2014, covering the following scenarios
- user can create a workbench with GPUs attached
- user can remove attached GPUs from a workbench
- user can add GPUs to an existent workbench

In addition, it increase a sleep time ODS-1969 (test on tolerations) which belogs to the same suite of the above ones