### PR TITLE
Fix Quick Starts tests to account for Starburst Enterprise

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -9,6 +9,8 @@ Resource       ../../../Common.robot
 ...                 https://my-project-s2i-python-service-openapi-3scale-api.cluster.com/?user_key=USER_KEY
 ...                 https://user-dev-rhoam-quarkus-openapi-3scale-api.cluster.com/?user_key=<API_KEY_GOES_HERE>
 ...                 https://user-dev-rhoam-quarkus-openapi-3scale-api.cluster.com/status/?user_key=.
+...                 https://console-openshift-console.apps.test-cluster.example.com
+...                 console-openshift-console.apps.test-cluster.example.com
 
 
 *** Keywords ***

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -256,7 +256,10 @@ Open QuickStart Step
 
 Validate Links Extracted From Text
     [Documentation]    Checks the health status of the links which have been
-    ...                extracted from the quick start texts
+    ...                extracted from the quick start texts.
+    ...                It skips validation of textual links which are supposed to be
+    ...                mere examples, hence invalid links. e.g., 
+    ...                http://example.apps.organization.abc3.p4.openshiftapps.com/prediction
     [Arguments]    ${doc_links}
     FOR    ${doc_link}    IN    @{doc_links}
         Log   ${doc_link}

--- a/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -315,6 +315,7 @@ Set Quick Starts Elements List Based On RHODS Type
             ...    create-jupyter-notebook    create-jupyter-notebook-anaconda
             ...    deploy-python-model    create-aikit-notebook    openvino-inference-notebook
             ...    pachyderm-beginner-tutorial-notebook    build-deploy-watson-model
+            ...    using-starburst-enterprise
     ELSE
             @{quickStartElements}=      Create List
             ...    create-jupyter-notebook    create-jupyter-notebook-anaconda


### PR DESCRIPTION
ODS-1305 and ODS-1402 must account for the new quick start of starburst enterprise. This PR is fixing both the test cases