### PR TITLE
Validates OdhDashboardConfig in 'Is RHODS Installed' keyword

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
@@ -3,6 +3,7 @@ Is RHODS Installed
   IF  "${cluster_type}" == "selfmanaged"
       ${result}=  Run Keyword And Return Status
       ...  Run Keywords
+      ...  Oc Get  kind=OdhDashboardConfig  namespace=redhat-ods-applications  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-monitoring  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-applications  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-operator  AND
@@ -11,6 +12,7 @@ Is RHODS Installed
   ELSE IF  "${cluster_type}" == "managed"
       ${result}=  Run Keyword And Return Status
       ...  Run Keywords
+      ...  Oc Get  kind=OdhDashboardConfig  namespace=redhat-ods-applications  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-monitoring  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-applications  AND
       ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-operator  AND


### PR DESCRIPTION
`Is RHODS Installed` only checks if all RHODS namespaces exist
(redhat-ods-monitoring, redhat-ods-applications, redhat-ods-operator),
but not if RHODS actually installed.

This can lead to false positive, 
for example when RHODS operator was uninstalled in Openshift UI, 
while RHODS namespaces still exist.

Validating OdhDashboardConfig existence 
can prevent such false positive of 'Is RHODS Installed' keyword.