### PR TITLE
fix for robocop action

### DIFF
--- a/.robocop
+++ b/.robocop
@@ -5,7 +5,7 @@
 #########################################################
 # Excluded rules                                        #
 #########################################################
---exclude could-be-forced-tags
+--exclude could-be-test-tags
 --exclude if-can-be-used
 --exclude todo-in-comment
 #--exclude missing-doc-suite


### PR DESCRIPTION
`could-be-forced-tags` rule has been removed and replaced by "could-be-test-tags" from the robocop 3.0.0 . Which was causing the robocop GitHub action to fail. 