### PR TITLE
Fix BYON Endpoint test

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -58,7 +58,7 @@ ${IMG_DESCRIPTION}=     Testing Only This image is only for illustration purpose
 &{IMG_PACKAGES}=        elyra=2.2.4    foo-pkg=a.b.c
 ${IMG_ENDPOINT_PT0}=        api/images
 ${IMG_ENDPOINT_PT1}=        byon
-${IMG_ENDPOINT_BODY}=        {"name":"Test-Byon-Image","description":"","packages":[],"software":[],"url":"test-url.io/myimages/test-notebook:v1"}
+${IMG_ENDPOINT_BODY}=        {"name":"Test-Byon-Image","description":"","packages":[],"software":[],"url":"test-url.io/myimages/test-notebook:v1"}    # robocop: disable
 
 ${NB_EVENTS_ENDPOINT_PT0}=      api/nb-events
 ${NB_EVENTS_ENDPOINT_PT1}=      ${NB_EVENTS_ENDPOINT_PT0}/${NOTEBOOK_NS}

--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -58,7 +58,7 @@ ${IMG_DESCRIPTION}=     Testing Only This image is only for illustration purpose
 &{IMG_PACKAGES}=        elyra=2.2.4    foo-pkg=a.b.c
 ${IMG_ENDPOINT_PT0}=        api/images
 ${IMG_ENDPOINT_PT1}=        byon
-${IMG_ENDPOINT_BODY}=        {"name":"Test-Byon-Image","description":"","packages":[],"software":[],"url":"test-url"}
+${IMG_ENDPOINT_BODY}=        {"name":"Test-Byon-Image","description":"","packages":[],"software":[],"url":"test-url.io/myimages/test-notebook:v1"}
 
 ${NB_EVENTS_ENDPOINT_PT0}=      api/nb-events
 ${NB_EVENTS_ENDPOINT_PT1}=      ${NB_EVENTS_ENDPOINT_PT0}/${NOTEBOOK_NS}


### PR DESCRIPTION
In RHODS v1.28 the URL validation has been added for custom images (BYON). The URL must match the regex reported [here](https://github.com/red-hat-data-services/odh-dashboard/commit/a80041df728895730c01ed5456731355506357e1#diff-ee836ba873f0df81818b2928dfb41d9b4935cb2de4ccf6ef26929fcaeda8f510)