### PR TITLE
Added support to install rhods from different update  channels

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -71,13 +71,13 @@ Clone OLM Install Repo
 Install RHODS In Self Managed Cluster Using CLI
    [Documentation]   Install rhods on self managed cluster using cli
    [Arguments]     ${cluster_type}     ${image_url}
-   ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${filename} && ./setup.sh -t operator -i ${image_url}   #robocop:disable
+   ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${filename} && ./setup.sh -t operator -u ${UPDATE_CHANNEL} -i ${image_url}   #robocop:disable
    Log To Console    ${output}
    Should Be Equal As Integers	${return_code}	 0   msg=Error detected while installing RHODS
 
 Install RHODS In Managed Cluster Using CLI
    [Documentation]   Install rhods on managed managed cluster using cli
    [Arguments]     ${cluster_type}     ${image_url}
-   ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${filename} && ./setup.sh -t addon -i ${image_url}  #robocop:disable
+   ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${filename} && ./setup.sh -t addon -u ${UPDATE_CHANNEL} -i ${image_url}  #robocop:disable
    Log To Console    ${output}
    Should Be Equal As Integers	${return_code}	 0  msg=Error detected while installing RHODS

--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -13,6 +13,7 @@ ${RHODS_OSD_INSTALL_REPO}     None
 @{SUPPORTED_TEST_ENV}    AWS   GCP   PSI
 ${TEST_ENV}              AWS
 ${INSTALL_TYPE}          OperatorHub
+${UPDATE_CHANNEL}        beta
 *** Tasks ***
 Can Install RHODS Operator
   [Tags]  install


### PR DESCRIPTION
SM:
`sh run_robot_test.sh --include install --test-variable image_url:brew.registry.redhat.io/rh-osbs/iib:492344 --test-variable TEST_ENV:GCP --test-variable cluster_type:selfmanaged --test-variable RHODS_OSD_INSTALL_REPO:<OLM repo> --test-variable INSTALL_TYPE:CLi --test-variable UPDATE_CHANNEL:odh-nightlies --test-case tasks/Tasks/rhods_olm.robot --test-variables-file test-variables.yml`

Managed:
`sh run_robot_test.sh --include install --test-variable image_url:brew.registry.redhat.io/rh-osbs/iib:492344 --test-variable TEST_ENV:GCP --test-variable cluster_type:managed --test-variable RHODS_OSD_INSTALL_REPO:<OLM repo> --test-variable INSTALL_TYPE:CLi --test-variable UPDATE_CHANNEL:odh-nightlies --test-case tasks/Tasks/rhods_olm.robot --test-variables-file test-variables.yml`