### PR TITLE
Change images URL in pipeline sample to test on disconnected clusters

### DIFF
--- a/ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/iris-pipeline-compiled.yaml
@@ -141,19 +141,19 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = data_prep(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-38
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
           env:
           - name: ORIG_PR_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
-        - image: registry.access.redhat.com/ubi8/ubi-minimal
+        - image: registry.redhat.io/ubi8/ubi-minimal@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
           name: output-taskrun-name
           command:
           - sh
           - -ec
           - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
-        - image: registry.access.redhat.com/ubi8/ubi-minimal
+        - image: registry.redhat.io/ubi8/ubi-minimal@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
           name: copy-results-artifacts
           command:
           - sh
@@ -282,19 +282,19 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = train_model(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-38
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
           env:
           - name: ORIG_PR_NAME
             valueFrom:
               fieldRef:
                 fieldPath: metadata.labels['custom.tekton.dev/originalPipelineRun']
-        - image: registry.access.redhat.com/ubi8/ubi-minimal
+        - image: registry.redhat.io/ubi8/ubi-minimal@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
           name: output-taskrun-name
           command:
           - sh
           - -ec
           - echo -n "$(context.taskRun.name)" > "$(results.taskrun-name.path)"
-        - image: registry.access.redhat.com/ubi8/ubi-minimal
+        - image: registry.redhat.io/ubi8/ubi-minimal@sha256:621f5245fb3e8597a626163cdf1229e1f8311e07ab71bb1e9332014b51c59f9c
           name: copy-results-artifacts
           command:
           - sh
@@ -430,7 +430,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = evaluate_model(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-38
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
           env:
           - name: ORIG_PR_NAME
             valueFrom:
@@ -510,7 +510,7 @@ spec:
             _parsed_args = vars(_parser.parse_args())
 
             _outputs = validate_model(**_parsed_args)
-          image: registry.access.redhat.com/ubi8/python-38
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
           env:
           - name: ORIG_PR_NAME
             valueFrom:

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -31,7 +31,7 @@ Create Pipeline Server
     Click Element    ${PIPELINES_SERVER_CONFIG_BTN_XP}
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
-    ...    timeout-pre-spinner=5s    timeout-spinner=35s
+    ...    timeout-pre-spinner=5s    timeout-spinner=60s
 
 Select Data Connection
     [Documentation]    Selects an existing data connection from the dropdown


### PR DESCRIPTION
Based on @jgarciao 's request in another PR https://github.com/red-hat-data-services/ods-ci/pull/796#discussion_r1211951595 , this PR is changing the image URL used in the pipeline sample.