### PR TITLE
fix the issue for upgrade verification

### DIFF
--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -198,8 +198,10 @@ OpenShift Resource Field Value Should Be Equal As Strings
     [Arguments]    ${actual}    ${expected}    @{resources}
     FOR    ${resource}    IN    @{resources}
         &{dict} =    Set Variable    ${resource}
-        Should Be Equal As Strings    ${dict.${actual}}    ${expected}
+        ${status} =    Run Keyword And Return Status    Should Be Equal As Strings    ${dict.${actual}}    ${expected}
+        Exit For Loop If    ${status}
     END
+    Run Keyword If    not ${status}   Fail     msg: Expected value didn't match with actual value
 
 OpenShift Resource Field Value Should Match Regexp
     [Documentation]

--- a/tests/Resources/ODS.robot
+++ b/tests/Resources/ODS.robot
@@ -201,7 +201,7 @@ OpenShift Resource Field Value Should Be Equal As Strings
         ${status} =    Run Keyword And Return Status    Should Be Equal As Strings    ${dict.${actual}}    ${expected}
         Exit For Loop If    ${status}
     END
-    Run Keyword If    not ${status}   Fail     msg: Expected value didn't match with actual value
+    IF    not ${status}   Fail     msg: Expected value didn't match with actual value
 
 OpenShift Resource Field Value Should Match Regexp
     [Documentation]


### PR DESCRIPTION
ODS-233 on upgrade cluster always fails because there are two replica set present and for older replica set we can not find the readyreplica value. this fix the issue.