### PR TITLE
Update xpath of PV input for 1.27

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -9,7 +9,7 @@ Resource       Projects.resource
 ${STORAGE_SECTION_XP}=             xpath=//div[@id="cluster-storages"]
 ${STORAGE_NAME_INPUT_XP}=          xpath=//input[@name="create-new-storage-name"]
 ${STORAGE_DESCR_INPUT_XP}=         xpath=//textarea[@name="create-new-storage-description"]
-${STORAGE_SIZE_INPUT_XP}=         xpath=//div/input[@aria-label="Input"]
+${STORAGE_SIZE_INPUT_XP}=         xpath=//div/input[@data-ouia-component-id="OUIA-Generated-TextInputBase-3"]
 ${STORAGE_SIZE_PLUS_BTN_XP}=         xpath=//div/button[@aria-label="Plus"]
 ${STORAGE_MOUNT_DIR_INPUT_XP}=         xpath=//input[@aria-label="mount-path-folder-value"]
 ${STORAGE_WORKBENCH_SELECTOR_XP}=         xpath=//div[contains(@class,"modal")]//div[contains(@class,"pf-c-select")]/ul/li

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -9,7 +9,7 @@ Resource       Projects.resource
 ${STORAGE_SECTION_XP}=             xpath=//div[@id="cluster-storages"]
 ${STORAGE_NAME_INPUT_XP}=          xpath=//input[@name="create-new-storage-name"]
 ${STORAGE_DESCR_INPUT_XP}=         xpath=//textarea[@name="create-new-storage-description"]
-${STORAGE_SIZE_INPUT_XP}=         xpath=//div/input[@data-ouia-component-id="OUIA-Generated-TextInputBase-3"]
+${STORAGE_SIZE_INPUT_XP}=         xpath=//div/input[contains(@aria-label,"input") or contains(@aria-label,"Input")]
 ${STORAGE_SIZE_PLUS_BTN_XP}=         xpath=//div/button[@aria-label="Plus"]
 ${STORAGE_MOUNT_DIR_INPUT_XP}=         xpath=//input[@aria-label="mount-path-folder-value"]
 ${STORAGE_WORKBENCH_SELECTOR_XP}=         xpath=//div[contains(@class,"modal")]//div[contains(@class,"pf-c-select")]/ul/li


### PR DESCRIPTION
In 1.27 the labels have been changed for PV size input field. Updating the xpath to work with both 1.27 and earlier releases.