### PR TITLE
Projects.Create Data Science Project: give more time for the page to reload

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -102,8 +102,8 @@ Create Data Science Project
         IF    ${is_home_open} == ${TRUE}
             Log    message=After DS Project creation, user did not get redirected to details page...
             Reload Page
-            Wait Until Page Contains Element    ${DS_PROJECT_XP}
-            Wait Until Page Contains Element    xpath://a[.="${title}"]
+            Wait Until Page Contains Element    ${DS_PROJECT_XP}  timeout=30s
+            Wait Until Page Contains Element    xpath://a[.="${title}"]  timeout=30s
             Open Data Science Project Details Page    project_title=${title}
         END
     END


### PR DESCRIPTION
With RHODS 1.27, we are seeing [many](https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift-psap_ci-artifacts/707/pull-ci-openshift-psap-ci-artifacts-main-ods-notebooks/1660640721922691072/artifacts/notebooks/test/artifacts/001__test_run/002__plots/report_00_report:_error_report.html) (18/300) users failing because of this timeout.

Increasing the timeout from 5s to 30s to avoid the failure.

This is related to https://issues.redhat.com/browse/RHODS-8477 workaround.