### PR TITLE
Increase default timeout for Start Workbench

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -253,7 +253,7 @@ Wait Until Workbench Is Restarting
 
 Start Workbench
     [Documentation]    Starts a workbench from the DS Project details page
-    [Arguments]     ${workbench_title}      ${timeout}=30s
+    [Arguments]     ${workbench_title}      ${timeout}=60s
 
     ${is_stopped}=      Run Keyword And Return Status   Workbench Status Should Be
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_STOPPED}


### PR DESCRIPTION
The default timeout is to fast
![image](https://github.com/red-hat-data-services/ods-ci/assets/687311/bc54f80e-5d8d-4754-9269-58e2af6a2f26)
