### PR TITLE
Enhance OpenShift Pipelines installation depending on environment + pipeline route bugfix

### DIFF
--- a/ods_ci/tests/Resources/Files/data-science-pipelines-sample.yaml
+++ b/ods_ci/tests/Resources/Files/data-science-pipelines-sample.yaml
@@ -1,7 +1,7 @@
 apiVersion: datasciencepipelinesapplications.opendatahub.io/v1alpha1
 kind: DataSciencePipelinesApplication
 metadata:
-  name: sample
+  name: pipelines-definition
 spec:
   # One of minio or externalStorage must be specified for objectStorage
   # This example illustrates minimal deployment with minio
@@ -11,7 +11,3 @@ spec:
     minio:
       # Image field is required
       image: 'quay.io/opendatahub/minio:RELEASE.2019-08-14T20-37-41Z-license-compliance'
-  # Optional
-  mlpipelineUI:
-    # Image field is required
-    image: 'quay.io/opendatahub/odh-ml-pipelines-frontend-container:beta-ui'

--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -319,7 +319,7 @@ Fetch Project Pods Info
     RETURN    @{project_pods_info}
 
 Fetch Cluster Platform Type
-    [Documentation]  Fetches the platform type of the cluster
+    [Documentation]  Fetches the platform type of the cluster (AWS, GCP, OpenStack, ...)
     ...    Args:
     ...        None
     ...    Returns:

--- a/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
+++ b/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
@@ -46,7 +46,7 @@ Install Red Hat OpenShift Pipelines
     Log    message=Installing OpenShift Pipelines operator: ${openshift_pipelines_version} (${platform} ${oc_version} Self-Managed: ${is_self_managed})
     ...    console=True
 
-    ${return_code}    ${output}=    Run And Return Rc And Output
+    ${return_code}=    Run And Return Rc
     ...    sed -i "s,channel: .*,channel: ${openshift_pipelines_version},g" ${EXECDIR}/${REDHAT_OPENSHIFT_PIPELINES_YAML}
     Should Be Equal As Integers    ${return_code}    0
     Oc Apply    kind=Subscription    src=${REDHAT_OPENSHIFT_PIPELINES_YAML}

--- a/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
+++ b/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
@@ -1,5 +1,6 @@
 *** Settings ***
 Documentation       Test suite for OpenShift Pipeline
+
 Resource            ../../RHOSi.resource
 Resource            ../../ODS.robot
 Resource            ../../Common.robot
@@ -10,17 +11,44 @@ Library             ../../libs/DataSciencePipelinesAPI.py
 
 
 *** Variables ***
-${REDHAT_OPENSHIFT_PIPELINES_YAML}=            ods_ci/tests/Resources/Files/redhat-openshift-pipelines.yaml
-&{OPENSHIFT_PIPELINES_VERSION}=                4.10=pipelines-1.8   4.11=pipelines-1.9  4.12=pipelines-1.10   4.13=pipelines-1.10  #robocop:disable
+${REDHAT_OPENSHIFT_PIPELINES_YAML}      ods_ci/tests/Resources/Files/redhat-openshift-pipelines.yaml
 
 
 *** Keywords ***
+# robocop: disable=too-many-calls-in-keyword,line-too-long
 Install Red Hat OpenShift Pipelines
-    [Documentation]    Install Red Hat OpenShift Pipelines
-    ${oc_vesrion}    Get OpenShift Version
-    ${pipeline}   Get From Dictionary     ${OPENSHIFT_PIPELINES_VERSION}    ${oc_vesrion}
-    ${return_code}    ${output}    Run And Return Rc And Output    sed -i "s,channel: .*,channel: ${pipeline},g" ${EXECDIR}/${REDHAT_OPENSHIFT_PIPELINES_YAML}    #robocop:disable
-    Should Be Equal As Integers	 ${return_code}	 0
+    [Documentation]    Install Red Hat OpenShift Pipelines operator depending on
+    ...     OpenShift version, platform and RHODS flavor (Managed/Self-Managed):
+    ...     - OpenShift 4.10:                  OpenShift Pipelines 1.8
+    ...     - OpenShift 4.11:                  OpenShift Pipelines 1.9
+    ...     - OpenShift >= 4.12 (AWS and GCP): OpenShift Pipelines 1.10 / 1.11 (depending on platform and flavor)
+    ...     - OpenShift >= 4.12 (other):       OpenShift Pipelines 1.11
+    ${oc_version}=    Get OpenShift Version
+    ${is_self_managed}=    Is RHODS Self-Managed
+    ${platform}=    Fetch Cluster Platform Type
+    IF    ${oc_version} == "4.10"
+        ${openshift_pipelines_version}=    Set Variable    pipelines-1.8"
+    ELSE IF    ${oc_version} == "4.11"
+        ${openshift_pipelines_version}=    Set Variable    pipelines-1.9
+    ELSE
+        IF    ${is_self_managed} == ${TRUE} and "${platform}" == "AWS"
+            ${openshift_pipelines_version}=    Set Variable    pipelines-1.10
+        ELSE IF    ${is_self_managed} == ${FALSE} and "${platform}" == "AWS"
+            ${openshift_pipelines_version}=    Set Variable    pipelines-1.11
+        ELSE IF    ${is_self_managed} == ${TRUE} and "${platform}" == "GCP"
+            ${openshift_pipelines_version}=    Set Variable    pipelines-1.11
+        ELSE IF    ${is_self_managed} == ${FALSE} and "${platform}" == "GCP"
+            ${openshift_pipelines_version}=    Set Variable    pipelines-1.10
+        ELSE
+            ${openshift_pipelines_version}=    Set Variable    pipelines-1.11
+        END
+    END
+    Log    message=Installing OpenShift Pipelines operator: ${openshift_pipelines_version} (${platform} ${oc_version} Self-Managed: ${is_self_managed})
+    ...    console=True
+
+    ${return_code}    ${output}=    Run And Return Rc And Output
+    ...    sed -i "s,channel: .*,channel: ${openshift_pipelines_version},g" ${EXECDIR}/${REDHAT_OPENSHIFT_PIPELINES_YAML}
+    Should Be Equal As Integers    ${return_code}    0
     Oc Apply    kind=Subscription    src=${REDHAT_OPENSHIFT_PIPELINES_YAML}
-    ${pod_count}    Wait Until OpenShift Pipelines Operator Is Deployed
-    Should Be True    ${pod_count} == 1    All the pods were created
+    ${pod_count}=    Wait Until OpenShift Pipelines Operator Is Deployed
+    Should Be True    ${pod_count} == 1    msg=Error installing OpenShift Pipelines operator

--- a/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
+++ b/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
@@ -18,11 +18,14 @@ ${REDHAT_OPENSHIFT_PIPELINES_YAML}      ods_ci/tests/Resources/Files/redhat-open
 # robocop: disable=too-many-calls-in-keyword,line-too-long
 Install Red Hat OpenShift Pipelines
     [Documentation]    Install Red Hat OpenShift Pipelines operator depending on
-    ...     OpenShift version, platform and RHODS flavor (Managed/Self-Managed):
+    ...     OpenShift version, platform (AWS/GCP/...) and RHODS flavor (Managed/Self-Managed) with the objective of
+    ...     testing all the operator versions without having to test all possible combinations:
     ...     - OpenShift 4.10:                  OpenShift Pipelines 1.8
     ...     - OpenShift 4.11:                  OpenShift Pipelines 1.9
     ...     - OpenShift >= 4.12 (AWS and GCP): OpenShift Pipelines 1.10 / 1.11 (depending on platform and flavor)
     ...     - OpenShift >= 4.12 (other):       OpenShift Pipelines 1.11
+    ...     Note: the complete operator compatiblity matrix is published at
+    ...      https://docs.openshift.com/container-platform/4.13/cicd/pipelines/op-release-notes.html
     ${oc_version}=    Get OpenShift Version
     ${is_self_managed}=    Is RHODS Self-Managed
     ${platform}=    Fetch Cluster Platform Type

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
@@ -34,11 +34,12 @@ Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     New Project    project-redirect-http
     Install DataSciencePipelinesApplication CR    project-redirect-http
     ${status}    Login And Wait Dsp Route    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
-    ...         project-redirect-http    ds-pipeline-ui-sample
+    ...         project-redirect-http    ds-pipeline-pipelines-definition
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long
     ${url}    Do Http Request    apis/v1beta1/runs
     Should Start With    ${url}    https
     Remove Pipeline Project    project-redirect-http
+
 
 *** Keywords ***
 End To End Pipeline Workflow Via Api
@@ -47,7 +48,7 @@ End To End Pipeline Workflow Via Api
     Remove Pipeline Project    ${project}
     New Project    ${project}
     Install DataSciencePipelinesApplication CR    ${project}
-    ${status}    Login And Wait Dsp Route    ${username}    ${password}    ${project}    ds-pipeline-ui-sample
+    ${status}    Login And Wait Dsp Route    ${username}    ${password}    ${project}    ds-pipeline-pipelines-definition
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long
     ${pipeline_id}    Create Pipeline    ${URL_TEST_PIPELINE_RUN_YAML}
     ${run_id}    Create Run    ${pipeline_id}

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/432__data-science-pipelines-tekton.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/432__data-science-pipelines-tekton.robot
@@ -22,10 +22,14 @@ Verify Ods Users Can Create And Run A Data Science Pipeline Using The Kfp_tekton
     [Tags]      Sanity
     ...         Tier1
     ...         ODS-2203
-    End To End Pipeline Workflow Using Kfp_tekton    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    pipelineskfptekton1    # robocop: disable:line-too-long
+    End To End Pipeline Workflow Using Kfp_tekton
+    ...    username=${TEST_USER.USERNAME}
+    ...    password=${TEST_USER.PASSWORD}
+    ...    project=pipelineskfptekton1
 
 
 *** Keywords ***
+# robocop: disable:line-too-long
 End To End Pipeline Workflow Using Kfp Tekton
     [Documentation]    Create, run and double check the pipeline result using Kfp_tekton python package. In the end,
     ...    clean the pipeline resources.
@@ -33,10 +37,12 @@ End To End Pipeline Workflow Using Kfp Tekton
     Remove Pipeline Project    ${project}
     New Project    ${project}
     Install DataSciencePipelinesApplication CR    ${project}
-    ${status}    Login And Wait Dsp Route    ${username}    ${password}    ${project}    ds-pipeline-ui-sample
-    Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long
-    ${result}    Kfp Tekton Create Run From Pipeline Func    ${username}    ${password}    ${project}    ds-pipeline-ui-sample    flip_coin.py    flipcoin_pipeline    # robocop: disable:line-too-long
-    ${run_status}   Kfp Tekton Wait For Run Completion    ${username}    ${password}    ${project}    ds-pipeline-ui-sample    ${result}
+    ${status}    Login And Wait Dsp Route    ${username}    ${password}    ${project}    ds-pipeline-pipelines-definition
+    Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working
+    ${result}    Kfp Tekton Create Run From Pipeline Func    ${username}    ${password}    ${project}
+    ...    ds-pipeline-pipelines-definition    flip_coin.py    flipcoin_pipeline
+    ${run_status}   Kfp Tekton Wait For Run Completion    ${username}    ${password}    ${project}
+    ...    ds-pipeline-pipelines-definition    ${result}
     Should Be True    '${run_status}' == 'Completed'    Pipeline run doesn't have Completed status
     [Teardown]    Remove Pipeline Project    ${project}
 


### PR DESCRIPTION
- When installing Red Hat OpenShift Pipelines operator, select version depending on OpenShift version, platform (AWS/GCP/...) and RHODS flavor (Managed/Self-Managed)
- Do not deploy KubeflowUI when creating a pipeline server with the sample DataSciencePipelineApplication
- Fix route used when creating a pipeline server with the sample DataSciencePipelineApplication (same as in PR #809)