### PR TITLE
Added options for Openstack Cloud and OCP CNI

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
@@ -49,7 +49,7 @@ items:
           hostPrefix: 23
         machineNetwork:
         - cidr: 10.0.0.0/16
-        networkType: OpenShiftSDN
+        networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
       platform:

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
@@ -49,7 +49,7 @@ items:
           hostPrefix: 23
         machineNetwork:
         - cidr: 10.0.0.0/16
-        networkType: OpenShiftSDN
+        networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
       platform:

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
@@ -54,7 +54,7 @@ items:
           hostPrefix: 23
         machineNetwork:
         - cidr: 192.169.0.0/16
-        networkType: OpenShiftSDN
+        networkType: {{ ${infrastructure_configurations}[ocp_network_type]|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
       platform:

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
@@ -92,7 +92,7 @@ items:
   type: Opaque
   data:
     clouds.yaml: ${infrastructure_configurations}[osp_yaml_encoded]
-    cloud: ${infrastructure_configurations}[osp_name_encoded]
+    cloud: ${OSP_CLOUD}
 - apiVersion: hive.openshift.io/v1
   kind: ClusterImageSet
   metadata:

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
@@ -54,7 +54,7 @@ items:
           hostPrefix: 23
         machineNetwork:
         - cidr: 192.169.0.0/16
-        networkType: {{ ${infrastructure_configurations}[ocp_network_type]|default("OVNKubernetes") }}
+        networkType: ${infrastructure_configurations}[ocp_network_type]
         serviceNetwork:
         - 172.30.0.0/16
       platform:

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -67,11 +67,16 @@ Select Provisioner Template
     RETURN    ${template}
         
 Create Openstack Resources
+    Log    Creating OSP resources in Cloud '${infrastructure_configurations}[osp_cloud_name]'    console=True
+    ${result} 	 	Run Process 	echo '${infrastructure_configurations}[osp_cloud_name]' | base64 -w0    shell=yes
+    Should Be True    ${result.rc} == 0
+    Set Task Variable    ${OSP_CLOUD}    ${result.stdout}
     ${FIP_API}    Evaluate    ${infrastructure_configurations}.get('fip_api')
     ${FIP_APPS}    Evaluate    ${infrastructure_configurations}.get('fip_apps')
     Run Keyword If    "${FIP_API}" == "" or "${FIP_APPS}" == ""    Create Floating IPs
+    ...    ELSE    Log    Reusing existing Floating IPs    console=True
     Set Task Variable    ${FIP_API}
-    Set Task Variable    ${FIP_APPS}
+    Set Task Variable    ${FIP_APPS}    
     Log    FIP_API = ${FIP_API}    console=True
     Log    FIP_APPS = ${FIP_APPS}    console=True
     ${hive_yaml} =    Set Variable    ${artifacts_dir}/${cluster_name}_hive.yaml
@@ -80,6 +85,7 @@ Create Openstack Resources
     Oc Apply    kind=List    src=${hive_yaml}    api_version=v1
 
 Create Floating IPs
+    Log    Creating Openstack Floating IPs and AWS DNS Records    console=True
     ${osp_clouds_yaml} =    Set Variable    ~/.config/openstack/clouds.yaml
     ${result} 	Run Process 	echo '${infrastructure_configurations}[osp_yaml_encoded]' | base64 --decode    shell=yes
     Should Be True    ${result.rc} == 0


### PR DESCRIPTION
Following options added when provisioning new cluster with Hive:
1. OCP Cloud name for Openstack (e.g. RHOS-D or RHOS-01)
2. OCP CNI type, where OVNKubernetes is the default

In addition, set AWS DNS records to update existing A records 
(Required for API and APPS floating IPs of Openstack)