### PR TITLE
Extend test for tolerations in workbenches

### DIFF
--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -212,3 +212,5 @@ Open Dashboard Cluster Settings
         Click Element  xpath://button[@id="settings"]
     END
     Click Element  xpath://a[.="Cluster settings"]
+    Wait for RHODS Dashboard to Load    expected_page=Cluster Settings
+    ...    wait_for_cards=${FALSE}

--- a/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -212,5 +212,5 @@ Open Dashboard Cluster Settings
         Click Element  xpath://button[@id="settings"]
     END
     Click Element  xpath://a[.="Cluster settings"]
-    Wait for RHODS Dashboard to Load    expected_page=Cluster Settings
+    Wait For RHODS Dashboard To Load    expected_page=Cluster Settings
     ...    wait_for_cards=${FALSE}

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -136,8 +136,8 @@ Verify User Can Remove GPUs From Workbench
 
 *** Keywords ***
 Project Suite Setup
-    [Documentation]    Suite setup steps for testing DS Projects. It creates some test variables
-    ...                and runs RHOSi setup
+    [Documentation]    Suite setup steps for testing DS Projects. 
+    ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     ${to_delete}=    Create List    ${PRJ_TITLE}
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -170,7 +170,7 @@ Verify Workbench Has The Expected Tolerations
 
 Verify Workbench Does Not Have The Given Tolerations
     [Documentation]    Verifies notebook pod created as workbench does not
-    ...                contain the given toleration  
+    ...                contain the given toleration
     [Arguments]    ${workbench_title}    ${tolerations_text}
     ...            ${project_title}=${PRJ_TITLE}
     Run Keyword And Continue On Failure

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -16,6 +16,7 @@ ${PRJ_TITLE_GPU}=   ODS-CI DS Project GPU
 ${PRJ_RESOURCE_NAME}=   ods-ci-ds-project-test-additional
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Project feature
 ${TOLERATIONS}=    workbench-tolerations
+${TOLERATIONS_2}=    workbench-tolerations-two
 ${DEFAULT_TOLERATIONS}=    NotebooksOnly   
 ${WORKBENCH_TITLE_TOL_1}=   ODS-CI Workbench Tol
 ${WORKBENCH_TITLE_TOL_2}=   ODS-CI Workbench Tol 2
@@ -38,7 +39,7 @@ Verify Notebook Tolerations Are Applied To Workbenches
     ...                - workbench created after toleration change
     ...                - toleration change applied to existent workbench (after restart)
     [Tags]    Tier1    Sanity
-    ...       ODS-1969
+    ...       ODS-1969    ODS-2057
     Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}  workbench_description=${WORKBENCH_DESCRIPTION}
     ...                 prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE}   deployment_size=Small
     ...                 storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_TOL_1}  pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
@@ -63,6 +64,22 @@ Verify Notebook Tolerations Are Applied To Workbenches
     Start Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
     Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_TOL_1}
     Verify Server Workbench Has The Expected Toleration    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    ...    toleration=${TOLERATIONS}    project_title=${PRJ_TITLE}
+    Open Dashboard Cluster Settings
+    Set Pod Toleration Via UI    ${TOLERATIONS_2}
+    Save Changes In Cluster Settings
+    Sleep   40s    reason=Wait enough time for letting Dashboard to fetch the latest toleration settings
+    Open Data Science Projects Home Page
+    Open Data Science Project Details Page       project_title=${PRJ_TITLE}
+    Stop Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    Run Keyword And Continue On Failure    Wait Until Workbench Is Stopped     workbench_title=${WORKBENCH_TITLE_TOL_1}
+    Start Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_TOL_1}
+    Verify Server Workbench Has The Expected Toleration    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    ...    toleration=${TOLERATIONS_2}    project_title=${PRJ_TITLE}
+    Run Keyword And Expect Error    Unexpected Pod Toleration
+    ...    Verify Server Workbench Has The Expected Toleration
+    ...    workbench_title=${WORKBENCH_TITLE_TOL_1}
     ...    toleration=${TOLERATIONS}    project_title=${PRJ_TITLE}
     [Teardown]    Restore Tolerations Settings And Clean Project
 

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -54,6 +54,10 @@ Verify Notebook Tolerations Are Applied To Workbenches
     ...                 storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_TOL_2}  pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
     Verify Server Workbench Has The Expected Toleration    workbench_title=${WORKBENCH_TITLE_TOL_2}
     ...    toleration=${TOLERATIONS}    project_title=${PRJ_TITLE}
+    Run Keyword And Expect Error    Unexpected Pod Toleration
+    ...    Verify Server Workbench Has The Expected Toleration
+    ...    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    ...    toleration=${TOLERATIONS}    project_title=${PRJ_TITLE}
     Stop Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
     Run Keyword And Continue On Failure    Wait Until Workbench Is Stopped     workbench_title=${WORKBENCH_TITLE_TOL_1}
     Start Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -17,8 +17,8 @@ ${PRJ_RESOURCE_NAME}=   ods-ci-ds-project-test-additional
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Project feature
 ${TOLERATIONS}=    workbench-tolerations
 ${DEFAULT_TOLERATIONS}=    NotebooksOnly   
-${WORKBENCH_TITLE_TOL_1}=   ODS-CI Workbench Tolerations
-${WORKBENCH_TITLE_TOL_2}=   ODS-CI Workbench Tolerations 2
+${WORKBENCH_TITLE_TOL_1}=   ODS-CI Workbench Tol
+${WORKBENCH_TITLE_TOL_2}=   ODS-CI Workbench Tol 2
 ${WORKBENCH_DESCRIPTION}=   a test workbench to check tolerations are applied
 ${WORKBENCH_TITLE_GPU}=   ODS-CI Workbench GPU
 ${WORKBENCH_DESCRIPTION_GPU}=   ${WORKBENCH_TITLE_GPU} is a test workbench using GPU
@@ -32,14 +32,13 @@ ${PV_SIZE}=         1
 
 
 *** Test Cases ***
-Verify Notebook Tolerations Are Applied To Workbenches When Set Up
+Verify Notebook Tolerations Are Applied To Workbenches
     [Documentation]    Verifies workbenches get the custom tolerations set by
-    ...                admins in "Cluster Settings" page
+    ...                admins in "Cluster Settings" page. It checks 2 scenarios:
+    ...                - workbench created after toleration change
+    ...                - toleration change applied to existent workbench (after restart)
     [Tags]    Tier1    Sanity
     ...       ODS-1969
-    # Launch Data Science Project Main Page
-    # Open Data Science Projects Home Page
-    # Open Data Science Project Details Page       project_title=${PRJ_TITLE}
     Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}  workbench_description=${WORKBENCH_DESCRIPTION}
     ...                 prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE}   deployment_size=Small
     ...                 storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_TOL_1}  pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
@@ -47,7 +46,7 @@ Verify Notebook Tolerations Are Applied To Workbenches When Set Up
     Open Dashboard Cluster Settings
     Set Pod Toleration Via UI    ${TOLERATIONS}
     Save Changes In Cluster Settings
-    Launch Data Science Project Main Page
+    Open Data Science Projects Home Page
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}
     Sleep   40s    reason=Wait enough time for letting Dashboard to fetch the latest toleration settings
     Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_2}  workbench_description=${WORKBENCH_DESCRIPTION}
@@ -124,7 +123,7 @@ Project Suite Setup
     Set Library Search Order    SeleniumLibrary
     ${to_delete}=    Create List    ${PRJ_TITLE}
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
-    #RHOSi Setup
+    RHOSi Setup
     Launch Data Science Project Main Page
     Open Data Science Projects Home Page
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
@@ -135,7 +134,7 @@ Project Suite Teardown
     ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
     Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
-    #RHOSi Teardown
+    RHOSi Teardown
 
 Verify Server Workbench Has The Expected Toleration
     [Documentation]    Verifies notebook pod created as workbench

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -181,7 +181,7 @@ Verify Workbench Does Not Have The Given Tolerations
 
 Restore Tolerations Settings And Clean Project
     [Documentation]    Reset the notebook tolerations after testing
-    Open Settings And Set Tolerations To    ${DEFAULT_TOLERATIONS}
+    Open Settings And Disable Tolerations
     Open Data Science Projects Home Page
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}
     Stop Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
@@ -190,10 +190,10 @@ Restore Tolerations Settings And Clean Project
     ...    reason=waiting for dashboard to fetch the latest tolerations settings
     Start Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
     Start Workbench    workbench_title=${WORKBENCH_TITLE_TOL_2}
-    Verify Workbench Has The Expected Tolerations    workbench_title=${WORKBENCH_TITLE_TOL_2}
-    ...    toleration=${DEFAULT_TOLERATIONS}    project_title=${PRJ_TITLE}
-    Verify Workbench Has The Expected Tolerations    workbench_title=${WORKBENCH_TITLE_TOL_2}
-    ...    toleration=${DEFAULT_TOLERATIONS}    project_title=${PRJ_TITLE}
+    Verify Workbench Does Not Have The Given Tolerations
+    ...    workbench_title=${WORKBENCH_TITLE_TOL_1}    tolerations_text=${DEFAULT_TOLERATIONS}
+    Verify Workbench Does Not Have The Given Tolerations
+    ...    workbench_title=${WORKBENCH_TITLE_TOL_2}    tolerations_text=${DEFAULT_TOLERATIONS}
     Verify Workbench Does Not Have The Given Tolerations
     ...    workbench_title=${WORKBENCH_TITLE_TOL_1}    tolerations_text=${TOLERATIONS}
     Verify Workbench Does Not Have The Given Tolerations
@@ -271,4 +271,13 @@ Open Settings And Set Tolerations To
     [Arguments]    ${tolerations_text}
     Open Dashboard Cluster Settings
     Set Pod Toleration Via UI    ${tolerations_text}
+    Save Changes In Cluster Settings
+
+Open Settings And Disable Tolerations
+    [Documentation]    Opens the "Cluster Settings" page in RHODS Dashboard
+    ...                and disable the tolerations settings.
+    ...                Before disabling the setting, it restores the default value
+    Open Dashboard Cluster Settings
+    Set Pod Toleration Via UI    ${DEFAULT_TOLERATIONS}
+    Disable Pod Toleration Via UI
     Save Changes In Cluster Settings

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -37,7 +37,7 @@ Verify Notebook Tolerations Are Applied To Workbenches
     [Documentation]    Verifies workbenches get the custom tolerations set by
     ...  admins in "Cluster Settings" page. It checks 3 scenarios:
     ...  - tolerations changes applied to a workbench created after toleration changes (from toleration = null to toletation != null)
-    ...  - tolerations change applied to existent workbench, after restart (from toleration = null to toletation != null)
+    ...  - tolerations change applied to existent workbench, after restart (from toleration = null to toletation A)
     ...  - tolerations change applied to existent workbench, after restart (from toleration = A to toletation = B)
     ...  - tolerations get removed from existent workbench, after restart (in the teardown)
     [Tags]    Tier1    Sanity

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -36,16 +36,19 @@ ${PV_SIZE}=         1
 Verify Notebook Tolerations Are Applied To Workbenches
     [Documentation]    Verifies workbenches get the custom tolerations set by
     ...  admins in "Cluster Settings" page. It checks 3 scenarios:
-    ...  - tolerations changes applied to a workbench created after toleration changes (from toleration = null to toletation != null)
-    ...  - tolerations change applied to existent workbench, after restart (from toleration = null to toletation A)
-    ...  - tolerations change applied to existent workbench, after restart (from toleration = A to toletation = B)
-    ...  - tolerations get removed from existent workbench, after restart (in the teardown)
+    ...  -tolerations changes applied to workbench created after the changes (value from null to A)
+    ...  -tolerations change applied to existent workbench, after restart (value from null to A)
+    ...  -tolerations change applied to existent workbench, after restart (value from A to A)
+    ...  -tolerations get removed from existent workbench, after restart (check in teardown)
     [Tags]    Tier1    Sanity
     ...       ODS-1969    ODS-2057
-    Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}  workbench_description=${WORKBENCH_DESCRIPTION}
+    Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}
+    ...                 workbench_description=${WORKBENCH_DESCRIPTION}
     ...                 prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE}   deployment_size=Small
-    ...                 storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_TOL_1}  pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
-    Run Keyword And Continue On Failure    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_TOL_1}
+    ...                 storage=Persistent  pv_existent=${FALSE}    pv_name=${PV_NAME_TOL_1}
+    ...                 pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
+    Run Keyword And Continue On Failure
+    ...    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE_TOL_1}
     Open Settings And Set Tolerations To    ${TOLERATIONS}
     Open Data Science Projects Home Page
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}
@@ -166,6 +169,8 @@ Verify Workbench Has The Expected Tolerations
     ...    msg=Unexpected Pod Toleration
 
 Verify Workbench Does Not Have The Given Tolerations
+    [Documentation]    Verifies notebook pod created as workbench does not
+    ...                contain the given toleration  
     [Arguments]    ${workbench_title}    ${tolerations_text}
     ...            ${project_title}=${PRJ_TITLE}
     Run Keyword And Continue On Failure
@@ -261,6 +266,8 @@ Check Limits And Requests For Every Workbench Pod Container
     END
 
 Open Settings And Set Tolerations To
+    [Documentation]    Opens the "Cluster Settings" page in RHODS Dashboard
+    ...                and set the tolerations settings to the given one
     [Arguments]    ${tolerations_text}
     Open Dashboard Cluster Settings
     Set Pod Toleration Via UI    ${tolerations_text}

--- a/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -35,9 +35,11 @@ ${PV_SIZE}=         1
 *** Test Cases ***
 Verify Notebook Tolerations Are Applied To Workbenches
     [Documentation]    Verifies workbenches get the custom tolerations set by
-    ...                admins in "Cluster Settings" page. It checks 2 scenarios:
-    ...                - workbench created after toleration change
-    ...                - toleration change applied to existent workbench (after restart)
+    ...  admins in "Cluster Settings" page. It checks 3 scenarios:
+    ...  - tolerations changes applied to a workbench created after toleration changes (from toleration = null to toletation != null)
+    ...  - tolerations change applied to existent workbench, after restart (from toleration = null to toletation != null)
+    ...  - tolerations change applied to existent workbench, after restart (from toleration = A to toletation = B)
+    ...  - tolerations get removed from existent workbench, after restart
     [Tags]    Tier1    Sanity
     ...       ODS-1969    ODS-2057
     Create Workbench    workbench_title=${WORKBENCH_TITLE_TOL_1}  workbench_description=${WORKBENCH_DESCRIPTION}


### PR DESCRIPTION
The current PR is adding ODS-2057 to the test for tolerations in workbenches. The final test covers the following scenarios:

- tolerations changes applied to a workbench created after toleration changes (from toleration = null to toletation != null)
- tolerations change applied to existent workbench, after restart (from toleration = null to toletation != null)
- tolerations change applied to existent workbench, after restart (from toleration = A to toletation = B)
- tolerations get removed from existent workbench, after restart (in the teardown)

P.S. the 4 scenarios where gathered in the same RF test to reduce the amount of time spent in changing and saving cluster settings (i.e., for every save, we must wait around 40s for the tolerations settings to be effective)