### PR TITLE
Fix ODS-489 and ODS-1768

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -93,9 +93,10 @@ Wait for RHODS Dashboard to Load
     [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"    ${wait_for_cards}=${TRUE}
     ...          ${expected_page}=Enabled
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
-    Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=15s
+    Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=20s
     IF    "${expected_page}" != "${NONE}"
-        Wait Until Page Contains Element    xpath://h1[text()="${expected_page}"]        
+        Wait Until Page Contains Element    xpath://h1[text()="${expected_page}"]
+        ...    timeout=10s     
     END
     IF    ${wait_for_cards} == ${TRUE}
         Wait Until Cards Are Loaded
@@ -212,6 +213,7 @@ Load Expected Data Of RHODS Explore Section
 Wait Until Cards Are Loaded
     [Documentation]    Waits until the Application cards are displayed in the page
     Wait Until Page Contains Element    xpath://div[contains(@class,'gallery')]/article
+    ...    timeout=10s
     
 
 Get App ID From Card

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -214,7 +214,6 @@ Wait Until Cards Are Loaded
     [Documentation]    Waits until the Application cards are displayed in the page
     Wait Until Page Contains Element    xpath://div[contains(@class,'gallery')]/article
     ...    timeout=10s
-    
 
 Get App ID From Card
     [Arguments]  ${card_locator}

--- a/tests/Resources/Page/ODH/ODHDashboard/ResourcesPage.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ResourcesPage.resource
@@ -40,7 +40,7 @@ Number Of Items Should Be
     [Arguments]    ${expected_number}
     ${version_check}=  Is RHODS Version Greater Or Equal Than  1.21.0
     IF  ${version_check}==True
-        ${versioned_title_xp}=    Set Variable    //div[@class="pf-c-content"]
+        ${versioned_title_xp}=    Set Variable    //div[@class="pf-c-card__title"]/div[@class="pf-c-content"]
     ELSE
         ${versioned_title_xp}=    Set Variable    //div[@class="pf-c-card__title odh-card__doc-title"]
     END


### PR DESCRIPTION
This PR is fixing 2 test cases (one Sanity and one Tier2) which were broken by the same root cause: in 1.22, there is an html change which is making those test cases to retrieve unwanted objects from the UI. The fix is retro-compatible with 1.21

In addition, it increases the timeouts of `Launch Dashboard` which sometimes we see failing in the automated runs.

Signed-off-by: bdattoma <bdattoma@redhat.com>