### PR TITLE
Fix App launch from Dashboard and add check on launch link for RHOAM TC

### DIFF
--- a/tests/Resources/Page/ODH/AiApps/Rhoam.resource
+++ b/tests/Resources/Page/ODH/AiApps/Rhoam.resource
@@ -44,3 +44,4 @@ Verify RHOAM Is Enabled In RHODS Dashboard
     ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}
     ...    browser_options=${BROWSER.OPTIONS}
     Verify Service Is Enabled    app_name=${RHOAM_DISPLAYED_NAME}
+    Launch ${RHOAM_DISPLAYED_NAME} From RHODS Dashboard Link

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -115,11 +115,7 @@ Launch ${dashboard_app} From RHODS Dashboard Link
   ...    expected_page=Enabled
   IF    "OpenShift" in $dashboard_app
       ${splits}=    Split String From Right    ${dashboard_app}    max_split=1
-      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath:${CARDS_XP}//*[text()='${splits[0]} ']
-      Run Keyword And Continue On Failure    Page Should Contain Element      xpath:${CARDS_XP}//*[text()='${splits[0]} ']//a
-      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]//a
-      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]//div[contains(@class,"pf-c-card__footer")]/a
-      # Click Link  xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]/div[contains(@class,"pf-c-card__footer")]/a
+      Click Link   xpath:${CARDS_XP}//*[text()='${splits[0]} ']/../..//a
   ELSE
       Click Link  xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()="${dashboard_app}"]]/div[contains(@class,"pf-c-card__footer")]/a
   END

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -111,9 +111,18 @@ Wait Until RHODS Dashboard ${dashboard_app} Is Visible
   ...    timeout=30s
 
 Launch ${dashboard_app} From RHODS Dashboard Link
-  Wait Until RHODS Dashboard ${dashboard_app} Is Visible
-  # Click Link  xpath://div[@class="pf-c-card__title" and .="${dashboard_app}"]/../div[contains(@class,"pf-c-card__footer")]/a
-  Click Link  xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()="${dashboard_app}"]]/div[contains(@class,"pf-c-card__footer")]/a
+  Wait for RHODS Dashboard to Load    wait_for_cards=${TRUE}
+  ...    expected_page=Enabled
+  IF    "OpenShift" in $dashboard_app
+      ${splits}=    Split String From Right    ${dashboard_app}    max_split=1
+      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath:${CARDS_XP}//*[text()='${splits[0]} ']
+      Run Keyword And Continue On Failure    Page Should Contain Element      xpath:${CARDS_XP}//*[text()='${splits[0]} ']//a
+      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]//a
+      # Run Keyword And Continue On Failure    Page Should Contain Element      xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]//div[contains(@class,"pf-c-card__footer")]/a
+      # Click Link  xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()='${splits[0]} ']]/div[contains(@class,"pf-c-card__footer")]/a
+  ELSE
+      Click Link  xpath://div[contains(@class,'gallery')]/div[//div[@class="pf-c-card__title"]//*[text()="${dashboard_app}"]]/div[contains(@class,"pf-c-card__footer")]/a
+  END
   IF    "${dashboard_app}" != "Jupyter"
        Switch Window  NEW
   END


### PR DESCRIPTION
This PR is achieving 2 goals:
1. fix `Launch ${dashboard_app} From RHODS Dashboard Link` keyword which is broken in RHODS v1.23
2. call `Launch ${RHOAM_DISPLAYED_NAME} From RHODS Dashboard Link` from RHOAM test case