### PR TITLE
Remove workaround for DS Project creation RHODS-8477

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -103,6 +103,15 @@ Create Data Science Project
     Click Button    ${GENERIC_CREATE_BTN_XP}
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${title}
+    ${open}=    Run Keyword And Return Status    Wait Until Project Is Open    project_title=${title}
+    IF    ${open} == ${FALSE}
+        ${is_home_open}=    Is Data Science Projects Page Open
+        IF    ${is_home_open} == ${TRUE}
+            Log    message=After DS Project ${title} creation, user did not get redirected to details page...(RHODS-8477)
+            ...    level=WARN
+            Fail
+        END
+    END
 
 Validate Generated Resource Name
     [Documentation]    Checks if the generated resource name matches the expected validation regex

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -102,18 +102,7 @@ Create Data Science Project
     Wait Until Element Is Enabled    ${GENERIC_CREATE_BTN_XP}
     Click Button    ${GENERIC_CREATE_BTN_XP}
     Wait Until Generic Modal Disappears
-    ${open}=    Run Keyword And Return Status    Wait Until Project Is Open    project_title=${title}
-    IF    ${open} == ${FALSE}
-        ${is_home_open}=    Is Data Science Projects Page Open
-        IF    ${is_home_open} == ${TRUE}
-            Log    message=After DS Project ${title} creation, user did not get redirected to details page...
-            ...    level=WARN
-            Reload Page
-            Wait Until Page Contains Element    ${DS_PROJECT_XP}  timeout=30s
-            Wait Until Project Is Listed    project_title=${title}
-            Open Data Science Project Details Page    project_title=${title}
-        END
-    END
+    Wait Until Project Is Open    project_title=${title}
 
 Validate Generated Resource Name
     [Documentation]    Checks if the generated resource name matches the expected validation regex


### PR DESCRIPTION
In RHODS 1.28 the issue with user not being redirected to DS Project page has been fixed. Hence, it's worth to remove the workaround in the code (even if it was conditional)