### PR TITLE
Use resource variable for ODH Dashboard project name when checking for the ODH Dashboard title

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ test-variables.yml
 # Ignore runtime files created by the run_robot_test.sh script
 venv/
 ods_ci.egg-info/
+ods-ci.log*
 test-output/
 dist/
 drivers/**/chromedriver

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -10,6 +10,7 @@ Library       JupyterLibrary
 
 
 *** Variables ***
+${ODH_DASHBOARD_PROJECT_NAME}=   Red Hat OpenShift Data Science
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-c-card'))]
@@ -45,7 +46,7 @@ ${NOTIFICATION_DRAWER_CLOSE_BTN}=  //div[@class="pf-c-drawer__panel"]/div/div//b
 ${NOTIFICATION_DRAWER_CLOSED}=  //div[@class="pf-c-drawer__panel" and @hidden=""]
 ${GROUPS_CONFIG_CM}=    groups-config
 ${RHODS_GROUPS_CONFIG_CM}=    rhods-groups-config
-${RHODS_LOGO_XPATH}=    //img[@alt="Red Hat OpenShift Data Science Logo"]
+${RHODS_LOGO_XPATH}=    //img[@alt="${ODH_DASHBOARD_PROJECT_NAME} Logo"]
 @{ISV_TO_REMOVE_SELF_MANAGED}=      Create List     starburst   nvidia    rhoam
 
 
@@ -91,7 +92,7 @@ Logout From RHODS Dashboard
     Wait Until Page Contains  Log in with OpenShift
 
 Wait for RHODS Dashboard to Load
-    [Arguments]  ${dashboard_title}="Red Hat OpenShift Data Science"    ${wait_for_cards}=${TRUE}
+    [Arguments]  ${dashboard_title}="${ODH_DASHBOARD_PROJECT_NAME}"    ${wait_for_cards}=${TRUE}
     ...          ${expected_page}=Enabled
     Wait For Condition    return document.title == ${dashboard_title}    timeout=15s
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=20s


### PR DESCRIPTION
To support running ods-ci against Open Data Hub deployments, this PR adds resource file variable to allow anyone to set the project name referenced in the Dashboard title xpath to support using `Open Data Hub` vs `Red Hat OpenShift Data Science`

This change should not affect existing functionality since the default value is still `Red Hat OpenShift Data Science` and can be set via the global variable `ODH_DASHBOARD_PROJECT_NAME`