### PR TITLE
Add first test and keywords for pipeline creation and execution via UI

### DIFF
--- a/ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
@@ -1,0 +1,544 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: iris-pipeline
+  annotations:
+    tekton.dev/output_artifacts: '{"data-prep": [{"key": "artifacts/$PIPELINERUN/data-prep/X_test.tgz",
+      "name": "data-prep-X_test", "path": "/tmp/outputs/X_test/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/X_train.tgz",
+      "name": "data-prep-X_train", "path": "/tmp/outputs/X_train/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/y_test.tgz",
+      "name": "data-prep-y_test", "path": "/tmp/outputs/y_test/data"}, {"key": "artifacts/$PIPELINERUN/data-prep/y_train.tgz",
+      "name": "data-prep-y_train", "path": "/tmp/outputs/y_train/data"}], "evaluate-model":
+      [{"key": "artifacts/$PIPELINERUN/evaluate-model/mlpipeline-metrics.tgz", "name":
+      "mlpipeline-metrics", "path": "/tmp/outputs/mlpipeline_metrics/data"}], "train-model":
+      [{"key": "artifacts/$PIPELINERUN/train-model/model.tgz", "name": "train-model-model",
+      "path": "/tmp/outputs/model/data"}]}'
+    tekton.dev/input_artifacts: '{"evaluate-model": [{"name": "data-prep-X_test",
+      "parent_task": "data-prep"}, {"name": "data-prep-y_test", "parent_task": "data-prep"},
+      {"name": "train-model-model", "parent_task": "train-model"}], "train-model":
+      [{"name": "data-prep-X_train", "parent_task": "data-prep"}, {"name": "data-prep-y_train",
+      "parent_task": "data-prep"}], "validate-model": [{"name": "train-model-model",
+      "parent_task": "train-model"}]}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"data-prep": [["X_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test"],
+      ["X_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train"],
+      ["y_test", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test"],
+      ["y_train", "$(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train"]],
+      "evaluate-model": [["mlpipeline-metrics", "/tmp/outputs/mlpipeline_metrics/data"]],
+      "train-model": [["model", "$(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model"]],
+      "validate-model": []}'
+    sidecar.istio.io/inject: "false"
+    tekton.dev/template: ''
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"inputs": [{"default": "iris-model", "name":
+      "model_obc", "optional": true, "type": "String"}], "name": "Iris Pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
+spec:
+  params:
+  - name: model_obc
+    value: iris-model
+  pipelineSpec:
+    params:
+    - name: model_obc
+      default: iris-model
+    tasks:
+    - name: data-prep
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --X-train
+          - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train
+          - --X-test
+          - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test
+          - --y-train
+          - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train
+          - --y-test
+          - $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test
+          command:
+          - sh
+          - -c
+          - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+            'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+            pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+            --user) && "$0" "$@"
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def _make_parent_dirs_and_return_path(file_path: str):
+                import os
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                return file_path
+
+            def data_prep(
+                X_train_file,
+                X_test_file,
+                y_train_file,
+                y_test_file,
+            ):
+                import pickle
+
+                import pandas as pd
+
+                from sklearn import datasets
+                from sklearn.model_selection import train_test_split
+
+                def get_iris_data():
+                    iris = datasets.load_iris()
+                    data = pd.DataFrame(
+                        {
+                            "sepalLength": iris.data[:, 0],
+                            "sepalWidth": iris.data[:, 1],
+                            "petalLength": iris.data[:, 2],
+                            "petalWidth": iris.data[:, 3],
+                            "species": iris.target,
+                        }
+                    )
+
+                    print("Initial Dataset:")
+                    print(data.head())
+
+                    return data
+
+                def create_training_set(dataset, test_size = 0.3):
+                    # Features
+                    X = dataset[["sepalLength", "sepalWidth", "petalLength", "petalWidth"]]
+                    # Labels
+                    y = dataset["species"]
+
+                    # Split dataset into training set and test set
+                    X_train, X_test, y_train, y_test = train_test_split(
+                        X, y, test_size=test_size, random_state=11
+                    )
+
+                    return X_train, X_test, y_train, y_test
+
+                def save_pickle(object_file, target_object):
+                    with open(object_file, "wb") as f:
+                        pickle.dump(target_object, f)
+
+                dataset = get_iris_data()
+                X_train, X_test, y_train, y_test = create_training_set(dataset)
+
+                save_pickle(X_train_file, X_train)
+                save_pickle(X_test_file, X_test)
+                save_pickle(y_train_file, y_train)
+                save_pickle(y_test_file, y_test)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Data prep', description='')
+            _parser.add_argument("--X-train", dest="X_train_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--X-test", dest="X_test_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--y-train", dest="y_train_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--y-test", dest="y_test_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = data_prep(**_parsed_args)
+          image: registry.access.redhat.com/ubi8/python-38
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        - image: registry.access.redhat.com/ubi8/ubi-minimal
+          name: output-taskrun-name
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
+        - image: registry.access.redhat.com/ubi8/ubi-minimal
+          name: copy-results-artifacts
+          command:
+          - sh
+          - -ec
+          - |
+            set -exo pipefail
+            TOTAL_SIZE=0
+            copy_artifact() {
+            if [ -d "$1" ]; then
+              tar -czvf "$1".tar.gz "$1"
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c "$1"${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch "$2"
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d "$1" ]; then
+                tar -tzf "$1".tar.gz > "$2"
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" "$1"; then
+                cp "$1" "$2"
+              fi
+            fi
+            }
+            copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_train $(results.X-train.path)
+            copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/X_test $(results.X-test.path)
+            copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_train $(results.y-train.path)
+            copy_artifact $(workspaces.data-prep.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/y_test $(results.y-test.path)
+          onError: continue
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        results:
+        - name: X-test
+          description: /tmp/outputs/X_test/data
+        - name: X-train
+          description: /tmp/outputs/X_train/data
+        - name: taskrun-name
+        - name: y-test
+          description: /tmp/outputs/y_test/data
+        - name: y-train
+          description: /tmp/outputs/y_train/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Data prep", "outputs":
+              [{"name": "X_train"}, {"name": "X_test"}, {"name": "y_train"}, {"name":
+              "y_test"}], "version": "Data prep@sha256=5aeb512900f57983c9f643ec30ddb4ccc66490a443269b51ce0a67d57cb373b0"}'
+        workspaces:
+        - name: data-prep
+      workspaces:
+      - name: data-prep
+        workspace: iris-pipeline
+    - name: train-model
+      params:
+      - name: data-prep-trname
+        value: $(tasks.data-prep.results.taskrun-name)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --X-train
+          - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/X_train
+          - --y-train
+          - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/y_train
+          - --model
+          - $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model
+          command:
+          - sh
+          - -c
+          - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+            'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+            pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+            --user) && "$0" "$@"
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def _make_parent_dirs_and_return_path(file_path: str):
+                import os
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                return file_path
+
+            def train_model(
+                X_train_file,
+                y_train_file,
+                model_file,
+            ):
+                import pickle
+
+                from sklearn.ensemble import RandomForestClassifier
+
+                def load_pickle(object_file):
+                    with open(object_file, "rb") as f:
+                        target_object = pickle.load(f)
+
+                    return target_object
+
+                def save_pickle(object_file, target_object):
+                    with open(object_file, "wb") as f:
+                        pickle.dump(target_object, f)
+
+                def train_iris(X_train, y_train):
+                    model = RandomForestClassifier(n_estimators=100)
+                    model.fit(X_train, y_train)
+
+                    return model
+
+                X_train = load_pickle(X_train_file)
+                y_train = load_pickle(y_train_file)
+
+                model = train_iris(X_train, y_train)
+
+                save_pickle(model_file, model)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Train model', description='')
+            _parser.add_argument("--X-train", dest="X_train_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--y-train", dest="y_train_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--model", dest="model_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = train_model(**_parsed_args)
+          image: registry.access.redhat.com/ubi8/python-38
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        - image: registry.access.redhat.com/ubi8/ubi-minimal
+          name: output-taskrun-name
+          command:
+          - sh
+          - -ec
+          - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
+        - image: registry.access.redhat.com/ubi8/ubi-minimal
+          name: copy-results-artifacts
+          command:
+          - sh
+          - -ec
+          - |
+            set -exo pipefail
+            TOTAL_SIZE=0
+            copy_artifact() {
+            if [ -d "$1" ]; then
+              tar -czvf "$1".tar.gz "$1"
+              SUFFIX=".tar.gz"
+            fi
+            ARTIFACT_SIZE=`wc -c "$1"${SUFFIX} | awk '{print $1}'`
+            TOTAL_SIZE=$( expr $TOTAL_SIZE + $ARTIFACT_SIZE)
+            touch "$2"
+            if [[ $TOTAL_SIZE -lt 3072 ]]; then
+              if [ -d "$1" ]; then
+                tar -tzf "$1".tar.gz > "$2"
+              elif ! awk "/[^[:print:]]/{f=1} END{exit !f}" "$1"; then
+                cp "$1" "$2"
+              fi
+            fi
+            }
+            copy_artifact $(workspaces.train-model.path)/artifacts/$ORIG_PR_NAME/$(context.taskRun.name)/model $(results.model.path)
+          onError: continue
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        params:
+        - name: data-prep-trname
+        results:
+        - name: model
+          description: /tmp/outputs/model/data
+        - name: taskrun-name
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Train model",
+              "outputs": [{"name": "model"}], "version": "Train model@sha256=cb1fbd399ee5849dcdfaafced23a0496cae1d5861795062b22512b766ec418ce"}'
+        workspaces:
+        - name: train-model
+      workspaces:
+      - name: train-model
+        workspace: iris-pipeline
+      runAfter:
+      - data-prep
+      - data-prep
+    - name: evaluate-model
+      params:
+      - name: data-prep-trname
+        value: $(tasks.data-prep.results.taskrun-name)
+      - name: train-model-trname
+        value: $(tasks.train-model.results.taskrun-name)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --X-test
+          - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/X_test
+          - --y-test
+          - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.data-prep-trname)/y_test
+          - --model
+          - $(workspaces.evaluate-model.path)/artifacts/$ORIG_PR_NAME/$(params.train-model-trname)/model
+          - --mlpipeline-metrics
+          - /tmp/outputs/mlpipeline_metrics/data
+          command:
+          - sh
+          - -c
+          - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+            'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+            pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+            --user) && "$0" "$@"
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def _make_parent_dirs_and_return_path(file_path: str):
+                import os
+                os.makedirs(os.path.dirname(file_path), exist_ok=True)
+                return file_path
+
+            def evaluate_model(
+                X_test_file,
+                y_test_file,
+                model_file,
+                mlpipeline_metrics_file,
+            ):
+                import json
+                import pickle
+
+                from sklearn.metrics import accuracy_score
+
+                def load_pickle(object_file):
+                    with open(object_file, "rb") as f:
+                        target_object = pickle.load(f)
+
+                    return target_object
+
+                X_test = load_pickle(X_test_file)
+                y_test = load_pickle(y_test_file)
+                model = load_pickle(model_file)
+
+                y_pred = model.predict(X_test)
+
+                accuracy_score_metric = accuracy_score(y_test, y_pred)
+                print(f"Accuracy: {accuracy_score_metric}")
+
+                metrics = {
+                    "metrics": [
+                        {
+                            "name": "accuracy-score",
+                            "numberValue": accuracy_score_metric,
+                            "format": "PERCENTAGE",
+                        },
+                    ]
+                }
+
+                with open(mlpipeline_metrics_file, "w") as f:
+                    json.dump(metrics, f)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Evaluate model', description='')
+            _parser.add_argument("--X-test", dest="X_test_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--y-test", dest="y_test_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--model", dest="model_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("--mlpipeline-metrics", dest="mlpipeline_metrics_file", type=_make_parent_dirs_and_return_path, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = evaluate_model(**_parsed_args)
+          image: registry.access.redhat.com/ubi8/python-38
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        params:
+        - name: data-prep-trname
+        - name: train-model-trname
+        stepTemplate:
+          volumeMounts:
+          - name: mlpipeline-metrics
+            mountPath: /tmp/outputs/mlpipeline_metrics
+        volumes:
+        - name: mlpipeline-metrics
+          emptyDir: {}
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Evaluate model",
+              "outputs": [{"name": "mlpipeline_metrics", "type": "Metrics"}], "version":
+              "Evaluate model@sha256=f398e65faecc6f5a4ba11a2c78d8a2274e3ede205a0e199c8bb615531a3abd4a"}'
+        workspaces:
+        - name: evaluate-model
+      workspaces:
+      - name: evaluate-model
+        workspace: iris-pipeline
+      runAfter:
+      - data-prep
+      - data-prep
+      - train-model
+    - name: validate-model
+      params:
+      - name: train-model-trname
+        value: $(tasks.train-model.results.taskrun-name)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --model
+          - $(workspaces.validate-model.path)/artifacts/$ORIG_PR_NAME/$(params.train-model-trname)/model
+          command:
+          - sh
+          - -c
+          - (PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m pip install --quiet --no-warn-script-location
+            'pandas' 'scikit-learn' || PIP_DISABLE_PIP_VERSION_CHECK=1 python3 -m
+            pip install --quiet --no-warn-script-location 'pandas' 'scikit-learn'
+            --user) && "$0" "$@"
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def validate_model(model_file):
+                import pickle
+
+                def load_pickle(object_file):
+                    with open(object_file, "rb") as f:
+                        target_object = pickle.load(f)
+
+                    return target_object
+
+                model = load_pickle(model_file)
+
+                input_values = [[5, 3, 1.6, 0.2]]
+
+                print(f"Performing test prediction on {input_values}")
+                result = model.predict(input_values)
+
+                print(f"Response: {result}")
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Validate model', description='')
+            _parser.add_argument("--model", dest="model_file", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = validate_model(**_parsed_args)
+          image: registry.access.redhat.com/ubi8/python-38
+          env:
+          - name: ORIG_PR_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
+        params:
+        - name: train-model-trname
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Validate model",
+              "outputs": [], "version": "Validate model@sha256=53d18ff94fc8f164e7d8455f2c87fa7fdac17e7502502aaa52012e4247d089ee"}'
+        workspaces:
+        - name: validate-model
+      workspaces:
+      - name: validate-model
+        workspace: iris-pipeline
+      runAfter:
+      - train-model
+    workspaces:
+    - name: iris-pipeline
+  workspaces:
+  - name: iris-pipeline
+    volumeClaimTemplate:
+      spec:
+        accessModes:
+        - ReadWriteOnce
+        resources:
+          requests:
+            storage: 2Gi

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
@@ -11,6 +11,7 @@ Library     ../../../../../libs/Helpers.py
 Verify Deployment
     [Documentation]     verifies the status of a Deployment in Openshift
     [Arguments]  ${component}  ${nPods}  ${nContainers}  ${containerNames}
+    ...          ${podStatuses}=${NONE}  ${containerStatuses}=${NONE}
     #No. of replicas
     Length Should Be  ${component}  ${nPods}
 
@@ -21,9 +22,17 @@ Verify Deployment
         @{names} =  Create List
         FOR  ${j}  IN RANGE  0  ${nContainers}
             Append To List  ${names}  ${pod.status.containerStatuses[${j}].name}
-            Should Be Equal As Strings  ${pod.status.phase}  Running
             ${state} =  Get Dictionary Keys  ${pod.status.containerStatuses[${j}].state}
-            Should Be Equal As Strings  ${state}[0]  running
+            IF    "${podStatuses}" == ${NONE}
+                Should Be Equal As Strings  ${pod.status.phase}  Running
+            ELSE
+                Should Be Equal As Strings  ${pod.status.phase}  ${podStatuses[${index}]}
+            END
+            IF    "${containerStatuses}" == ${NONE}
+                Should Be Equal As Strings  ${state}[0]  running
+            ELSE
+                Should Be Equal As Strings  ${state}[0]  ${containerStatuses[${j}]}
+            END 
         END
         Sort List  ${names}
         Sort List  ${containerNames}

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
@@ -32,7 +32,7 @@ Verify Deployment
                 Should Be Equal As Strings  ${state}[0]  running
             ELSE
                 Should Be Equal As Strings  ${state}[0]  ${containerStatuses[${j}]}
-            END 
+            END
         END
         Sort List  ${names}
         Sort List  ${containerNames}

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/HighAvailability.robot
@@ -23,12 +23,12 @@ Verify Deployment
         FOR  ${j}  IN RANGE  0  ${nContainers}
             Append To List  ${names}  ${pod.status.containerStatuses[${j}].name}
             ${state} =  Get Dictionary Keys  ${pod.status.containerStatuses[${j}].state}
-            IF    "${podStatuses}" == ${NONE}
+            IF    "${podStatuses}" == "${NONE}"
                 Should Be Equal As Strings  ${pod.status.phase}  Running
             ELSE
                 Should Be Equal As Strings  ${pod.status.phase}  ${podStatuses[${index}]}
             END
-            IF    "${containerStatuses}" == ${NONE}
+            IF    "${containerStatuses}" == "${NONE}"
                 Should Be Equal As Strings  ${state}[0]  running
             ELSE
                 Should Be Equal As Strings  ${state}[0]  ${containerStatuses[${j}]}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -69,4 +69,8 @@ Select Pipeline For The Run
     Wait Until Page Contains Element    xpath://ul/li/a[text()="${pipeline_name}"]
     Click Element     xpath://ul/li/a[text()="${pipeline_name}"]
 
-    
+Get Workflow Name From Topology Page
+    [Documentation]    Returns the workflow name corresponding to the displayed pipeline.
+    ...                The workflow name can be used to retrieve pods, for example
+    ${workflow_name}=    Get Text    xpath://div/div[text()="Workflow name"]/following-sibling::div
+    RETURN    ${workflow_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -37,17 +37,17 @@ Fill In Pipeline Import Form
     Choose File    //div[@class="pf-c-file-upload"]//input[@type="file"]    ${pwd}/${filepath}
     Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
 
-Fill In Run Creation Form
+Fill In Run Creation Form    # robocop: disable
     [Documentation]    Compiles the form to create a pipeline run.
     ...                It works when you start server creation from either
     ...                DS Project details page or DS Pipelines page.
-    [Arguments]    ${name}    ${pipeline_name}    ${from_actions}=${TRUE}    ${run_type}=Immediate    ${trigger_type}=Periodic
-    ...            ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
-    ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}&{model_param}
+    [Arguments]    ${name}    ${pipeline_name}    ${from_actions}=${TRUE}    ${run_type}=Immediate
+    ...            ${trigger_type}=Periodic    ${start_date}=${NONE}    ${start_time}=${NONE}
+    ...            ${end_date}=${NONE}    ${end_time}=${NONE}    ${cron_expr}=${NONE}&{model_param}
     Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
     Input Text    ${PIPELINE_DESC_INPUT_XP}    ${name}
     Run Keyword And Continue On Failure
-    ...    Element Should Be Disabled    ${GENERIC_CREATE_BTN_XP}  
+    ...    Element Should Be Disabled    ${GENERIC_CREATE_BTN_XP} 
     Select Pipeline For The Run    pipeline_name=${pipeline_name}
     Element Should Be Enabled    ${GENERIC_CREATE_BTN_XP}
     # select run_type

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -47,7 +47,7 @@ Fill In Run Creation Form    # robocop: disable
     Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
     Input Text    ${PIPELINE_DESC_INPUT_XP}    ${name}
     Run Keyword And Continue On Failure
-    ...    Element Should Be Disabled    ${GENERIC_CREATE_BTN_XP} 
+    ...    Element Should Be Disabled    ${GENERIC_CREATE_BTN_XP}
     Select Pipeline For The Run    pipeline_name=${pipeline_name}
     Element Should Be Enabled    ${GENERIC_CREATE_BTN_XP}
     # select run_type

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -25,19 +25,48 @@ Install DataSciencePipelinesApplication CR
     Should Be True    ${generation_value} == 1    DataSciencePipelinesApplication created
 
 Fill In Pipeline Import Form
-    [Documentation]    Compiles the form to create a pipeline server.
+    [Documentation]    Compiles the form to create a pipeline.
     ...                It works when you start server creation from either
     ...                DS Project details page or DS Pipelines page.
     [Arguments]    ${name}    ${filepath}    ${project_title}
-    ...            ${description}=${NONE}    ${press_cancel}=${FALSE}
+    ...            ${description}=${NONE}
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
     Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
     Input Text    ${PIPELINE_DESC_INPUT_XP}    ${description}
     ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
     Choose File    //div[@class="pf-c-file-upload"]//input[@type="file"]    ${pwd}/${filepath}
     Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    IF    ${press_cancel} == ${TRUE}
-        Click Button    ${GENERIC_CANCEL_BTN_XP}
-    ELSE
-        Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    END
+
+Fill In Run Creation Form
+    [Documentation]    Compiles the form to create a pipeline run.
+    ...                It works when you start server creation from either
+    ...                DS Project details page or DS Pipelines page.
+    [Arguments]    ${name}    ${pipeline_name}    ${from_actions}=${TRUE}    ${run_type}=Immediate    ${trigger_type}=Periodic
+    ...            ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
+    ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}&{model_param}
+    Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
+    Input Text    ${PIPELINE_DESC_INPUT_XP}    ${name}
+    Run Keyword And Continue On Failure
+    ...    Element Should Be Disabled    ${GENERIC_CREATE_BTN_XP}  
+    Select Pipeline For The Run    pipeline_name=${pipeline_name}
+    Element Should Be Enabled    ${GENERIC_CREATE_BTN_XP}
+    # select run_type
+    # set options based on run_type
+    # change model param if required
+    # check selected project
+    # insert name
+    # insert description
+    # select pipeline
+    # select run type
+    # insert additional params based on run type
+    # insert additinal params based on the model
+
+Select Pipeline For The Run
+    [Documentation]    Selects the given ${pipeline_name} from the pipeline
+    ...                dropdown in the Run creation form.
+    [Arguments]    ${pipeline_name}
+    Click Element    xpath://section[@id="run-section-pipeline"]//span[text()="Select a pipeline"]/..
+    Wait Until Page Contains Element    xpath://ul/li/a[text()="${pipeline_name}"]
+    Click Element     xpath://ul/li/a[text()="${pipeline_name}"]
+
+    

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -10,6 +10,9 @@ Library             ../../../../../libs/DataSciencePipelinesAPI.py
 
 *** Variables ***
 ${DATA_SCIENCE_PIPELINES_APPLICATION_YAML}=    ods_ci/tests/Resources/Files/data-science-pipelines-sample.yaml
+${PIPELINES_IMPORT_BTN_FORM_XP}=    xpath://footer/button[text()="Import pipeline"]
+${PIPELINE_NAME_INPUT_XP}=    id:pipeline-name
+${PIPELINE_DESC_INPUT_XP}=    id:pipeline-description
 
 
 *** Keywords ***
@@ -20,3 +23,21 @@ Install DataSciencePipelinesApplication CR
     Oc Apply    kind=DataSciencePipelinesApplication    src=${DATA_SCIENCE_PIPELINES_APPLICATION_YAML}     namespace=${project}    # robocop: disable:line-too-long
     ${generation_value}    Run    oc get datasciencepipelinesapplications -n ${project} -o json | jq '.items[0].metadata.generation'    # robocop: disable:line-too-long
     Should Be True    ${generation_value} == 1    DataSciencePipelinesApplication created
+
+Fill In Pipeline Import Form
+    [Documentation]    Compiles the form to create a pipeline server.
+    ...                It works when you start server creation from either
+    ...                DS Project details page or DS Pipelines page.
+    [Arguments]    ${name}    ${filepath}    ${project_title}
+    ...            ${description}=${NONE}    ${press_cancel}=${FALSE}
+    Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
+    Input Text    ${PIPELINE_DESC_INPUT_XP}    ${description}
+    ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
+    Choose File    //div[@class="pf-c-file-upload"]//input[@type="file"]    ${pwd}/${filepath}
+    Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    IF    ${press_cancel} == ${TRUE}
+        Click Button    ${GENERIC_CANCEL_BTN_XP}
+    ELSE
+        Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -59,4 +59,6 @@ Verify Pipeline Server Deployments
     ...    label_selector=app=mariadb-pipelines-definition
     ${containerNames} =  Create List  mariadb
     Verify Deployment    ${db}  1  1  ${containerNames}
-
+    
+    @{all_pods} =  Oc Get    kind=Pod    namespace=${namespace}
+    Run Keyword And Continue On Failure    Length Should Be    ${all_pods}    4

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -47,7 +47,7 @@ Import Pipeline
     Click Button    ${PIPELINES_IMPORT_BTN_XP}
     Wait Until Generic Modal Appears
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    Fill In Pipeline Import Form    ${name}    ${filepath}    ${project_title}    ${description}    ${press_cancel}
+    Fill In Pipeline Import Form    ${name}    ${filepath}    ${project_title}    ${description}
     IF    ${press_cancel} == ${TRUE}
         Click Button    ${GENERIC_CANCEL_BTN_XP}
     ELSE

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -10,6 +10,9 @@ ${PIPELINES_SERVER_BTN_XP}=    xpath://button[text()="Create a pipeline server"]
 ${PIPELINES_SERVER_CONFIG_BTN_XP}=    xpath://button[text()="Configure"]
 ${PIPELINES_IMPORT_BTN_XP}=    xpath://button[text()="Import pipeline"]
 ${CREATE_RUN_BTN_XP}=    xpath://*[text()="Create run"]
+${RUN_TOPOLOGY_DETAILS_BTN_XP}=    xpath://li//button[text()="Details"]
+${RUN_TOPOLOGY_OUTPUT_BTN_XP}=    xpath://li//button[text()="Run output"]
+${RUN_TOPOLOGY_XP}=    css:div[data-test-id="topology"]
 
 
 *** Keywords ***
@@ -80,11 +83,13 @@ Create Pipeline Run
         Click Button    ${GENERIC_CANCEL_BTN_XP}
         Wait for RHODS Dashboard to Load    expected_page=Pipelines
         ...    wait_for_cards=${FALSE}
+        ${workflow_name}=    Set Variable    ${NONE}
     ELSE
         Click Element    ${GENERIC_CREATE_BTN_XP}
-        Wait for RHODS Dashboard to Load    expected_page=${name}
-        ...    wait_for_cards=${FALSE}
+        Wait Until Page Contains Run Topology Page    run_name=${name}
+        ${workflow_name}=    Get Workflow Name From Topology Page    
     END
+    RETURN    ${workflow_name}
 
 Click Action From Actions Menu
     [Documentation]    Click an action from Actions menu (3-dots menu on the right)
@@ -150,7 +155,14 @@ Wait Until Pipeline Last Run Is Finished
     [Documentation]
     [Arguments]    ${pipeline_name}    ${timeout}=60s
     ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
-    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}//td/a//span[text()="Running"]
+    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}//td/div[text()="Running"]
+    ...    timeout=${timeout}
+
+Wait Until Pipeline Last Run Is Started
+    [Documentation]
+    [Arguments]    ${pipeline_name}    ${timeout}=60s
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    Wait Until Page Contains Element    ${pipeline_row_xp}//td/div[text()="Running"]
     ...    timeout=${timeout}
 
 Show Pipeline Runs Section
@@ -161,8 +173,19 @@ Show Pipeline Runs Section
     ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
     Click Element    ${pipeline_row_xp}//td[@class="pf-c-table__toggle"]/button
 
+Wait Until Page Contains Run Topology Page
+    [Arguments]    ${run_name}
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element
+    ...    xpath://h1//div[text()="${run_name}"]    timeout=10s
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element
+    ...    ${RUN_TOPOLOGY_DETAILS_BTN_XP}
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element
+    ...    ${RUN_TOPOLOGY_OUTPUT_BTN_XP}
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element
+    ...    ${RUN_TOPOLOGY_XP}
+
 Verify Pipeline Server Deployments
-    [Documentation]    Verifies the correct deployment of modelmesh in the rhods namespace
+    [Documentation]    Verifies the correct deployment of DS Pipelines in the rhods namespace
     [Arguments]    ${project_title}
     ${namespace}=    Get Openshift Namespace From Data Science Project
     ...    project_title=${project_title}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation    Collection of keywords to interact with DS Pipelines
 Resource       Projects.resource
+Resource       ../ODHDataSciencePipelines.resource
 
 
 *** Variables ***
@@ -8,9 +9,7 @@ ${PIPELINES_SECTION_XP}=    xpath://div[@id="pipelines-projects"]
 ${PIPELINES_SERVER_BTN_XP}=    xpath://button[text()="Create a pipeline server"]
 ${PIPELINES_SERVER_CONFIG_BTN_XP}=    xpath://button[text()="Configure"]
 ${PIPELINES_IMPORT_BTN_XP}=    xpath://button[text()="Import pipeline"]
-${PIPELINES_IMPORT_BTN_FORM_XP}=    xpath://footer/button[text()="Import pipeline"]
-${PIPELINE_NAME_INPUT_XP}=    id:pipeline-name
-${PIPELINE_DESC_INPUT_XP}=    id:pipeline-description
+
 
 
 *** Keywords ***
@@ -26,7 +25,6 @@ Create Pipeline server
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_SERVER_CONFIG_BTN_XP}
     Select Data Connection    dc_name=${dc_name}
     Element Should Be Enabled    ${PIPELINES_SERVER_CONFIG_BTN_XP}
-    # Sleep    10s    Waiting to give time the dc secret to be fully ready
     Click Element    ${PIPELINES_SERVER_CONFIG_BTN_XP}
     Wait Until Generic Modal Disappears
 
@@ -46,18 +44,28 @@ Import Pipeline
     Click Button    ${PIPELINES_IMPORT_BTN_XP}
     Wait Until Generic Modal Appears
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
-    Input Text    ${PIPELINE_DESC_INPUT_XP}    ${description}
-    ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
-    Choose File    //div[@class="pf-c-file-upload"]//input[@type="file"]    ${pwd}/${filepath}
-    Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    IF    ${press_cancel} == ${TRUE}
-        Click Button    ${GENERIC_CANCEL_BTN_XP}
-    ELSE
-        Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
-    END
+    Fill In Pipeline Import Form    ${name}    ${filepath}    ${project_title}    ${description}    ${press_cancel}
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
+
+Create Pipeline Run
+    [Documentation]    Create a pipeline run from DS Project details page.
+    ...                Note that the ${type} arguments can accept:
+    ...                - immediate
+    ...                - schedule -> this requires to insert additional arguments
+    ...                TEMPORARILY SUPPORTING ONLY IMMEDIATE RUNS AND DEFAULT MODEL PARAMS
+    [Arguments]    ${name}    ${pipeline_name}    ${run_type}=Immediate    ${trigger_type}=Periodic
+    ...            ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
+    ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}    &{model_param}
+    Log    working in progress...
+    # check selected project
+    # insert name
+    # insert description
+    # select pipeline
+    # select run type
+    # insert additional params based on run type
+    # insert additinal params based on the model
+    
 
 Pipeline Should Be Listed
     [Documentation]    Checks a pipeline is listed in the DS Project details page
@@ -74,7 +82,6 @@ Pipeline Should Be Listed
         ...    Wait Until Page Contains Element
         ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
     END
-
 
 Pipeline Should Not Be Listed
     [Documentation]    Checks a pipeline is not listed in the DS Project details page

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -9,7 +9,7 @@ ${PIPELINES_SECTION_XP}=    xpath://div[@id="pipelines-projects"]
 ${PIPELINES_SERVER_BTN_XP}=    xpath://button[text()="Create a pipeline server"]
 ${PIPELINES_SERVER_CONFIG_BTN_XP}=    xpath://button[text()="Configure"]
 ${PIPELINES_IMPORT_BTN_XP}=    xpath://button[text()="Import pipeline"]
-
+${CREATE_RUN_BTN_XP}=    xpath://*[text()="Create run"]
 
 
 *** Keywords ***
@@ -45,6 +45,11 @@ Import Pipeline
     Wait Until Generic Modal Appears
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
     Fill In Pipeline Import Form    ${name}    ${filepath}    ${project_title}    ${description}    ${press_cancel}
+    IF    ${press_cancel} == ${TRUE}
+        Click Button    ${GENERIC_CANCEL_BTN_XP}
+    ELSE
+        Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    END
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
 
@@ -54,18 +59,39 @@ Create Pipeline Run
     ...                - immediate
     ...                - schedule -> this requires to insert additional arguments
     ...                TEMPORARILY SUPPORTING ONLY IMMEDIATE RUNS AND DEFAULT MODEL PARAMS
-    [Arguments]    ${name}    ${pipeline_name}    ${run_type}=Immediate    ${trigger_type}=Periodic
-    ...            ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
-    ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}    &{model_param}
-    Log    working in progress...
-    # check selected project
-    # insert name
-    # insert description
-    # select pipeline
-    # select run type
-    # insert additional params based on run type
-    # insert additinal params based on the model
-    
+    [Arguments]    ${name}    ${pipeline_name}    ${from_actions_menu}=${TRUE}    ${run_type}=Immediate
+    ...            ${trigger_type}=Periodic    ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
+    ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}    ${press_cancel}=${FALSE}    &{model_param}
+    IF    ${from_actions_menu} == ${FALSE}
+        Show Pipeline Runs Section    pipeline_name=${pipeline_name}
+        Wait Until Page Contains Element    ${CREATE_RUN_BTN_XP}
+        Click Element    ${CREATE_RUN_BTN_XP}
+    ELSE
+        Pipelines.Click Action From Actions Menu    pipeline_name=${pipeline_name}
+        ...    action=Create run
+    END
+    Wait for RHODS Dashboard to Load    expected_page=Create run
+    ...    wait_for_cards=${FALSE}
+    Fill In Run Creation Form    name=${name}    pipeline_name=${pipeline_name}
+    ...    run_type=${run_type}    trigger_type=Periodic    start_date=${start_date}
+    ...    start_time=${start_time}    end_date=${end_date}    end_time=${end_time}
+    ...    cron_expr=${cron_expr}    &{model_param}
+    IF    ${press_cancel} == ${TRUE}
+        Click Button    ${GENERIC_CANCEL_BTN_XP}
+        Wait for RHODS Dashboard to Load    expected_page=Pipelines
+        ...    wait_for_cards=${FALSE}
+    ELSE
+        Click Element    ${GENERIC_CREATE_BTN_XP}
+        Wait for RHODS Dashboard to Load    expected_page=${name}
+        ...    wait_for_cards=${FALSE}
+    END
+
+Click Action From Actions Menu
+    [Documentation]    Click an action from Actions menu (3-dots menu on the right)
+    [Arguments]    ${pipeline_name}    ${action}
+    Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${pipeline_name}"]]/td[contains(@class,"pf-c-table__action")]/div/button[@aria-label="Actions"]    # robocop: disable
+    Wait Until Page Contains Element       xpath=//tr[td[@data-label="Name"]//*[text()="${pipeline_name}"]]/td[contains(@class,"pf-c-table__action")]/div/ul/li/button[text()="${action}"]    # robocop: disable
+    Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${pipeline_name}"]]/td[contains(@class,"pf-c-table__action")]/div/ul/li/button[text()="${action}"]    # robocop: disable
 
 Pipeline Should Be Listed
     [Documentation]    Checks a pipeline is listed in the DS Project details page
@@ -93,6 +119,47 @@ Pipeline Should Not Be Listed
     ...    Wait Until Page Does Not Contain Element
     ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
 
+Pipeline Run Should Be Listed
+    [Documentation]    Checks a pipeline run is listed in the DS Project details page
+    ...                under the hidden run sub-section.
+    ...                THIS KEYWORD NEED A REFINEMENT TO CHECK THE RUN AND ITS CORRESPONDING STATUS
+    ...                WHEN MULTIPLE RUNS ARE EXECUTED
+    [Arguments]     ${name}    ${pipeline_name}
+    Show Pipeline Runs Section    pipeline_name=${pipeline_name}
+    Run keyword And Continue On Failure
+    ...    Wait Until Page Contains Element
+    ...        ${PIPELINES_SECTION_XP}//a//span[text()="${name}"]
+
+Pipeline Last Run Should Be
+    [Documentation]    Checks the pipeline last run which is reported is the expected one
+    [Arguments]    ${pipeline_name}    ${run_name}
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    Run keyword And Continue On Failure
+    ...    Page Should Contain Element
+    ...        ${pipeline_row_xp}//td/a//span[text()="${run_name}"]
+
+Pipeline Last Run Status Should Be
+    [Documentation]    Checks if the pipeline last run has the expected status
+    [Arguments]    ${pipeline_name}    ${status}
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    Run keyword And Continue On Failure
+    ...    Page Should Contain Element
+    ...        ${pipeline_row_xp}//td/div[text()="${status}"]
+
+Wait Until Pipeline Last Run Is Finished
+    [Documentation]
+    [Arguments]    ${pipeline_name}    ${timeout}=60s
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}//td/a//span[text()="Running"]
+    ...    timeout=${timeout}
+
+Show Pipeline Runs Section
+    [Documentation]    Open the sub-section of the pipeline runs in the DS Project details page.
+    ...                The sub-section is hidden and the robot clicks on a toggle button
+    ...                near the pipeline name to show the sub-section
+    [Arguments]    ${pipeline_name}
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    Click Element    ${pipeline_row_xp}//td[@class="pf-c-table__toggle"]/button
 
 Verify Pipeline Server Deployments
     [Documentation]    Verifies the correct deployment of modelmesh in the rhods namespace

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -1,0 +1,62 @@
+*** Settings ***
+Documentation    Collection of keywords to interact with DS Pipelines
+Resource       Projects.resource
+
+
+*** Variables ***
+${PIPELINES_SECTION_XP}=    xpath://div[@id="pipelines-projects"]
+${PIPELINES_SERVER_BTN_XP}=    xpath://button[text()="Create a pipeline server"]
+${PIPELINES_SERVER_CONFIG_BTN_XP}=    xpath://button[text()="Configure"]
+${PIPELINES_IMPORT_BTN_XP}=    xpath://button[text()="Import pipeline"]
+
+
+*** Keywords ***
+Create Pipeline server
+    [Documentation]    Creates the DS Pipeline server from DS Project details page
+    ...                It assumes the Data Connection is aleady created
+    ...                and you wants to use defaul DB configurations [TEMPORARY]
+    [Arguments]    ${dc_name}
+    Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_XP}
+    Element Should Be Enabled    ${PIPELINES_SERVER_BTN_XP}
+    Click Button    ${PIPELINES_SERVER_BTN_XP}
+    Wait Until Generic Modal Appears
+    Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_SERVER_CONFIG_BTN_XP}
+    Select Data Connection    dc_name=${dc_name}
+    Element Should Be Enabled    ${PIPELINES_SERVER_CONFIG_BTN_XP}
+    # Sleep    10s    Waiting to give time the dc secret to be fully ready
+    Click Element    ${PIPELINES_SERVER_CONFIG_BTN_XP}
+    Wait Until Generic Modal Disappears
+
+Select Data Connection
+    [Documentation]    Selects an existing data connection from the dropdown
+    ...                in the modal for Pipeline Server creation
+    [Arguments]    ${dc_name}
+    Click Element    css:form div span button[aria-label="Options menu"]
+    Wait Until Page Contains Element    xpath://button[text()="${dc_name}"]
+    Click Element    xpath://button[text()="${dc_name}"]
+
+Verify Pipeline Server Deployments
+    [Documentation]    Verifies the correct deployment of modelmesh in the rhods namespace
+    [Arguments]    ${project_title}
+    ${namespace}=    Get Openshift Namespace From Data Science Project
+    ...    project_title=${project_title}
+    @{persistenceagent} =  Oc Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=app=ds-pipeline-persistenceagent-pipelines-definition
+    ${containerNames} =  Create List  ds-pipeline-persistenceagent
+    Verify Deployment    ${persistenceagent}  1  1  ${containerNames}
+
+    @{pipeline_definition} =  Oc Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=app=ds-pipeline-pipelines-definition
+    ${containerNames} =  Create List  oauth-proxy    ds-pipeline-api-server
+    Verify Deployment    ${pipeline_definition}  1  2  ${containerNames}
+
+    @{schedule_workflow} =  Oc Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=app=ds-pipeline-scheduledworkflow-pipelines-definition
+    ${containerNames} =  Create List  ds-pipeline-scheduledworkflow
+    Verify Deployment    ${schedule_workflow}  1  1  ${containerNames}
+
+    @{db} =  Oc Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=app=mariadb-pipelines-definition
+    ${containerNames} =  Create List  mariadb
+    Verify Deployment    ${db}  1  1  ${containerNames}
+

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -20,7 +20,7 @@ Create Pipeline Server
     [Documentation]    Creates the DS Pipeline server from DS Project details page
     ...                It assumes the Data Connection is aleady created
     ...                and you wants to use defaul DB configurations [TEMPORARY]
-    [Arguments]    ${dc_name}
+    [Arguments]    ${dc_name}    ${project_title}
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_XP}
     Element Should Be Enabled    ${PIPELINES_SERVER_BTN_XP}
     Click Button    ${PIPELINES_SERVER_BTN_XP}
@@ -30,6 +30,8 @@ Create Pipeline Server
     Element Should Be Enabled    ${PIPELINES_SERVER_CONFIG_BTN_XP}
     Click Element    ${PIPELINES_SERVER_CONFIG_BTN_XP}
     Wait Until Generic Modal Disappears
+    Wait Until Project Is Open    project_title=${project_title}
+    ...    timeout-pre-spinner=5s    timeout-spinner=35s
 
 Select Data Connection
     [Documentation]    Selects an existing data connection from the dropdown

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -61,17 +61,31 @@ Import Pipeline
 
 Pipeline Should Be Listed
     [Documentation]    Checks a pipeline is listed in the DS Project details page
-    [Arguments]     ${pipeline_name}
+    [Arguments]     ${pipeline_name}    ${pipeline_description}
     Run keyword And Continue On Failure
     ...    Wait Until Page Contains Element
     ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
+    IF    "${pipeline_description}" == ${NONE}
+        Run keyword And Continue On Failure
+        ...    Wait Until Page Does Not Contain Element
+        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+    ELSE
+        Run keyword And Continue On Failure
+        ...    Wait Until Page Contains Element
+        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+    END
+
 
 Pipeline Should Not Be Listed
     [Documentation]    Checks a pipeline is not listed in the DS Project details page
-    [Arguments]     ${pipeline_name}
+    [Arguments]     ${pipeline_name}    ${pipeline_description}
     Run keyword And Continue On Failure
     ...    Wait Until Page Does Not Contain Element
     ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
+    Run keyword And Continue On Failure
+    ...    Wait Until Page Does Not Contain Element
+    ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+
 
 Verify Pipeline Server Deployments
     [Documentation]    Verifies the correct deployment of modelmesh in the rhods namespace

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -16,7 +16,7 @@ ${RUN_TOPOLOGY_XP}=    css:div[data-test-id="topology"]
 
 
 *** Keywords ***
-Create Pipeline server
+Create Pipeline Server
     [Documentation]    Creates the DS Pipeline server from DS Project details page
     ...                It assumes the Data Connection is aleady created
     ...                and you wants to use defaul DB configurations [TEMPORARY]
@@ -101,15 +101,15 @@ Click Action From Actions Menu
 Pipeline Should Be Listed
     [Documentation]    Checks a pipeline is listed in the DS Project details page
     [Arguments]     ${pipeline_name}    ${pipeline_description}
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
     ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
     IF    "${pipeline_description}" == ${NONE}
-        Run keyword And Continue On Failure
+        Run Keyword And Continue On Failure
         ...    Wait Until Page Does Not Contain Element
         ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
     ELSE
-        Run keyword And Continue On Failure
+        Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
         ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
     END
@@ -117,10 +117,10 @@ Pipeline Should Be Listed
 Pipeline Should Not Be Listed
     [Documentation]    Checks a pipeline is not listed in the DS Project details page
     [Arguments]     ${pipeline_name}    ${pipeline_description}
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Wait Until Page Does Not Contain Element
     ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Wait Until Page Does Not Contain Element
     ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
 
@@ -131,7 +131,7 @@ Pipeline Run Should Be Listed
     ...                WHEN MULTIPLE RUNS ARE EXECUTED
     [Arguments]     ${name}    ${pipeline_name}
     Show Pipeline Runs Section    pipeline_name=${pipeline_name}
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
     ...        ${PIPELINES_SECTION_XP}//a//span[text()="${name}"]
 
@@ -139,7 +139,7 @@ Pipeline Last Run Should Be
     [Documentation]    Checks the pipeline last run which is reported is the expected one
     [Arguments]    ${pipeline_name}    ${run_name}
     ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Page Should Contain Element
     ...        ${pipeline_row_xp}//td/a//span[text()="${run_name}"]
 
@@ -147,7 +147,7 @@ Pipeline Last Run Status Should Be
     [Documentation]    Checks if the pipeline last run has the expected status
     [Arguments]    ${pipeline_name}    ${status}
     ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
-    Run keyword And Continue On Failure
+    Run Keyword And Continue On Failure
     ...    Page Should Contain Element
     ...        ${pipeline_row_xp}//td/div[text()="${status}"]
 
@@ -189,25 +189,21 @@ Verify Pipeline Server Deployments
     [Arguments]    ${project_title}
     ${namespace}=    Get Openshift Namespace From Data Science Project
     ...    project_title=${project_title}
-    @{persistenceagent} =  Oc Get    kind=Pod    namespace=${namespace}
+    @{persistenceagent}=  Oc Get    kind=Pod    namespace=${namespace}
     ...    label_selector=app=ds-pipeline-persistenceagent-pipelines-definition
-    ${containerNames} =  Create List  ds-pipeline-persistenceagent
+    ${containerNames}=  Create List  ds-pipeline-persistenceagent
     Verify Deployment    ${persistenceagent}  1  1  ${containerNames}
-
-    @{pipeline_definition} =  Oc Get    kind=Pod    namespace=${namespace}
+    @{pipeline_definition}=  Oc Get    kind=Pod    namespace=${namespace}
     ...    label_selector=app=ds-pipeline-pipelines-definition
-    ${containerNames} =  Create List  oauth-proxy    ds-pipeline-api-server
+    ${containerNames}=  Create List  oauth-proxy    ds-pipeline-api-server
     Verify Deployment    ${pipeline_definition}  1  2  ${containerNames}
-
-    @{schedule_workflow} =  Oc Get    kind=Pod    namespace=${namespace}
+    @{schedule_workflow}=  Oc Get    kind=Pod    namespace=${namespace}
     ...    label_selector=app=ds-pipeline-scheduledworkflow-pipelines-definition
-    ${containerNames} =  Create List  ds-pipeline-scheduledworkflow
+    ${containerNames}=  Create List  ds-pipeline-scheduledworkflow
     Verify Deployment    ${schedule_workflow}  1  1  ${containerNames}
-
-    @{db} =  Oc Get    kind=Pod    namespace=${namespace}
+    @{db}=  Oc Get    kind=Pod    namespace=${namespace}
     ...    label_selector=app=mariadb-pipelines-definition
-    ${containerNames} =  Create List  mariadb
+    ${containerNames}=  Create List  mariadb
     Verify Deployment    ${db}  1  1  ${containerNames}
-    
-    @{all_pods} =  Oc Get    kind=Pod    namespace=${namespace}
+    @{all_pods}=  Oc Get    kind=Pod    namespace=${namespace}
     Run Keyword And Continue On Failure    Length Should Be    ${all_pods}    4

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -56,7 +56,7 @@ Import Pipeline
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
 
-Create Pipeline Run
+Create Pipeline Run    # robocop: disable
     [Documentation]    Create a pipeline run from DS Project details page.
     ...                Note that the ${type} arguments can accept:
     ...                - immediate
@@ -73,7 +73,7 @@ Create Pipeline Run
         Pipelines.Click Action From Actions Menu    pipeline_name=${pipeline_name}
         ...    action=Create run
     END
-    Wait for RHODS Dashboard to Load    expected_page=Create run
+    Wait For RHODS Dashboard To Load    expected_page=Create run
     ...    wait_for_cards=${FALSE}
     Fill In Run Creation Form    name=${name}    pipeline_name=${pipeline_name}
     ...    run_type=${run_type}    trigger_type=Periodic    start_date=${start_date}
@@ -81,13 +81,13 @@ Create Pipeline Run
     ...    cron_expr=${cron_expr}    &{model_param}
     IF    ${press_cancel} == ${TRUE}
         Click Button    ${GENERIC_CANCEL_BTN_XP}
-        Wait for RHODS Dashboard to Load    expected_page=Pipelines
+        Wait For RHODS Dashboard To Load    expected_page=Pipelines
         ...    wait_for_cards=${FALSE}
         ${workflow_name}=    Set Variable    ${NONE}
     ELSE
         Click Element    ${GENERIC_CREATE_BTN_XP}
         Wait Until Page Contains Run Topology Page    run_name=${name}
-        ${workflow_name}=    Get Workflow Name From Topology Page    
+        ${workflow_name}=    Get Workflow Name From Topology Page
     END
     RETURN    ${workflow_name}
 
@@ -103,15 +103,15 @@ Pipeline Should Be Listed
     [Arguments]     ${pipeline_name}    ${pipeline_description}
     Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
-    ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
+    ...    ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
     IF    "${pipeline_description}" == ${NONE}
         Run Keyword And Continue On Failure
         ...    Wait Until Page Does Not Contain Element
-        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]    # robocop: disable
     ELSE
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
-        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+        ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]    # robocop: disable
     END
 
 Pipeline Should Not Be Listed
@@ -119,10 +119,10 @@ Pipeline Should Not Be Listed
     [Arguments]     ${pipeline_name}    ${pipeline_description}
     Run Keyword And Continue On Failure
     ...    Wait Until Page Does Not Contain Element
-    ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
+    ...    ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
     Run Keyword And Continue On Failure
     ...    Wait Until Page Does Not Contain Element
-    ...        ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]
+    ...    ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]//td[@data-label="Name"]/*[p[text()="${pipeline_description}"]]    # robocop: disable
 
 Pipeline Run Should Be Listed
     [Documentation]    Checks a pipeline run is listed in the DS Project details page
@@ -133,35 +133,37 @@ Pipeline Run Should Be Listed
     Show Pipeline Runs Section    pipeline_name=${pipeline_name}
     Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
-    ...        ${PIPELINES_SECTION_XP}//a//span[text()="${name}"]
+    ...    ${PIPELINES_SECTION_XP}//a//span[text()="${name}"]
 
 Pipeline Last Run Should Be
     [Documentation]    Checks the pipeline last run which is reported is the expected one
     [Arguments]    ${pipeline_name}    ${run_name}
-    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]    # robocop: disable
     Run Keyword And Continue On Failure
     ...    Page Should Contain Element
-    ...        ${pipeline_row_xp}//td/a//span[text()="${run_name}"]
+    ...    ${pipeline_row_xp}//td/a//span[text()="${run_name}"]
 
 Pipeline Last Run Status Should Be
     [Documentation]    Checks if the pipeline last run has the expected status
     [Arguments]    ${pipeline_name}    ${status}
-    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]    # robocop: disable
     Run Keyword And Continue On Failure
     ...    Page Should Contain Element
-    ...        ${pipeline_row_xp}//td/div[text()="${status}"]
+    ...    ${pipeline_row_xp}//td/div[text()="${status}"]
 
 Wait Until Pipeline Last Run Is Finished
-    [Documentation]
+    [Documentation]    Waits until the run reported in the "last run" column of the test pipeline
+    ...                in the DS Project details page completes the execution (i.e., status is not Running)
     [Arguments]    ${pipeline_name}    ${timeout}=60s
-    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]    # robocop: disable
     Wait Until Page Does Not Contain Element    ${pipeline_row_xp}//td/div[text()="Running"]
     ...    timeout=${timeout}
 
 Wait Until Pipeline Last Run Is Started
-    [Documentation]
+    [Documentation]    Waits until the run reported in the "last run" column of the test pipeline
+    ...                in the DS Project details page starts the execution (i.e., status is Running)
     [Arguments]    ${pipeline_name}    ${timeout}=60s
-    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]    # robocop: disable
     Wait Until Page Contains Element    ${pipeline_row_xp}//td/div[text()="Running"]
     ...    timeout=${timeout}
 
@@ -170,10 +172,12 @@ Show Pipeline Runs Section
     ...                The sub-section is hidden and the robot clicks on a toggle button
     ...                near the pipeline name to show the sub-section
     [Arguments]    ${pipeline_name}
-    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]
+    ${pipeline_row_xp}=    Set Variable     ${PIPELINES_SECTION_XP}//tr[td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]]    # robocop: disable
     Click Element    ${pipeline_row_xp}//td[@class="pf-c-table__toggle"]/button
 
 Wait Until Page Contains Run Topology Page
+    [Documentation]    Waits until the page containing the run details and its topology
+    ...                is rendered on the screen
     [Arguments]    ${run_name}
     Run Keyword And Continue On Failure    Wait Until Page Contains Element
     ...    xpath://h1//div[text()="${run_name}"]    timeout=10s
@@ -184,7 +188,7 @@ Wait Until Page Contains Run Topology Page
     Run Keyword And Continue On Failure    Wait Until Page Contains Element
     ...    ${RUN_TOPOLOGY_XP}
 
-Verify Pipeline Server Deployments
+Verify Pipeline Server Deployments    # robocop: disable
     [Documentation]    Verifies the correct deployment of DS Pipelines in the rhods namespace
     [Arguments]    ${project_title}
     ${namespace}=    Get Openshift Namespace From Data Science Project

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -8,6 +8,9 @@ ${PIPELINES_SECTION_XP}=    xpath://div[@id="pipelines-projects"]
 ${PIPELINES_SERVER_BTN_XP}=    xpath://button[text()="Create a pipeline server"]
 ${PIPELINES_SERVER_CONFIG_BTN_XP}=    xpath://button[text()="Configure"]
 ${PIPELINES_IMPORT_BTN_XP}=    xpath://button[text()="Import pipeline"]
+${PIPELINES_IMPORT_BTN_FORM_XP}=    xpath://footer/button[text()="Import pipeline"]
+${PIPELINE_NAME_INPUT_XP}=    id:pipeline-name
+${PIPELINE_DESC_INPUT_XP}=    id:pipeline-description
 
 
 *** Keywords ***
@@ -34,6 +37,41 @@ Select Data Connection
     Click Element    css:form div span button[aria-label="Options menu"]
     Wait Until Page Contains Element    xpath://button[text()="${dc_name}"]
     Click Element    xpath://button[text()="${dc_name}"]
+
+Import Pipeline
+    [Documentation]    Import a pipeline definition from DS Project details page.
+    ...                It expects to receive the relative path starting from ods_ci/
+    [Arguments]    ${name}    ${filepath}    ${project_title}    ${description}=${NONE}    ${press_cancel}=${FALSE}
+    Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_XP}
+    Click Button    ${PIPELINES_IMPORT_BTN_XP}
+    Wait Until Generic Modal Appears
+    Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    Input Text    ${PIPELINE_NAME_INPUT_XP}    ${name}
+    Input Text    ${PIPELINE_DESC_INPUT_XP}    ${description}
+    ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
+    Choose File    //div[@class="pf-c-file-upload"]//input[@type="file"]    ${pwd}/${filepath}
+    Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    IF    ${press_cancel} == ${TRUE}
+        Click Button    ${GENERIC_CANCEL_BTN_XP}
+    ELSE
+        Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
+    END
+    Wait Until Generic Modal Disappears
+    Wait Until Project Is Open    project_title=${project_title}
+
+Pipeline Should Be Listed
+    [Documentation]    Checks a pipeline is listed in the DS Project details page
+    [Arguments]     ${pipeline_name}
+    Run keyword And Continue On Failure
+    ...    Wait Until Page Contains Element
+    ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
+
+Pipeline Should Not Be Listed
+    [Documentation]    Checks a pipeline is not listed in the DS Project details page
+    [Arguments]     ${pipeline_name}
+    Run keyword And Continue On Failure
+    ...    Wait Until Page Does Not Contain Element
+    ...        ${PIPELINES_SECTION_XP}//td[@data-label="Name"]/*[a[text()="${pipeline_name}"]]
 
 Verify Pipeline Server Deployments
     [Documentation]    Verifies the correct deployment of modelmesh in the rhods namespace

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -59,9 +59,10 @@ Delete Data Science Project
 
 Wait Until Project Is Open
     [Documentation]    Waits until a DS Project Details page is laoded
-    [Arguments]     ${project_title}
+    [Arguments]     ${project_title}    ${timeout-pre-spinner}=3s    ${timeout-spinner}=5s
     Wait Until Page Contains Element    xpath=//h1[contains(text(),"${project_title}")]    timeout=30
     Maybe Wait For Dashboard Loading Spinner Page
+    ...    timeout-pre=${timeout-pre-spinner}    timeout=${timeout-spinner}
 
 Project Should Be Listed
     [Documentation]    Checks a Project is available in DS Project home page

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -39,8 +39,6 @@ Verify User Can Create A DS Pipeline From DS Project UI
     Capture Page Screenshot
     
 
-
-
 *** Keywords ***
 Pipelines Suite Setup
     Set Library Search Order    SeleniumLibrary
@@ -53,6 +51,7 @@ Pipelines Suite Setup
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
+    # Open Data Science Project Details Page    ${PRJ_TITLE}
     Create Data Science Project    title=${PRJ_TITLE}
     ...    description=${PRJ_DESCRIPTION}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_NAME}
@@ -60,7 +59,7 @@ Pipelines Suite Setup
     ...            aws_bucket_name=ods-ci-ds-pipelines
     Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
     ...    wait_for_cards=${FALSE}
-    Wait Until Project Is Open
+    Wait Until Project Is Open    project_title=${PRJ_TITLE}
     # TO DELETE # Maybe Wait For Dashboard Loading Spinner Page
     Log    message=reload needed to avoid RHODS-8923
     ...    level=WARN

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -19,7 +19,7 @@ ${PIPELINE_TEST_FILEPATH}=    ods_ci/tests/Resources/Files/pipeline-samples/iris
 *** Test Cases ***
 Verify User Can Create A DS Pipeline From DS Project UI
     [Tags]    Sanity    Tier1
-    ...       ODS-XYZ
+    ...       ODS-2206
     Create Pipeline server    dc_name=${DC_NAME}
     Wait Until Pipeline Server Is Deployed
     Import Pipeline    name=${PIPELINE_TEST_NAME}
@@ -28,12 +28,14 @@ Verify User Can Create A DS Pipeline From DS Project UI
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${TRUE}
     Pipeline Should Not Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    pipeline_description=${PIPELINE_TEST_DESC}
     Import Pipeline    name=${PIPELINE_TEST_NAME}
     ...    description=${PIPELINE_TEST_DESC}
     ...    project_title=${PRJ_TITLE}
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${FALSE}
     Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    pipeline_description=${PIPELINE_TEST_DESC}
     Capture Page Screenshot
     
 
@@ -59,7 +61,7 @@ Pipelines Suite Setup
     Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
     ...    wait_for_cards=${FALSE}
     Wait Until Project Is Open
-    TO DELETE # Maybe Wait For Dashboard Loading Spinner Page
+    # TO DELETE # Maybe Wait For Dashboard Loading Spinner Page
     Log    message=reload needed to avoid RHODS-8923
     ...    level=WARN
     RHOSi Setup

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -59,14 +59,15 @@ Verify User Can Create And Run A DS Pipeline From DS Project Details Page
 
 
 *** Keywords ***
-Pipelines Suite Setup
+Pipelines Suite Setup    # robocop: disable
+    [Documentation]    Sets global test variables, create a DS project and a data connection
     Set Library Search Order    SeleniumLibrary
     ${prj_title}=    Set Variable    ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
     ${iris_pipeline_name}=    Set Variable    ${PIPELINE_TEST_BASENAME}-${TEST_USER_3.USERNAME}
     Set Suite Variable    ${PRJ_TITLE}    ${prj_title}
     Set Suite Variable    ${PIPELINE_TEST_NAME}    ${iris_pipeline_name}
     ${to_delete}=    Create List    ${PRJ_TITLE}
-    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}    
+    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -1,0 +1,45 @@
+*** Settings ***
+Documentation      Suite to test additional scenarios for Data Science Projects (a.k.a DSG) feature
+Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+Suite Setup        Pipelines Suite Setup
+Suite Teardown     Pipelines Suite Teardown
+
+
+*** Variables ***
+${PRJ_BASE_TITLE}=   DSP
+${PRJ_DESCRIPTION}=   ${PRJ_BASE_TITLE} is a test project for validating DS Pipelines feature
+${DC_NAME}=    ds-pipeline-conn
+
+
+*** Test Cases ***
+Verify User Can Create A DS Pipeline From DS Project UI
+    [Tags]    Sanity    Tier1
+    ...       ODS-XYZ
+    Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
+    ...    wait_for_cards=${FALSE}
+    Create Pipeline server    dc_name=${DC_NAME}
+    # Verify Pipeline Server Deployments    project_title=${PRJ_TITLE}
+
+
+*** Keywords ***
+Pipelines Suite Setup
+    Set Library Search Order    SeleniumLibrary
+    ${prj_title}=    Set Variable    ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+    Set Suite Variable    ${PRJ_TITLE}    ${prj_title}
+    ${to_delete}=    Create List    ${PRJ_TITLE}
+    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}    
+    Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
+    ...    password=${TEST_USER_3.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
+    Create Data Science Project    title=${PRJ_TITLE}
+    ...    description=${PRJ_DESCRIPTION}
+    Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_NAME}
+    ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
+    ...            aws_bucket_name=ods-ci-ds-pipelines
+    # RHOSi Setup
+
+Pipelines Suite Teardown
+    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    # RHOSi Teardown

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -14,10 +14,10 @@ ${DC_NAME}=    ds-pipeline-conn
 ${PIPELINE_TEST_BASENAME}=    iris
 ${PIPELINE_TEST_DESC}=    test pipeline definition
 ${PIPELINE_TEST_FILEPATH}=    ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
-
+${PIPELINE_TEST_RUN_BASENAME}=    ${PIPELINE_TEST_BASENAME}-run
 
 *** Test Cases ***
-Verify User Can Create A DS Pipeline From DS Project UI
+Verify User Can Create And Run A DS Pipeline From DS Project Details Page
     [Tags]    Sanity    Tier1
     ...       ODS-2206
     Create Pipeline server    dc_name=${DC_NAME}
@@ -37,7 +37,25 @@ Verify User Can Create A DS Pipeline From DS Project UI
     Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
     ...    pipeline_description=${PIPELINE_TEST_DESC}
     Capture Page Screenshot
-    
+    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    from_actions_menu=${FALSE}    run_type=Immediate
+    ...    press_cancel=${TRUE}
+    Open Data Science Project Details Page    ${PRJ_TITLE}
+    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    from_actions_menu=${FALSE}    run_type=Immediate
+    # check pipeline details section - for future PR
+    # check pipeline representation exists  - for future PR
+    # check run output section  - for future PR
+    Open Data Science Project Details Page    ${PRJ_TITLE}
+    Wait Until Pipeline Last Run Is Finished    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    timeout=180s
+    Pipeline Last Run Should Be    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    run_name=${PIPELINE_TEST_RUN_BASENAME}
+    Pipeline Last Run Status Should Be    pipeline_name=${PIPELINE_TEST_NAME}
+    ...    status=Completed
+    Pipeline Run Should be Listed    name=${PIPELINE_TEST_RUN_BASENAME}
+    ...    pipeline_name=${PIPELINE_TEST_NAME}
+
 
 *** Keywords ***
 Pipelines Suite Setup

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -11,6 +11,9 @@ Suite Teardown     Pipelines Suite Teardown
 ${PRJ_BASE_TITLE}=   DSP
 ${PRJ_DESCRIPTION}=   ${PRJ_BASE_TITLE} is a test project for validating DS Pipelines feature
 ${DC_NAME}=    ds-pipeline-conn
+${PIPELINE_TEST_BASENAME}=    iris
+${PIPELINE_TEST_DESC}=    test pipeline definition
+${PIPELINE_TEST_FILEPATH}=    ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
 
 
 *** Test Cases ***
@@ -19,12 +22,30 @@ Verify User Can Create A DS Pipeline From DS Project UI
     ...       ODS-XYZ
     Create Pipeline server    dc_name=${DC_NAME}
     Wait Until Pipeline Server Is Deployed
+    Import Pipeline    name=${PIPELINE_TEST_NAME}
+    ...    description=${PIPELINE_TEST_DESC}
+    ...    project_title=${PRJ_TITLE}
+    ...    filepath=${PIPELINE_TEST_FILEPATH}
+    ...    press_cancel=${TRUE}
+    Pipeline Should Not Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
+    Import Pipeline    name=${PIPELINE_TEST_NAME}
+    ...    description=${PIPELINE_TEST_DESC}
+    ...    project_title=${PRJ_TITLE}
+    ...    filepath=${PIPELINE_TEST_FILEPATH}
+    ...    press_cancel=${FALSE}
+    Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
+    Capture Page Screenshot
+    
+
+
 
 *** Keywords ***
 Pipelines Suite Setup
     Set Library Search Order    SeleniumLibrary
     ${prj_title}=    Set Variable    ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+    ${iris_pipeline_name}=    Set Variable    ${PIPELINE_TEST_BASENAME}-${TEST_USER_3.USERNAME}
     Set Suite Variable    ${PRJ_TITLE}    ${prj_title}
+    Set Suite Variable    ${PIPELINE_TEST_NAME}    ${iris_pipeline_name}
     ${to_delete}=    Create List    ${PRJ_TITLE}
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}    
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
@@ -37,7 +58,8 @@ Pipelines Suite Setup
     ...            aws_bucket_name=ods-ci-ds-pipelines
     Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
     ...    wait_for_cards=${FALSE}
-    Maybe Wait For Dashboard Loading Spinner Page
+    Wait Until Project Is Open
+    TO DELETE # Maybe Wait For Dashboard Loading Spinner Page
     Log    message=reload needed to avoid RHODS-8923
     ...    level=WARN
     RHOSi Setup

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -17,13 +17,8 @@ ${DC_NAME}=    ds-pipeline-conn
 Verify User Can Create A DS Pipeline From DS Project UI
     [Tags]    Sanity    Tier1
     ...       ODS-XYZ
-    Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
-    ...    wait_for_cards=${FALSE}
-    Log    message=reload needed to avoid RHODS-8923
-    ...    level=WARN
     Create Pipeline server    dc_name=${DC_NAME}
-    # Verify Pipeline Server Deployments    project_title=${PRJ_TITLE}
-
+    Wait Until Pipeline Server Is Deployed
 
 *** Keywords ***
 Pipelines Suite Setup
@@ -40,8 +35,20 @@ Pipelines Suite Setup
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_NAME}
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=ods-ci-ds-pipelines
-    # RHOSi Setup
+    Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
+    ...    wait_for_cards=${FALSE}
+    Maybe Wait For Dashboard Loading Spinner Page
+    Log    message=reload needed to avoid RHODS-8923
+    ...    level=WARN
+    RHOSi Setup
 
 Pipelines Suite Teardown
     Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
-    # RHOSi Teardown
+    RHOSi Teardown
+
+Wait Until Pipeline Server Is Deployed
+    [Documentation]    Waits until all the expected pods of the pipeline server
+    ...                are running
+    Wait Until Keyword Succeeds    5 times    5s
+    ...    Verify Pipeline Server Deployments    project_title=${PRJ_TITLE}
+

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -19,6 +19,8 @@ Verify User Can Create A DS Pipeline From DS Project UI
     ...       ODS-XYZ
     Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
     ...    wait_for_cards=${FALSE}
+    Log    message=reload needed to avoid RHODS-8923
+    ...    level=WARN
     Create Pipeline server    dc_name=${DC_NAME}
     # Verify Pipeline Server Deployments    project_title=${PRJ_TITLE}
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -24,6 +24,7 @@ Verify User Can Create And Run A DS Pipeline From DS Project Details Page    # r
     [Tags]    Sanity    Tier1
     ...       ODS-2206
     Create Pipeline Server    dc_name=${DC_NAME}
+    ...    project_title=${PRJ_TITLE}
     Wait Until Pipeline Server Is Deployed
     Import Pipeline    name=${PIPELINE_TEST_NAME}
     ...    description=${PIPELINE_TEST_DESC}
@@ -95,7 +96,7 @@ Pipelines Suite Teardown
 Wait Until Pipeline Server Is Deployed
     [Documentation]    Waits until all the expected pods of the pipeline server
     ...                are running
-    Wait Until Keyword Succeeds    5 times    5s
+    Wait Until Keyword Succeeds    10 times    10s
     ...    Verify Pipeline Server Deployments    project_title=${PRJ_TITLE}
 
 Verify Pipeline Run Deployment Is Successful    # robocop: disable


### PR DESCRIPTION
the PR is adding the basic keywords to create pipeline server, pipelines and runs from UI.

There are enhancements and addition to do on this in future PRs, like:
- e2e flow from DS Pipeline page in RHODS dashboard rather than DS Project details page
- checks on Topology page
- test creation of `scheduled` runs rather than `immediate` ones
- test creation of data connection directly from form instead creating it prior to create the pipeline server
- test with external DB instead of default mariadb
- import a new pipeline from `Create run` form
- others