### PR TITLE
Enable FIPS validation in Hive deployments

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
@@ -52,6 +52,7 @@ items:
         networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
+      fips: true
       platform:
         aws:
           region: {{ aws_region|default("us-east-1") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
@@ -52,7 +52,7 @@ items:
         networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
-      fips: true
+      fips: {{ fips_validation|default("false") }}
       platform:
         aws:
           region: {{ aws_region|default("us-east-1") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
@@ -52,7 +52,7 @@ items:
         networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
-      fips: true
+      fips: {{ fips_validation|default("false") }}
       platform:
         gcp:
           projectID: {{ gcp_project_id }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
@@ -52,6 +52,7 @@ items:
         networkType: {{ ocp_network_type|default("OVNKubernetes") }}
         serviceNetwork:
         - 172.30.0.0/16
+      fips: true
       platform:
         gcp:
           projectID: {{ gcp_project_id }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
@@ -6,9 +6,10 @@
 export CLUSTER_NAME=${1:-$CLUSTER_NAME}
 export AWS_DOMAIN=${2:-$AWS_DOMAIN}
 export OSP_NETWORK=${3:-$OSP_NETWORK}
-export OUTPUT_DIR=${4:-.${CLUSTER_NAME}_conf}
+export OSP_CLOUD=${4:-openstack}
+export OUTPUT_DIR=${5:-.${CLUSTER_NAME}_conf}
 
-# Cluster name should converted to lowercase
+# Cluster name should be converted to lowercase
 export CLUSTER_NAME=${CLUSTER_NAME,,} 
 
 if [[ -z $CLUSTER_NAME || -z $AWS_DOMAIN || -z $OSP_NETWORK ]] ; then
@@ -22,7 +23,7 @@ else
   echo "Creating Floating IPs on OSP external network '$OSP_NETWORK' and A records in AWS domain: $CLUSTER_NAME.$AWS_DOMAIN"
 fi
 
-export OS_CLOUD=openstack
+export OS_CLOUD=${OSP_CLOUD}
 
 if ! openstack catalog list -c Endpoints ; then
   echo -e "Openstack access is not properly configured."

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
@@ -57,6 +57,7 @@ items:
         networkType: ${infrastructure_configurations}[ocp_network_type]
         serviceNetwork:
         - 172.30.0.0/16
+      fips: true
       platform:
         openstack:
           cloud: ${infrastructure_configurations}[osp_cloud_name]

--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
@@ -57,7 +57,7 @@ items:
         networkType: ${infrastructure_configurations}[ocp_network_type]
         serviceNetwork:
         - 172.30.0.0/16
-      fips: true
+      fips: ${infrastructure_configurations}[fips_validation]
       platform:
         openstack:
           cloud: ${infrastructure_configurations}[osp_cloud_name]

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -91,11 +91,11 @@ Create Floating IPs
     Should Be True    ${result.rc} == 0
     Create File    ${osp_clouds_yaml}    ${result.stdout}
     File Should Not Be Empty    ${osp_clouds_yaml}
-    ${shell_script} =     Set Variable     ${CURDIR}/OSP/create_fips.sh
-    ${result} 	Run Process 	sh     ${shell_script}    ${cluster_name}    ${infrastructure_configurations}[aws_domain]
-    ...    ${infrastructure_configurations}[osp_network]    ${infrastructure_configurations}[osp_cloud_name]    ${artifacts_dir}/    shell=yes
-    Log    ${shell_script}:\n${result.stdout}\n${result.stderr}     console=True
-    Should Be True    ${result.rc} == 0
+    ${shell_script} =     Catenate
+    ...    ${CURDIR}/OSP/create_fips.sh ${cluster_name} ${infrastructure_configurations}[aws_domain]
+    ...    ${infrastructure_configurations}[osp_network] ${infrastructure_configurations}[osp_cloud_name] ${artifacts_dir}/    
+    ${return_code} =    Run and Watch Command    ${shell_script}    output_should_contain=Exporting Floating IPs
+    Should Be Equal As Integers	${return_code}	 0   msg=Error creating floating IPs for cluster '${cluster_name}'
     ${fips_file_to_export} =    Set Variable    ${artifacts_dir}/${cluster_name}.${infrastructure_configurations}[aws_domain].fips
     Export Variables From File    ${fips_file_to_export}
 

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -112,6 +112,8 @@ Verify Cluster Is Successfully Provisioned
     END
     Create File    ${install_log_file}    ${install_log_data}
     Should Contain    ${install_log_data}    install completed successfully
+    ${result} =    Run Process 	grep 'install completed successfully' ${install_log_file}    shell=yes
+    Should Be True    ${result.rc} == 0
 
 Wait For Cluster To Be Ready
     ${pool_namespace} =    Get Cluster Pool Namespace    ${pool_name}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -93,7 +93,7 @@ Create Floating IPs
     File Should Not Be Empty    ${osp_clouds_yaml}
     ${shell_script} =     Set Variable     ${CURDIR}/OSP/create_fips.sh
     ${result} 	Run Process 	sh     ${shell_script}    ${cluster_name}    ${infrastructure_configurations}[aws_domain]
-    ...    ${infrastructure_configurations}[osp_network]    ${artifacts_dir}/    shell=yes
+    ...    ${infrastructure_configurations}[osp_network]    ${infrastructure_configurations}[osp_cloud_name]    ${artifacts_dir}/    shell=yes
     Log    ${shell_script}:\n${result.stdout}\n${result.stderr}     console=True
     Should Be True    ${result.rc} == 0
     ${fips_file_to_export} =    Set Variable    ${artifacts_dir}/${cluster_name}.${infrastructure_configurations}[aws_domain].fips

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -336,11 +336,13 @@ Run And Watch Command
   ${proc_result} =	    Wait For Process    ${process_id}    timeout=3 secs
   Terminate Process    ${process_id}    kill=true
   Should Be Equal As Integers	    ${proc_result.rc}    0    msg=Error occured while running: ${command}
-  IF    "${output_should_contain}" != "${NONE}" 
-      Should Contain    ${process_log}    ${output_should_contain}
+  IF  "${output_should_contain}" != "${NONE}"
+    ${result} =    Run Process 	grep '${output_should_contain}' '${process_log}'    shell=yes
+    Should Be True    ${result.rc} == 0    msg='${process_log}' should contain '${output_should_contain}'
   END
-  IF    "${output_should_not_contain}" != "${NONE}" 
-      Should Not Contain    ${process_log}    ${output_should_not_contain}
+  IF  "${output_should_not_contain}" != "${NONE}"
+    ${result} =    Run Process 	grep -L '${output_should_not_contain}' '${process_log}' | grep .    shell=yes
+    Should Be True    ${result.rc} == 0    msg='${process_log}' should not contain '${output_should_not_contain}'
   END
   RETURN    ${proc_result.rc}
 
@@ -348,12 +350,12 @@ Check Process Output and Status
   [Documentation]    Helper keyward for 'Run And Watch Command', to tail proccess and check its status
   [Arguments]    ${process_id}
   Log To Console    .    no_newline=true
-  ${new_log_data} = 	Get File 	${process_log}
-  ${old_log_data} = 	Get File 	${temp_log}
-  ${last_line_index} =    Get Line Count    ${old_log_data}
-  @{new_lines} =    Split To Lines    ${new_log_data}    ${last_line_index}
+  ${log_data} = 	Get File 	${process_log}
+  ${temp_log_data} = 	Get File 	${temp_log}
+  ${last_line_index} =    Get Line Count    ${temp_log_data}
+  @{new_lines} =    Split To Lines    ${log_data}    ${last_line_index}
   FOR    ${line}    IN    @{new_lines}
       Log To Console    ${line}
   END
-  Create File    ${temp_log}    ${new_log_data}
+  Create File    ${temp_log}    ${log_data}
   Process Should Be Stopped	    ${process_id}


### PR DESCRIPTION
Hive templates for OCP install includes new flag to enable FIPS.
To enable it, add to infrastructure_configuration.yaml:
```
infrastructure_configurations:
  fips_validation: true
```

In addition:
- OCP on OSP task uses OS_CLOUD according to infrastructure configuration.
- Creating Floating IPs script is called with "Run and Watch Command" keyword.