### PR TITLE
Upgrade ODS-CI image to centos stream 9

### DIFF
--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -14,21 +14,16 @@ ARG OC_VERSION=4.10
 ARG OC_CHANNEL=stable
 
 
-RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
-    dnf install -y python38 jq git unzip chromium chromedriver redhat-lsb-core httpd-tools &&\
-    dnf clean all
-
-## Install yq in the image
-RUN curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
-    chmod +x /usr/bin/yq
-
-## Install oc and ocm in the container
-RUN curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \
+RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
+    dnf install -y jq git unzip chromium chromedriver python3-distro httpd-tools &&\
+    dnf clean all &&\
+    curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
+    chmod +x /usr/bin/yq &&\
+    curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \
     tar xvf $HOME/oc_client.tar.gz -C /usr/local/bin/ && \
     rm -rf $HOME/oc_client.tar.gz && rm /usr/local/bin/README.md && chmod 755 /usr/local/bin/oc && oc version --client && \
     curl -L https://github.com/openshift-online/ocm-cli/releases/download/v0.1.62/ocm-linux-amd64 -o $HOME/ocm && \
     mv $HOME/ocm /usr/local/bin/ && chmod 755 /usr/local/bin/ocm && ocm version
-
 
 RUN mkdir $HOME/ods-ci
 # Change the WORKDIR so the run script references any files/folders from the root of the repo

--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -17,12 +17,12 @@ ARG OC_CHANNEL=stable
 RUN dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
     dnf install -y jq git unzip chromium chromedriver python3-distro httpd-tools &&\
     dnf clean all &&\
-    curl -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
+    curl --proto "=https" -L https://github.com/mikefarah/yq/releases/download/v4.25.1/yq_linux_amd64 -o /usr/bin/yq &&\
     chmod +x /usr/bin/yq &&\
-    curl -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \
+    curl --proto "=https" -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \
     tar xvf $HOME/oc_client.tar.gz -C /usr/local/bin/ && \
     rm -rf $HOME/oc_client.tar.gz && rm /usr/local/bin/README.md && chmod 755 /usr/local/bin/oc && oc version --client && \
-    curl -L https://github.com/openshift-online/ocm-cli/releases/download/v0.1.62/ocm-linux-amd64 -o $HOME/ocm && \
+    curl --proto "=https" -L https://github.com/openshift-online/ocm-cli/releases/download/v0.1.62/ocm-linux-amd64 -o $HOME/ocm && \
     mv $HOME/ocm /usr/local/bin/ && chmod 755 /usr/local/bin/ocm && ocm version
 
 RUN mkdir $HOME/ods-ci

--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}

--- a/ods_ci/build/run.sh
+++ b/ods_ci/build/run.sh
@@ -25,6 +25,6 @@ if [ "${SET_ENVIRONMENT}" -eq 1 ]; then \
   fi
 fi
 echo "-----| ODS-CI is starting the tests run...|-----"
-./ods_ci/run_robot_test.sh --skip-pip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}"
+./ods_ci/run_robot_test.sh --skip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}"
 
 

--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -191,22 +191,22 @@ case "$(uname -s)" in
          echo "$PATH"
          ;;
     Linux)
-       case "$(lsb_release --id --short)" in
-       "Fedora"|"CentOS")
+       case "$(distro -j | jq '.id')" in
+       "fedora"|"centos")
              ## Bootstrap script to setup drivers ##
              echo "setting driver  to $currentpath/Drivers/fedora"
              PATH=$PATH:$currentpath/drivers/fedora
              export PATH=$PATH
              echo "$PATH"
         ;;
-        "Ubuntu")
+        "ubuntu")
              echo "Ubuntu"
              echo "setting driver  to $currentpath/drivers/ubuntu"
              PATH=$PATH:$currentpath/drivers/ubuntu
              export PATH=$PATH
              echo "$PATH"
         ;;
-        "openSUSE project"|"SUSE LINUX"|"openSUSE")
+        "opensuse project"|"suse linux"|"opensuse")
              echo "Not yet supported, but shouldn't be hard for you to fix :) "
              echo "Please add the driver, test and submit PR"
              exit 1


### PR DESCRIPTION
Image upgrade comes with additional changes in the Dockerfile:
1. replace `lsb_release` with python pkg `distro` ([details](https://access.redhat.com/solutions/6973382))
2. upgrade to python 3.9 (installed by default in centos stream 9)
3. upgrade fedora `epel` to avoid issue with chromium installation

Plus, 3 more changes not related to OS upgrade:
1. add security hotspot fix as suggested by SonarCloud in the cURL steps
2. join 2 RUN steps into one single one ([docker best practices](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers))
3. fix the argument `--skip-pip-install` in `run.sh` script which was preventing the scripts to run