### PR TITLE
[RHODS-4116] Adding Quickstart test for restart functionality 

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -76,6 +76,8 @@ Close QuickStart From Button
 Mark Step Check As Yes
     Wait Until Page Contains Element    //input[@data-testid="qs-drawer-check-yes"]
     Click Button    //input[@data-testid="qs-drawer-check-yes"]
+    Wait Until Page Contains Element    //div[contains(@class, "pf-m-success")]
+
 
 Mark Step Check As No
     Wait Until Page Contains Element    //input[@data-testid="qs-drawer-check-no"]

--- a/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -96,7 +96,6 @@ Verify Filters Are Working On Resources Page
     Filter By Application (Aka Povider) And Check Output
     Filter By Using More Than One Filter And Check Output
 
-<<<<<<< HEAD
 Verify App Name On Resource Tile
     [Documentation]    Check that each resource tile specifies which application it refers to
     [Tags]    Sanity
@@ -106,8 +105,6 @@ Verify App Name On Resource Tile
     Wait For RHODS Dashboard To Load    expected_page=Resources
     Validate App Name Is Present On Each Tile
 
-=======
->>>>>>> 9256755 (Adding Quickstart test for restart functionality [RHODS-4116])
 
 *** Keywords ***
 Resources Test Setup


### PR DESCRIPTION
Covers the scope for
[ODS-1405](https://polarion.engineering.redhat.com/polarion/#/project/OpenDataHub/workitem?id=ODS-1405)
[ODS-1406](https://polarion.engineering.redhat.com/polarion/#/project/OpenDataHub/workitem?id=ODS-1406)

It tests the existing quickstart tests on all the quickstart cards instead of on specific ones.

Existing Known failure: "build-deploy-watson-model" fails due to no Yes, no radio links exist. Talks ongoing to remove this quickstart.