### PR TITLE
Move ODS-2201 to sanity

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -25,7 +25,7 @@ Verify User Can Access Permission Tab In Their Owned DS Project
 
 Verify User Can Make Their Owned DS Project Accessible To Other Users    # robocop: disable
     [Documentation]    Verify user can give access permissions for their DS Projects to other users
-    [Tags]    Tier1    Smoke
+    [Tags]    Tier1    Sanity
     ...       ODS-2201
     Switch To User    ${TEST_USER_3.USERNAME}
     Move To Tab    Permissions


### PR DESCRIPTION
ODS-2201 is currently in Smoke suite, but ODS-2202 relies on the env setting done by the first one. Hence, moving ODS-2201 to Sanity.