### PR TITLE
ods_ci/build/Dockerfile: update to give HOME read/write access to the user

### DIFF
--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -51,8 +51,8 @@ COPY ods_ci/configs/resources/oauth_ldap_idp.json ods_ci/configs/resources/oauth
 COPY ods_ci/configs/templates/ca-rolebinding.yaml ods_ci/configs/templates/ca-rolebinding.yaml
 COPY ods_ci/utils/scripts/ocm/templates/create_ldap_idp.jinja ods_ci/utils/scripts/ocm/templates/create_ldap_idp.jinja
 RUN  chmod +x ods_ci/build/run.sh &&\
-     chmod +x ods_ci/build/clean_idp.sh &&\
-     chmod 775 . # writing permissions for ods-ci.log
+     chmod +x ods_ci/build/clean_idp.sh
+
 COPY pyproject.toml .
 COPY poetry.lock .
 COPY README.md .
@@ -60,6 +60,9 @@ RUN python3 --version
 RUN curl -sSL https://install.python-poetry.org | python3 -
 ENV PATH="${PATH}:$HOME/.local/bin"
 RUN poetry install
+
+RUN chgrp -R 0 . && \
+    chmod -R g=u .
 
 
 ENTRYPOINT ["./ods_ci/build/run.sh"]


### PR DESCRIPTION
This PR updates the ownership of the HOME directory of the container image, so that users with any UID can read/write into it.

This follows [OpenShift guidelines](https://docs.openshift.com/container-platform/4.13/openshift_images/create-images.html#use-uid_create-images).

-- 

The notebook scale test test-harness broke because of [this update](https://github.com/openshift-psap/ods-ci/commit/5d30a7f169a904f7e08ef7bdf80cfc3349a446fa), as it tries to copy files from a mounted volume into the HOME directory.