### PR TITLE
Remove workaround for RHODS-8923 in DSP UI testing

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -80,11 +80,6 @@ Pipelines Suite Setup    # robocop: disable
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_NAME}
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=ods-ci-ds-pipelines
-    Reload RHODS Dashboard Page    expected_page=${PRJ_TITLE}
-    ...    wait_for_cards=${FALSE}
-    Wait Until Project Is Open    project_title=${PRJ_TITLE}
-    Log    message=reload needed to avoid RHODS-8923
-    ...    level=WARN
     RHOSi Setup
 
 Pipelines Suite Teardown


### PR DESCRIPTION
As part of 1.28 verification, we need to ensure that our tests do not apply the workaround for RHODS-8923: reloading DS project details page after creating a DC and before creating a DSP Server.
