### PR TITLE
Clone OLM Install repo if uninstalling either with CLI or Operatorhub

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -59,6 +59,7 @@ Uninstall RHODS In OSD
 
 Uninstall RHODS In Self Managed Cluster
   [Documentation]  Uninstall rhods from self-managed cluster
+  Clone OLM Install Repo
   IF  "${INSTALL_TYPE}" == "Cli"
       Uninstall RHODS In Self Managed Cluster Using CLI
   ELSE IF  "${INSTALL_TYPE}" == "OperatorHub"
@@ -73,7 +74,6 @@ RHODS Operator Should Be Uninstalled
 
 Uninstall RHODS In Self Managed Cluster Using CLI
   [Documentation]   UnInstall rhods on self-managed cluster using cli
-  Clone OLM Install Repo
   ${return_code}    Run and Watch Command
   ...    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator -a "authorino serverless servicemesh servicemesh3 clusterobservability tempo opentelemetry kueue certmanager cma connectivitylink leaderworkerset jobset"
   ...    timeout=30 min

--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -8,14 +8,14 @@ Library          OperatingSystem
 Library          String
 
 ***Variables***
-${cluster_type}                 selfmanaged
-${image_url}                    ${EMPTY}
-${TEST_ENV}                     AWS
-${INSTALL_TYPE}                 OperatorHub
-${UPDATE_CHANNEL}               odh-nightlies
-${RHODS_VERSION}                None
-${CATALOG_SOURCE}               redhat-operators
-${RHOAI_VERSION}                ${EMPTY}
+${cluster_type}              selfmanaged
+${image_url}                 ${EMPTY}
+${RHODS_OSD_INSTALL_REPO}    None
+@{SUPPORTED_TEST_ENV}        AWS   GCP   PSI
+${TEST_ENV}                  AWS
+${INSTALL_TYPE}              OperatorHub
+${UPDATE_CHANNEL}            beta
+${OLM_DIR}                   olminstall
 
 *** Tasks ***
 Can Install RHODS Operator

--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -8,14 +8,14 @@ Library          OperatingSystem
 Library          String
 
 ***Variables***
-${cluster_type}              selfmanaged
-${image_url}                 ${EMPTY}
-${RHODS_OSD_INSTALL_REPO}    None
-@{SUPPORTED_TEST_ENV}        AWS   GCP   PSI
-${TEST_ENV}                  AWS
-${INSTALL_TYPE}              OperatorHub
-${UPDATE_CHANNEL}            beta
-${OLM_DIR}                   olminstall
+${cluster_type}                 selfmanaged
+${image_url}                    ${EMPTY}
+${TEST_ENV}                     AWS
+${INSTALL_TYPE}                 OperatorHub
+${UPDATE_CHANNEL}               odh-nightlies
+${RHODS_VERSION}                None
+${CATALOG_SOURCE}               redhat-operators
+${RHOAI_VERSION}                ${EMPTY}
 
 *** Tasks ***
 Can Install RHODS Operator


### PR DESCRIPTION
This is required since "Clone OLM Install" was not called before
"Uninstall RHODS In Self Managed Cluster For Operatorhub".
This can cause "Install Teardown" to fail on:
`Mentioned directory olminstall is not present. Kindly verify if provided folder name is correct`

By moving "Clone OLM Install" into "Uninstall RHODS In Self Managed Cluster"
the required directory "olminstall" is created in advanced, for both CLI or Operatorhub installations.

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/82450d53-31fd-4d01-b1a6-d729953bc9fb)
