### PR TITLE
Refactor Project Sharing tests and add a test for user group access

### DIFF
--- a/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -15,7 +15,9 @@ Go To ${group_name} Group Page
 Create Group
     [Documentation]     Creates a user group in OCP
     [Arguments]   ${group_name}
-    Oc Create  kind=Group   src={"metadata": {"name": "${group_name}"}, "users": null}
+    ${res}  ${output}=    Run And Return Rc And Output    oc adm groups new ${group_name}
+    # Oc Create  kind=Group   src={"metadata": {"name": "${group_name}"}, "users": null}
+    Should Be Equal As Integers    ${res}    0
 
 Delete Group
     [Documentation]     Deletes a user group in OCP

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -17,6 +17,7 @@ Assign ${permission_type} Permissions To ${username}
     Element Should Be Disabled    ${SAVE_BUTTON}
     Input Text    css:input[aria-label="project-sharing-name-input"]    ${username}
     Select Permission Type    permission_type=${permission_type}
+    Save Permission
 
 Change ${username} Permissions To ${permission_type}
     [Documentation]    Change the level of permission ${permission_type} for the given user ${username}
@@ -37,9 +38,22 @@ Select Permission Type
     [Arguments]    ${permission_type}
     Click Element    ${PERMISSIONS_DROPDOWN}
     Click Element    xpath://ul/li/button/span[text()="${permission_type}"]
+
+Save Permission
     Element Should Be Enabled    ${SAVE_BUTTON}
     Click Element    ${SAVE_BUTTON}
     Wait Until Page Does Not Contain Element    ${SAVE_BUTTON}
+
+Assign ${permission_type} Permissions To Group ${group_name}
+    [Documentation]    Assign the user ${username} and level of permission ${permission_type}
+    ...    to the currently open DS Project in UI
+    Log     ${username} - ${permission_type}
+    Click Element    xpath://button[text()="Add group"]
+    Element Should Be Disabled    ${SAVE_BUTTON}
+    Click Element    css:inputþ[aria-label="Name selection"]
+    Wait Until Page Contains Element    xpath://li/button[text()="${group_name}"]
+    Select Permission Type    permission_type=${permission_type}
+    Save Permission
 
 Click Action From Actions Menu
     [Documentation]    Click an action from Actions menu (3-dots menu on the right)
@@ -77,3 +91,8 @@ RoleBinding Should Exist
     ...    subject_name=${subject_name}
     Run Keyword And Continue On Failure    Should Not Be Empty    ${out}
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${rc}    0
+
+Is ${username} In The Permissions Table
+    ${present}=    Run Keyword And Return Status
+    ...    Page Should Contain Element       xpath=//tr[td[@data-label="Username"]//*[text()="${username}"]]
+    RETURN    ${present}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -26,6 +26,7 @@ Change ${username} Permissions To ${permission_type}
     Permissions.Click Action From Actions Menu    username=${username}
     ...    action=Edit
     Select Permission Type    permission_type=${permission_type}
+    Save Permission
 
 Remove ${username} Permissions
     [Documentation]    Remove the the access to the given user ${username}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -6,10 +6,11 @@ Resource       ./Projects.resource
 *** Variables ***
 ${SAVE_BUTTON}=    xpath://button[@data-id="save-rolebinding-button"]
 ${PERMISSIONS_DROPDOWN}=    xpath://td[@data-label="Permission"]//button[@aria-label="Options menu"]
+${IS_CLUSTER_ADMIN}=    ${FALSE}
 
 
 *** Keywords ***
-Assign ${permission_type} Permissions To ${username}
+Assign ${permission_type} Permissions To User ${username}
     [Documentation]    Assign the user ${username} and level of permission ${permission_type}
     ...    to the currently open DS Project in UI
     Log     ${username} - ${permission_type}
@@ -45,13 +46,17 @@ Save Permission
     Wait Until Page Does Not Contain Element    ${SAVE_BUTTON}
 
 Assign ${permission_type} Permissions To Group ${group_name}
-    [Documentation]    Assign the user ${username} and level of permission ${permission_type}
+    [Documentation]    Assign the user ${group_name} and level of permission ${permission_type}
     ...    to the currently open DS Project in UI
-    Log     ${username} - ${permission_type}
+    Log     ${group_name} - ${permission_type}
     Click Element    xpath://button[text()="Add group"]
     Element Should Be Disabled    ${SAVE_BUTTON}
-    Click Element    css:inputþ[aria-label="Name selection"]
-    Wait Until Page Contains Element    xpath://li/button[text()="${group_name}"]
+    IF    ${IS_CLUSTER_ADMIN} == ${FALSE}
+        Input Text    css:input[aria-label="project-sharing-name-input"]    ${group_name}
+    ELSE
+        Click Element    css:input[aria-label="Name selection"]
+        Wait Until Page Contains Element    xpath://li/button[text()="${group_name}"]
+    END
     Select Permission Type    permission_type=${permission_type}
     Save Permission
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -110,7 +110,7 @@ Create Data Science Project
             ...    level=WARN
             Reload Page
             Wait Until Page Contains Element    ${DS_PROJECT_XP}  timeout=30s
-            Wait Until Page Contains Element    xpath://a[.="${title}"]  timeout=30s
+            Wait Until Project Is Listed    project_title=${title}
             Open Data Science Project Details Page    project_title=${title}
         END
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -68,6 +68,12 @@ Project Should Be Listed
     [Arguments]     ${project_title}
     Run Keyword And Continue On Failure     Page Should Contain Element    xpath=//td/div/a[text()="${project_title}"]
 
+Wait Until Project Is Listed
+    [Documentation]    Waits until the DS projects appears in the list in DS project Home Page
+    [Arguments]     ${project_title}    ${timeout}=30s
+    Wait Until Page Contains Element    xpath=//td/div/a[text()="${project_title}"]
+    ...    timeout=${timeout}
+
 Project Should Not Be Listed
     [Documentation]    Checks a Project is not available in DS Project home page
     [Arguments]     ${project_title}
@@ -101,6 +107,7 @@ Create Data Science Project
         ${is_home_open}=    Is Data Science Projects Page Open
         IF    ${is_home_open} == ${TRUE}
             Log    message=After DS Project creation, user did not get redirected to details page...
+            ...    level=WARN
             Reload Page
             Wait Until Page Contains Element    ${DS_PROJECT_XP}  timeout=30s
             Wait Until Page Contains Element    xpath://a[.="${title}"]  timeout=30s

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -106,7 +106,7 @@ Create Data Science Project
     IF    ${open} == ${FALSE}
         ${is_home_open}=    Is Data Science Projects Page Open
         IF    ${is_home_open} == ${TRUE}
-            Log    message=After DS Project creation, user did not get redirected to details page...
+            Log    message=After DS Project ${title} creation, user did not get redirected to details page...
             ...    level=WARN
             Reload Page
             Wait Until Page Contains Element    ${DS_PROJECT_XP}  timeout=30s
@@ -333,6 +333,7 @@ Permissions Tab Should Not Be Accessible
     [Documentation]    Verify user cannot access the "Permissions" tab of a DS project
     ${status}=    Run Keyword And Return Status    Permissions Tab Should Be Accessible
     IF    ${status} == ${TRUE}
+        Capture Page Screenshot
         Fail    msg=user should not have rights to access Permissions tab on the current DS Project
     END
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -82,18 +82,15 @@ Verify User Can Assign Access Permissions To User Groups
     ...    subject_name=${USER_GROUP_2}
 
     Switch To User    ${USER_A}
-    Capture Page Screenshot
     Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
+    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
     Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
 
     Switch To User    ${USER_C}
     Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
+    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
     Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
@@ -105,8 +102,7 @@ Verify User Can Assign Access Permissions To User Groups
 
     Switch To User    ${USER_A}
     Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
+    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
     Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
@@ -114,8 +110,7 @@ Verify User Can Assign Access Permissions To User Groups
 
     Switch To User    ${USER_C}
     Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
+    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
     Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
@@ -125,8 +120,7 @@ Verify User Can Assign Access Permissions To User Groups
 
     Switch To User    ${USER_C}
     Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
+    Reload Page If Project ${PRJ_USER_B_TITLE} Is Listed
     Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
     RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_C}
@@ -270,3 +264,23 @@ Refresh Pages
     Open Data Science Projects Home Page
     Reload RHODS Dashboard Page    expected_page=Data science projects
     ...    wait_for_cards=${FALSE}
+
+Reload Page If Project ${project_title} Is Not Listed
+    ${is_listed}=    Run Keyword And Return Status
+    ...    Project Should Be Listed    project_title=${project_title}
+    IF    ${is_listed} == ${FALSE}
+        Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!    # robocop:disable
+        ...    level=WARN
+        Reload RHODS Dashboard Page    expected_page=Data science projects
+        ...    wait_for_cards=${FALSE}        
+    END
+
+Reload Page If Project ${project_title} Is Listed
+    ${is_listed}=    Run Keyword And Return Status
+    ...    Project Should Be Listed    project_title=${project_title}
+    IF    ${is_listed} == ${TRUE}
+        Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!    # robocop:disable
+        ...    level=WARN
+        Reload RHODS Dashboard Page    expected_page=Data science projects
+        ...    wait_for_cards=${FALSE}        
+    END

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -220,7 +220,15 @@ Reload Page If Project ${project_title} Is Not Listed
         Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!    # robocop:disable
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data science projects
-        ...    wait_for_cards=${FALSE}        
+        ...    wait_for_cards=${FALSE}
+        ${is_listed}=    Run Keyword And Return Status
+        ...    Project Should Be Listed    project_title=${project_title}
+        IF    ${is_listed} == ${FALSE}
+            Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
+            ...    level=WARN
+            Reload RHODS Dashboard Page    expected_page=Data science projects
+            ...    wait_for_cards=${FALSE}
+        END
     END
 
 Reload Page If Project ${project_title} Is Listed

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -7,14 +7,14 @@ Suite Teardown     Project Permissions Mgmt Suite Teardown
 
 *** Variables ***
 ${PRJ_BASE_TITLE}=   ODS-CI DS Project
-${PRJ_A_TITLE}=   ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
 ${PRJ_DESCRIPTION}=   ${PRJ_BASE_TITLE} is a test project for validating DS Project Sharing feature
 ${WORKBENCH_DESCRIPTION}=   a test workbench to check project sharing
 ${NB_IMAGE}=        Minimal Python
 ${PV_NAME}=         ods-ci-project-sharing
 ${PV_DESCRIPTION}=         it is a PV created to test DS Projects Sharing feature
 ${PV_SIZE}=         1
-
+${USER_GROUP_1}=    ds-group-1
+${USER_GROUP_2}=    ds-group-2
 
 *** Test Cases ***
 Verify User Can Access Permission Tab In Their Owned DS Project
@@ -27,16 +27,16 @@ Verify User Can Make Their Owned DS Project Accessible To Other Users    # roboc
     [Documentation]    Verify user can give access permissions for their DS Projects to other users
     [Tags]    Tier1    Smoke
     ...       ODS-2201
-    Switch To User    ${TEST_USER_3.USERNAME}
+    Switch To User    ${USER_B}
     Move To Tab    Permissions
-    Assign Edit Permissions To ${TEST_USER_4.USERNAME}
-    Assign Admin Permissions To ${TEST_USER_2.USERNAME}
-    Switch To User    ${TEST_USER_4.USERNAME}
-    Open Data Science Project Details Page    ${PRJ_A_TITLE}
+    Assign Edit Permissions To ${USER_C}
+    Assign Admin Permissions To ${USER_A}
+    Switch To User    ${USER_C}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
     Capture Page Screenshot
-    Switch To User    ${TEST_USER_2.USERNAME}
-    Open Data Science Project Details Page    ${PRJ_A_TITLE}
+    Switch To User    ${USER_A}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
     Capture Page Screenshot
 
@@ -44,30 +44,30 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     [Documentation]    Verify user can modify/remove access permissions for their DS Projects to other users
     [Tags]    Tier1    Sanity
     ...       ODS-2202
-    Switch To User    ${TEST_USER_3.USERNAME}
+    Switch To User    ${USER_B}
     Move To Tab    Permissions
-    Change ${TEST_USER_4.USERNAME} Permissions To Admin
-    Change ${TEST_USER_2.USERNAME} Permissions To Edit
-    Switch To User    ${TEST_USER_4.USERNAME}
-    Open Data Science Project Details Page    ${PRJ_A_TITLE}
+    Change ${USER_C} Permissions To Admin
+    Change ${USER_A} Permissions To Edit
+    Switch To User    ${USER_C}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
     Components Tab Should Be Accessible
-    RoleBinding Should Exist    project_title=${PRJ_A_TITLE}
-    ...    subject_name=${TEST_USER_4.USERNAME}
-    Switch To User    ${TEST_USER_2.USERNAME}
-    Open Data Science Project Details Page    ${PRJ_A_TITLE}
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_C}
+    Switch To User    ${USER_A}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
-    RoleBinding Should Exist    project_title=${PRJ_A_TITLE}
-    ...    subject_name=${TEST_USER_2.USERNAME}
-    Switch To User    ${TEST_USER_3.USERNAME}
-    Remove ${TEST_USER_4.USERNAME} Permissions
-    Switch To User    ${TEST_USER_4.USERNAME}
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_A}
+    Switch To User    ${USER_B}
+    Remove ${USER_C} Permissions
+    Switch To User    ${USER_C}
     Open Data Science Projects Home Page
     Reload RHODS Dashboard Page    expected_page=Data science projects
     ...    wait_for_cards=${FALSE}
-    Project Should Not Be Listed    project_title=${PRJ_A_TITLE}
-    RoleBinding Should Not Exist    project_title=${PRJ_A_TITLE}
-    ...    subject_name=${TEST_USER_4.USERNAME}
+    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
+    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_C}
 
 
 *** Keywords ***
@@ -75,36 +75,13 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     [Documentation]    Suite setup steps for testing DS Projects.
     ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
-    ${to_delete}=    Create List    ${PRJ_A_TITLE}
-    ...    ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
-    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     RHOSi Setup
-    Remove User From Group    username=${TEST_USER_2.USERNAME}
-    ...    group_name=dedicated-admins
-    Remove User From Group    username=${TEST_USER_2.USERNAME}
-    ...    group_name=rhods-admins
-    Add User To Group    username=${TEST_USER_2.USERNAME}
-    ...    group_name=rhods-users
-    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}  ocp_user_pw=${TEST_USER_2.PASSWORD}
-    ...    ocp_user_auth_type=${TEST_USER_2.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
-    ...    browser=${BROWSER.NAME}   browser_options=${BROWSER.OPTIONS}
-    ...    browser_alias=${TEST_USER_2.USERNAME}-session
-    Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
-    ...    password=${TEST_USER_3.PASSWORD}
-    ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
-    ...    browser_alias=${TEST_USER_3.USERNAME}-session
-    Create Data Science Project    title=${PRJ_A_TITLE}
-    ...    description=${PRJ_DESCRIPTION}
-    Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
-    Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
-    ...    password=${TEST_USER_4.PASSWORD}
-    ...    ocp_user_auth_type=${TEST_USER_4.AUTH_TYPE}
-    ...    browser_alias=${TEST_USER_4.USERNAME}-session
-    Create Data Science Project    title=${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
-    ...    description=${PRJ_DESCRIPTION}
-    Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
+    Launch RHODS Dashboard Session With User A
+    Launch RHODS Dashboard Session And Create A DS Project With User B
+    Launch RHODS Dashboard Session With User C
+    ${to_delete}=    Create List    ${PRJ_USER_B_TITLE}
+    ...    ${PRJ_USER_C_TITLE}
+    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
 
 Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
@@ -112,11 +89,11 @@ Project Permissions Mgmt Suite Teardown
     Close All Browsers
     Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
-    Remove User From Group    username=${TEST_USER_2.USERNAME}
+    Remove User From Group    username=${USER_A}
     ...    group_name=rhods-users
-    Add User To Group    username=${TEST_USER_2.USERNAME}
+    Add User To Group    username=${USER_A}
     ...    group_name=dedicated-admins
-    Add User To Group    username=${TEST_USER_2.USERNAME}
+    Add User To Group    username=${USER_A}
     ...    group_name=rhods-admins
 
 Switch To User
@@ -124,3 +101,56 @@ Switch To User
     ...    is a user login session in RHODS Dashboard
     [Arguments]    ${username}
     Switch Browser    ${username}-session
+
+Launch RHODS Dashboard Session With User A
+    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}  ocp_user_pw=${TEST_USER_2.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER_2.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
+    ...    browser=${BROWSER.NAME}   browser_options=${BROWSER.OPTIONS}
+    ...    browser_alias=${TEST_USER_2.USERNAME}-session
+    Set Suite Variable    ${USER_A}    ${TEST_USER_2.USERNAME}
+
+Launch RHODS Dashboard Session And Create A DS Project With User B
+    ${PRJ_USER_B_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+    Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
+    ...    password=${TEST_USER_3.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
+    ...    browser_alias=${TEST_USER_3.USERNAME}-session
+    Create Data Science Project    title=${PRJ_USER_B_TITLE}
+    ...    description=${PRJ_DESCRIPTION}
+    Permissions Tab Should Be Accessible
+    Components Tab Should Be Accessible
+    Set Suite Variable    ${USER_B}    ${TEST_USER_3.USERNAME}
+    Set Suite Variable    ${PRJ_USER_B_TITLE}    ${PRJ_USER_B_TITLE}
+
+Launch RHODS Dashboard Session With User C
+    ${PRJ_USER_C_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
+    Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
+    ...    password=${TEST_USER_4.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER_4.AUTH_TYPE}
+    ...    browser_alias=${TEST_USER_4.USERNAME}-session
+    Create Data Science Project    title=${PRJ_USER_C_TITLE}
+    ...    description=${PRJ_DESCRIPTION}
+    Permissions Tab Should Be Accessible
+    Components Tab Should Be Accessible
+    Set Suite Variable    ${USER_C}    ${TEST_USER_4.USERNAME}
+    Set Suite Variable    ${PRJ_USER_C_TITLE}    ${PRJ_USER_C_TITLE}
+
+Restore Permissions Of The Project
+    Switch To User    ${USER_B}
+    Move To Tab    Permissions
+    Remove ${USER_A} Permissions
+    Remove ${USER_C} Permissions
+    Switch To User    ${USER_A}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
+    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_A}
+    Switch To User    ${USER_C}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
+    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_C}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -42,6 +42,7 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     Move To Tab    Permissions
     Change ${USER_C} Permissions To Admin
     Change ${USER_A} Permissions To Edit
+    Refresh Pages
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     Switch To User    ${USER_B}
@@ -181,21 +182,8 @@ Restore Permissions Of The Project
     IF    ${present_c} == ${TRUE}
         Remove ${USER_C} Permissions        
     END
-    Switch To User    ${USER_A}
-    Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
-    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
-    Capture Page Screenshot
-    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_A}
-    Switch To User    ${USER_C}
-    Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
-    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
-    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_C}
+    ${USER_A} Should Not Have Access To ${PRJ_USER_B_TITLE}
+    ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Refresh Pages
     Switch To User    ${USER_A}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -31,14 +31,8 @@ Verify User Can Make Their Owned DS Project Accessible To Other Users    # roboc
     Move To Tab    Permissions
     Assign Edit Permissions To User ${USER_C}
     Assign Admin Permissions To User ${USER_A}
-    Switch To User    ${USER_C}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Not Be Accessible
-    Capture Page Screenshot
-    Switch To User    ${USER_A}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Be Accessible
-    Capture Page Screenshot
+    ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
+    ${USER_A} Should Have Admin Access To ${PRJ_USER_B_TITLE}
 
 Verify User Can Modify And Revoke Access To DS Projects From Other Users    # robocop: disable
     [Documentation]    Verify user can modify/remove access permissions for their DS Projects to other users
@@ -48,26 +42,11 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     Move To Tab    Permissions
     Change ${USER_C} Permissions To Admin
     Change ${USER_A} Permissions To Edit
-    Switch To User    ${USER_C}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
-    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_C}
-    Switch To User    ${USER_A}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Not Be Accessible
-    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_A}
+    ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
+    ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     Switch To User    ${USER_B}
     Remove ${USER_C} Permissions
-    Switch To User    ${USER_C}
-    Open Data Science Projects Home Page
-    Reload RHODS Dashboard Page    expected_page=Data science projects
-    ...    wait_for_cards=${FALSE}
-    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
-    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_C}
+    ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify User Can Assign Access Permissions To User Groups
     [Tags]    Tier1    Sanity
@@ -261,6 +240,7 @@ ${username} Should Have Edit Access To ${project_title}
     Wait Until Project Is Listed    project_title=${project_title}
     Open Data Science Project Details Page    ${project_title}
     Permissions Tab Should Not Be Accessible
+    # add checks on subsections
 
 ${username} Should Have Admin Access To ${project_title}
     Switch To User    ${username}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -230,7 +230,15 @@ Reload Page If Project ${project_title} Is Listed
         Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!    # robocop:disable
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data science projects
-        ...    wait_for_cards=${FALSE}        
+        ...    wait_for_cards=${FALSE}
+        ${is_listed}=    Run Keyword And Return Status
+        ...    Project Should Be Listed    project_title=${project_title}
+        IF    ${is_listed} == ${TRUE}
+            Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
+            ...    level=WARN
+            Reload RHODS Dashboard Page    expected_page=Data science projects
+            ...    wait_for_cards=${FALSE}
+        END
     END
 
 ${username} Should Have Edit Access To ${project_title}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -71,59 +71,29 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
 
 Verify User Can Assign Access Permissions To User Groups
     [Tags]    Tier1    Sanity
-    ...       ODS-XYZ
+    ...       ODS-2208
     [Setup]    Restore Permissions Of The Project
     Switch To User    ${USER_B}
     Assign Edit Permissions To Group ${USER_GROUP_1}
-    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_GROUP_1}
     Assign Admin Permissions To Group ${USER_GROUP_2}
     RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_GROUP_1}
+    
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_GROUP_2}
-
-    Switch To User    ${USER_A}
-    Open Data Science Projects Home Page
-    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
-    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Not Be Accessible
-
-    Switch To User    ${USER_C}
-    Open Data Science Projects Home Page
-    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
-    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
-
+    Sleep   5s
+    ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
+    ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     Switch To User    ${USER_B}
     Change ${USER_GROUP_1} Permissions To Admin
     Change ${USER_GROUP_2} Permissions To Edit
-
-    Switch To User    ${USER_A}
-    Open Data Science Projects Home Page
-    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
-    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
-
-    Switch To User    ${USER_C}
-    Open Data Science Projects Home Page
-    Reload Page If Project ${PRJ_USER_B_TITLE} Is Not Listed
-    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
-    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
-    Permissions Tab Should Not Be Accessible
-
+    Sleep   5s
+    ${USER_A} Should Have Admin Access To ${PRJ_USER_B_TITLE}
+    ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     Switch To User    ${USER_B}
     Remove ${USER_GROUP_2} Permissions
-
-    Switch To User    ${USER_C}
-    Open Data Science Projects Home Page
-    Reload Page If Project ${PRJ_USER_B_TITLE} Is Listed
-    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
-    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_C}
+    Sleep   5s
+    ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 
 *** Keywords ***
@@ -140,7 +110,6 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     Set User Groups For Testing
     Refresh Pages
     
-
 Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
@@ -284,3 +253,28 @@ Reload Page If Project ${project_title} Is Listed
         Reload RHODS Dashboard Page    expected_page=Data science projects
         ...    wait_for_cards=${FALSE}        
     END
+
+${username} Should Have Edit Access To ${project_title}
+    Switch To User    ${username}
+    Open Data Science Projects Home Page
+    Reload Page If Project ${project_title} Is Not Listed
+    Wait Until Project Is Listed    project_title=${project_title}
+    Open Data Science Project Details Page    ${project_title}
+    Permissions Tab Should Not Be Accessible
+
+${username} Should Have Admin Access To ${project_title}
+    Switch To User    ${username}
+    Open Data Science Projects Home Page
+    Reload Page If Project ${project_title} Is Not Listed
+    Wait Until Project Is Listed    project_title=${project_title}
+    Open Data Science Project Details Page    ${project_title}
+    Permissions Tab Should Be Accessible
+    Components Tab Should Be Accessible
+
+${username} Should Not Have Access To ${project_title}
+    Switch To User    ${username}
+    Open Data Science Projects Home Page
+    Reload Page If Project ${project_title} Is Listed
+    Project Should Not Be Listed    project_title=${project_title}
+    RoleBinding Should Not Exist    project_title=${project_title}
+    ...    subject_name=${username}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -69,6 +69,10 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_C}
 
+Verify User Can Assign Access Permissions To User Groups
+    [Setup]    Restore Permissions Of The Project
+    Switch To User    ${USER_B}
+
 
 *** Keywords ***
 Project Permissions Mgmt Suite Setup    # robocop: disable
@@ -76,12 +80,13 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
+    ${to_delete}=    Create List
+    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch RHODS Dashboard Session With User A
     Launch RHODS Dashboard Session And Create A DS Project With User B
     Launch RHODS Dashboard Session With User C
-    ${to_delete}=    Create List    ${PRJ_USER_B_TITLE}
-    ...    ${PRJ_USER_C_TITLE}
-    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
+    Set User Groups For Testing
+    
 
 Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
@@ -95,6 +100,12 @@ Project Permissions Mgmt Suite Teardown
     ...    group_name=dedicated-admins
     Add User To Group    username=${USER_A}
     ...    group_name=rhods-admins
+    Add User To Group    username=${USER_C}
+    ...    group_name=rhods-users
+    Add User To Group    username=${USER_B}
+    ...    group_name=rhods-users
+    Delete Group    ${USER_GROUP_1}
+    Delete Group    ${USER_GROUP_2}
 
 Switch To User
     [Documentation]    Move from one browser window to another. Every browser window
@@ -111,6 +122,7 @@ Launch RHODS Dashboard Session With User A
 
 Launch RHODS Dashboard Session And Create A DS Project With User B
     ${PRJ_USER_B_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+    Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_USER_B_TITLE}
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
@@ -124,6 +136,7 @@ Launch RHODS Dashboard Session And Create A DS Project With User B
 
 Launch RHODS Dashboard Session With User C
     ${PRJ_USER_C_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
+    Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_USER_C_TITLE}
     Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
     ...    password=${TEST_USER_4.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_4.AUTH_TYPE}
@@ -134,6 +147,24 @@ Launch RHODS Dashboard Session With User C
     Components Tab Should Be Accessible
     Set Suite Variable    ${USER_C}    ${TEST_USER_4.USERNAME}
     Set Suite Variable    ${PRJ_USER_C_TITLE}    ${PRJ_USER_C_TITLE}
+
+Set User Groups For Testing
+    Create Group    ${USER_GROUP_1}
+    Create Group    ${USER_GROUP_2}
+    Remove User From Group    username=${USER_A}
+    ...    group_name=dedicated-admins
+    Remove User From Group    username=${USER_A}
+    ...    group_name=rhods-admins
+    Add User To Group    username=${USER_A}
+    ...    group_name=${USER_GROUP_2}
+    Remove User From Group    username=${USER_C}
+    ...    group_name=rhods-users
+    Remove User From Group    username=${USER_B}
+    ...    group_name=rhods-users
+    Add User To Group    username=${USER_C}
+    ...    group_name=${USER_GROUP_1}
+    Add User To Group    username=${USER_B}
+    ...    group_name=${USER_GROUP_1}
 
 Restore Permissions Of The Project
     Switch To User    ${USER_B}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -46,6 +46,7 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     Switch To User    ${USER_B}
+    Move To Tab    Permissions
     Remove ${USER_C} Permissions
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -29,8 +29,8 @@ Verify User Can Make Their Owned DS Project Accessible To Other Users    # roboc
     ...       ODS-2201
     Switch To User    ${USER_B}
     Move To Tab    Permissions
-    Assign Edit Permissions To ${USER_C}
-    Assign Admin Permissions To ${USER_A}
+    Assign Edit Permissions To User ${USER_C}
+    Assign Admin Permissions To User ${USER_A}
     Switch To User    ${USER_C}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
@@ -70,12 +70,42 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     ...    subject_name=${USER_C}
 
 Verify User Can Assign Access Permissions To User Groups
-    [Tags]    Tier1    Smoke
+    [Tags]    Tier1    Sanity
     ...       ODS-XYZ
     [Setup]    Restore Permissions Of The Project
     Switch To User    ${USER_B}
     Assign Edit Permissions To Group ${USER_GROUP_1}
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_GROUP_1}
     Assign Admin Permissions To Group ${USER_GROUP_2}
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_GROUP_2}
+    Switch To User    ${USER_A}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
+    Permissions Tab Should Not Be Accessible
+    Switch To User    ${USER_C}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
+    Permissions Tab Should Be Accessible
+    Components Tab Should Be Accessible
+    Switch To User    ${USER_B}
+    Change ${USER_GROUP_1} Permissions To Admin
+    Change ${USER_GROUP_2} Permissions To Edit
+    Switch To User    ${USER_A}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
+    Permissions Tab Should Be Accessible
+    Components Tab Should Be Accessible
+    Switch To User    ${USER_C}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
+    Permissions Tab Should Not Be Accessible
+    Switch To User    ${USER_B}
+    Remove ${USER_GROUP_2} Permissions
+    Switch To User    ${USER_C}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
+    RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_C}
 
 
 *** Keywords ***
@@ -113,9 +143,12 @@ Project Permissions Mgmt Suite Teardown
 
 Switch To User
     [Documentation]    Move from one browser window to another. Every browser window
-    ...    is a user login session in RHODS Dashboard
-    [Arguments]    ${username}
+    ...    is a user login session in RHODS Dashboard.
+    ...    The variable ${is_cluster_admin} is used to enable UI flows which require
+    ...    a user with cluster-admin or dedicated-admin level of privileges.
+    [Arguments]    ${username}    ${is_cluster_admin}=${FALSE}
     Switch Browser    ${username}-session
+    Set Suite Variable    ${IS_CLUSTER_ADMIN}    ${is_cluster_admin}
 
 Launch RHODS Dashboard Session With User A
     Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}  ocp_user_pw=${TEST_USER_2.PASSWORD}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -70,8 +70,12 @@ Verify User Can Modify And Revoke Access To DS Projects From Other Users    # ro
     ...    subject_name=${USER_C}
 
 Verify User Can Assign Access Permissions To User Groups
+    [Tags]    Tier1    Smoke
+    ...       ODS-XYZ
     [Setup]    Restore Permissions Of The Project
     Switch To User    ${USER_B}
+    Assign Edit Permissions To Group ${USER_GROUP_1}
+    Assign Admin Permissions To Group ${USER_GROUP_2}
 
 
 *** Keywords ***
@@ -155,22 +159,28 @@ Set User Groups For Testing
     ...    group_name=dedicated-admins
     Remove User From Group    username=${USER_A}
     ...    group_name=rhods-admins
-    Add User To Group    username=${USER_A}
-    ...    group_name=${USER_GROUP_2}
     Remove User From Group    username=${USER_C}
     ...    group_name=rhods-users
     Remove User From Group    username=${USER_B}
     ...    group_name=rhods-users
-    Add User To Group    username=${USER_C}
+    Add User To Group    username=${USER_A}
     ...    group_name=${USER_GROUP_1}
+    Add User To Group    username=${USER_C}
+    ...    group_name=${USER_GROUP_2}
     Add User To Group    username=${USER_B}
     ...    group_name=${USER_GROUP_1}
 
 Restore Permissions Of The Project
     Switch To User    ${USER_B}
     Move To Tab    Permissions
-    Remove ${USER_A} Permissions
-    Remove ${USER_C} Permissions
+    ${present_a}=    Is ${USER_A} In The Permissions Table
+    IF    ${present_a} == ${TRUE}
+        Remove ${USER_A} Permissions        
+    END
+    ${present_c}=    Is ${USER_C} In The Permissions Table
+    IF    ${present_c} == ${TRUE}
+        Remove ${USER_C} Permissions        
+    END
     Switch To User    ${USER_A}
     Open Data Science Projects Home Page
     Reload RHODS Dashboard Page    expected_page=Data science projects

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -80,25 +80,49 @@ Verify User Can Assign Access Permissions To User Groups
     Assign Admin Permissions To Group ${USER_GROUP_2}
     RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_GROUP_2}
+
     Switch To User    ${USER_A}
+    Capture Page Screenshot
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
+
     Switch To User    ${USER_C}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
     Components Tab Should Be Accessible
+
     Switch To User    ${USER_B}
     Change ${USER_GROUP_1} Permissions To Admin
     Change ${USER_GROUP_2} Permissions To Edit
+
     Switch To User    ${USER_A}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Be Accessible
     Components Tab Should Be Accessible
+
     Switch To User    ${USER_C}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
     Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
     Permissions Tab Should Not Be Accessible
+
     Switch To User    ${USER_B}
     Remove ${USER_GROUP_2} Permissions
+
     Switch To User    ${USER_C}
     Open Data Science Projects Home Page
     Reload RHODS Dashboard Page    expected_page=Data science projects
@@ -120,6 +144,7 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     Launch RHODS Dashboard Session And Create A DS Project With User B
     Launch RHODS Dashboard Session With User C
     Set User Groups For Testing
+    Refresh Pages
     
 
 Project Permissions Mgmt Suite Teardown
@@ -219,6 +244,7 @@ Restore Permissions Of The Project
     Reload RHODS Dashboard Page    expected_page=Data science projects
     ...    wait_for_cards=${FALSE}
     Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
+    Capture Page Screenshot
     RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_A}
     Switch To User    ${USER_C}
@@ -228,3 +254,19 @@ Restore Permissions Of The Project
     Project Should Not Be Listed    project_title=${PRJ_USER_B_TITLE}
     RoleBinding Should Not Exist    project_title=${PRJ_USER_B_TITLE}
     ...    subject_name=${USER_C}
+
+Refresh Pages
+    Switch To User    ${USER_A}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Switch To User    ${USER_B}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}
+    Wait Until Project Is Listed    project_title=${PRJ_USER_B_TITLE}
+    Open Data Science Project Details Page    ${PRJ_USER_B_TITLE}
+    Switch To User    ${USER_C}
+    Open Data Science Projects Home Page
+    Reload RHODS Dashboard Page    expected_page=Data science projects
+    ...    wait_for_cards=${FALSE}


### PR DESCRIPTION
this PR is adding a new basic test for Project Sharing feature: [ODS-2208](https://polarion.engineering.redhat.com/polarion/#/project/OpenDataHub/workitem?id=ODS-2208) (i.e., sharing DS project access to groups instead of users

Moreover, it refactors the already present test cases in the suite to make them shorter and more user-friendly.

NOTE: especially ODS-2208 is sometimes failing because of the apparently unstable refresh of the dashboard. Although, I've added the page reload and some waits it keeps failing. I think there's not more value for me trying to workaround how to dashboard refreshes now given other priorities (pipeline UI automation). In 1.28 the situation may be improved, if not I will dig more into the question.

UPDATE: after adding a second conditional page reload, it seems more stable