### PR TITLE
Add option to skip 'Maybe Wait For Dashboard Loading Spinner Page' for performance testing

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -780,6 +780,12 @@ Maybe Wait For Dashboard Loading Spinner Page
     [Documentation]     Detecs the loading symbol (spinner) and wait for it to disappear.
     ...                 If the spinner does not appear, the keyword ignores the error.
     [Arguments]    ${timeout}=5s
+
+    ${do not wait for spinner}=    Get Variable Value    ${ODH_DASHBOARD_DO_NOT_WAIT_FOR_SPINNER_PAGE}  # defaults to None if undefined
+    IF   ${do not wait for spinner} == ${true}
+      RETURN
+    END
+
     Run Keyword And Ignore Error    Run Keywords
     ...    Wait Until Page Contains Element    xpath=//span[@class="pf-c-spinner__tail-ball"]    timeout=${timeout}
     ...    AND


### PR DESCRIPTION
Following the discussion in #709 I open this PR to discuss how to get this change merged in the code, in a way that is compatible with the notebook scale test and QE tests at the same time.

The reason why we can't have it as part of the notebook scale test is that this call introduce a `Sleep 5s` delay that invalidates the timing measurements.

