### PR TITLE
Add support to enalbe disable compoent

### DIFF
--- a/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
+++ b/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
@@ -1,19 +1,34 @@
 import argparse
 import yaml
+import os
 
 
 def toggle_components(yaml_file, component_states):
     "This function will enable and disable the component"
-    with open(yaml_file, "r") as f:
-        data_science_cluster = yaml.safe_load(f)
+    if os.path.exists(yaml_file):
+        with open(yaml_file, "r") as f:
+            data_science_cluster = yaml.safe_load(f)
+    else:
+        # If YAML file does not exist, create a new DataScienceCluster YAML
+        data_science_cluster = {
+            "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
+            "kind": "DataScienceCluster",
+            "metadata": {"name": "dsc"},
+            "spec": {"components": {}},
+        }
 
     components = data_science_cluster["spec"]["components"]
-    for component, enabled in component_states.items():
-        if component in components:
-            components[component]["enabled"] = enabled
+    for component in components:
+        if component in component_states:
+            components[component]["enabled"] = component_states[component]
         else:
-            # If component is not present, add it to the YAML
-            components[component] = {"enabled": enabled}
+            # If component is not present, add it to the YAML with default state (False)
+            components[component] = {"enabled": False}
+
+    for component in component_states:
+        if component not in components:
+            # Add the component with its state to the YAML
+            components[component] = {"enabled": component_states[component]}
 
     with open(yaml_file, "w") as f:
         yaml.dump(data_science_cluster, f)

--- a/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
+++ b/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
@@ -1,41 +1,50 @@
 import argparse
 import yaml
 
+
 def toggle_components(yaml_file, component_states):
     "This function will enable and disable the component"
-    with open(yaml_file, 'r') as f:
+    with open(yaml_file, "r") as f:
         data_science_cluster = yaml.safe_load(f)
 
-    components = data_science_cluster['spec']['components']
+    components = data_science_cluster["spec"]["components"]
     for component, enabled in component_states.items():
         if component in components:
-            components[component]['enabled'] = enabled
+            components[component]["enabled"] = enabled
         else:
             # If component is not present, add it to the YAML
-            components[component] = {'enabled': enabled}
+            components[component] = {"enabled": enabled}
 
-    with open(yaml_file, 'w') as f:
+    with open(yaml_file, "w") as f:
         yaml.dump(data_science_cluster, f)
 
+
 def main():
-    parser = argparse.ArgumentParser(description='Toggle components in DataScienceCluster YAML.')
-    parser.add_argument('yaml_file', type=str, help='Path to the YAML file')
+    parser = argparse.ArgumentParser(
+        description="Toggle components in DataScienceCluster YAML."
+    )
+    parser.add_argument("yaml_file", type=str, help="Path to the YAML file")
 
     # Dynamic component states as a single command-line argument in the format: --component component1:state1,component2:state2,...
-    parser.add_argument('--components', type=str, help='Comma-separated list of components and their states (component1:state1,component2:state2,...)')
+    parser.add_argument(
+        "--components",
+        type=str,
+        help="Comma-separated list of components and their states (component1:state1,component2:state2,...)",
+    )
 
     args = parser.parse_args()
 
     # Parse and convert the component states argument into a dictionary
     component_states = {}
     if args.components:
-        components_list = args.components.split(',')
+        components_list = args.components.split(",")
         for component in components_list:
-            comp, state = component.split(':')
-            component_states[comp] = True if state.lower() == 'true' else False
+            comp, state = component.split(":")
+            component_states[comp] = True if state.lower() == "true" else False
 
     toggle_components(args.yaml_file, component_states)
     print("DataScienceCluster YAML has been updated.")
+
 
 if __name__ == "__main__":
     main()

--- a/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
+++ b/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
@@ -1,0 +1,41 @@
+import argparse
+import yaml
+
+def toggle_components(yaml_file, component_states):
+    "This function will enable and disable the component"
+    with open(yaml_file, 'r') as f:
+        data_science_cluster = yaml.safe_load(f)
+
+    components = data_science_cluster['spec']['components']
+    for component, enabled in component_states.items():
+        if component in components:
+            components[component]['enabled'] = enabled
+        else:
+            # If component is not present, add it to the YAML
+            components[component] = {'enabled': enabled}
+
+    with open(yaml_file, 'w') as f:
+        yaml.dump(data_science_cluster, f)
+
+def main():
+    parser = argparse.ArgumentParser(description='Toggle components in DataScienceCluster YAML.')
+    parser.add_argument('yaml_file', type=str, help='Path to the YAML file')
+
+    # Dynamic component states as a single command-line argument in the format: --component component1:state1,component2:state2,...
+    parser.add_argument('--components', type=str, help='Comma-separated list of components and their states (component1:state1,component2:state2,...)')
+
+    args = parser.parse_args()
+
+    # Parse and convert the component states argument into a dictionary
+    component_states = {}
+    if args.components:
+        components_list = args.components.split(',')
+        for component in components_list:
+            comp, state = component.split(':')
+            component_states[comp] = True if state.lower() == 'true' else False
+
+    toggle_components(args.yaml_file, component_states)
+    print("DataScienceCluster YAML has been updated.")
+
+if __name__ == "__main__":
+    main()

--- a/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
+++ b/ods_ci/utils/scripts/miscellaneous/dsc_ComponentOps.py
@@ -3,7 +3,7 @@ import yaml
 import os
 
 
-def toggle_components(yaml_file, component_states):
+def toggle_components(yaml_file, component_states, set_default=True):
     "This function will enable and disable the component"
     if os.path.exists(yaml_file):
         with open(yaml_file, "r") as f:
@@ -13,7 +13,7 @@ def toggle_components(yaml_file, component_states):
         data_science_cluster = {
             "apiVersion": "datasciencecluster.opendatahub.io/v1alpha1",
             "kind": "DataScienceCluster",
-            "metadata": {"name": "dsc"},
+            "metadata": {"name": "example"},
             "spec": {"components": {}},
         }
 
@@ -21,8 +21,8 @@ def toggle_components(yaml_file, component_states):
     for component in components:
         if component in component_states:
             components[component]["enabled"] = component_states[component]
-        else:
-            # If component is not present, add it to the YAML with default state (False)
+        elif set_default:
+            # If component is not present and set_default is True, add it to the YAML with default state (False)
             components[component] = {"enabled": False}
 
     for component in component_states:
@@ -47,6 +47,13 @@ def main():
         help="Comma-separated list of components and their states (component1:state1,component2:state2,...)",
     )
 
+    # Optional argument to skip setting default value for unspecified components
+    parser.add_argument(
+        "--no-default",
+        action="store_true",
+        help="Do not set default value for unspecified components",
+    )
+
     args = parser.parse_args()
 
     # Parse and convert the component states argument into a dictionary
@@ -57,7 +64,8 @@ def main():
             comp, state = component.split(":")
             component_states[comp] = True if state.lower() == "true" else False
 
-    toggle_components(args.yaml_file, component_states)
+    # Pass the set_default argument based on the --no-default parameter
+    toggle_components(args.yaml_file, component_states, not args.no_default)
     print("DataScienceCluster YAML has been updated.")
 
 


### PR DESCRIPTION
Usage
To use the script, execute it from the command line with the following format:

python yaml_component_tool.py <yaml_file> --components <component1>:<state1>,<component2>:<state2>,...
