### PR TITLE
Add new tests for WatsonX serving stack

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -5,7 +5,8 @@
             "models": {
                 "flan-t5-small-caikit": {
                     "generatedTokenCount":  5,
-                    "response_text": "74 degrees F"
+                    "response_text": "74 degrees F",
+                    "streamed_response_text":   "{'details':{}}{'tokens':[{'text':'▁','logprob':-1.6961849927902222}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.2507317066192627}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324553906917572}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.3610913753509521}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}"
                 },
                 "bloom-560m-caikit": {
                     "generatedTokenCount":  20,

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -110,7 +110,7 @@ Wait For Pods To Be Ready
     END
 
 Wait For Pods To Be Terminated
-    [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s
+    [Arguments]    ${label_selector}    ${namespace}    ${timeout}=180s
     Wait Until Keyword Succeeds    ${timeout}    3s
     ...    Check If Pod Exists    namespace=${namespace}    label_selector=${label_selector}
     ...    status_only=${FALSE}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -138,22 +138,23 @@ Get Pod Hardware Resources And Limits
     RETURN    ${resources}
 
 Container Hardware Resources Should Match Expected
-    [Arguments]    ${container_name}    ${pod_label_selector}    ${namespace}    ${exp_requests}=${EMPTY}    ${exp_limits}=${EMPTY}
+    [Arguments]    ${container_name}    ${pod_label_selector}    ${namespace}
+    ...            ${exp_requests}=${NONE}    ${exp_limits}=${NONE}
     ${resources_dict}=    Get Pod Hardware Resources And Limits    label_selector=${pod_label_selector}
     ...    namespace=${namespace}    container_name=${container_name}
-    IF    ${exp_requests} == &{EMPTY}
+    IF    ${exp_requests} == ${NONE}
         Dictionary Should Not Contain Key    ${resources_dict}    requests
     ELSE
         ${requests}=    Set Variable    ${resources_dict}[requests]
         FOR    ${index}    ${resource}    IN ENUMERATE    @{requests.keys()}
-            Should Be Equal As Strings    "${requests}[${resource}]"    ${exp_requests}[${resource}]
+            Should Be Equal As Strings    ${requests}[${resource}]    ${exp_requests}[${resource}]
         END
     END
-    IF    ${exp_limits} == &{EMPTY}
+    IF    ${exp_limits} == ${NONE}
         Dictionary Should Not Contain Key    ${resources_dict}    limits
     ELSE
         ${limits}=    Set Variable    ${resources_dict}[limits]
         FOR    ${index}    ${resource}    IN ENUMERATE    @{limits.keys()}
-            Should Be Equal As Strings    "${limits}[${resource}]"    ${exp_limits}[${resource}]
+            Should Be Equal As Strings    ${limits}[${resource}]    ${exp_limits}[${resource}]
         END
     END

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -123,3 +123,37 @@ Add Secret To Service Account
     ${rc}    ${out}=    Run And Return Rc And Output
     ...    oc patch sa ${sa_name} -n ${namespace} -p '{"secrets": [{"name": "${secret_name}"}]}'
     Should Be Equal As Integers    ${rc}    ${0}
+
+Get Pod Hardware Resources And Limits
+    [Arguments]    ${label_selector}    ${namespace}    ${container_name}=${NONE}
+    IF    "${container_name}" == "${NONE}"
+        ${rc}    ${resources}=    Run And Return Rc And Output
+        ...    oc get pods -l ${label_selector} -n ${namespace} -ojson | jq '.items[].spec.containers[] | .resources'
+    ELSE
+        ${rc}    ${resources}=    Run And Return Rc And Output
+        ...    oc get pods -l ${label_selector} -n ${namespace} -ojson | jq '.items[].spec.containers[] | select(.name=="${container_name}") | .resources'
+    END
+    Should Be Equal As Integers    ${rc}    ${0}
+    ${resources}=    Load Json String    ${resources}
+    RETURN    ${resources}
+
+Container Hardware Resources Should Match Expected
+    [Arguments]    ${container_name}    ${pod_label_selector}    ${namespace}    ${exp_requests}=${EMPTY}    ${exp_limits}=${EMPTY}
+    ${resources_dict}=    Get Pod Hardware Resources And Limits    label_selector=${pod_label_selector}
+    ...    namespace=${namespace}    container_name=${container_name}
+    IF    ${exp_requests} == &{EMPTY}
+        Dictionary Should Not Contain Key    ${resources_dict}    requests
+    ELSE
+        ${requests}=    Set Variable    ${resources_dict}[requests]
+        FOR    ${index}    ${resource}    IN ENUMERATE    @{requests.keys()}
+            Should Be Equal As Strings    "${requests}[${resource}]"    ${exp_requests}[${resource}]
+        END
+    END
+    IF    ${exp_limits} == &{EMPTY}
+        Dictionary Should Not Contain Key    ${resources_dict}    limits
+    ELSE
+        ${limits}=    Set Variable    ${resources_dict}[limits]
+        FOR    ${index}    ${resource}    IN ENUMERATE    @{limits.keys()}
+            Should Be Equal As Strings    "${limits}[${resource}]"    ${exp_limits}[${resource}]
+        END
+    END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -173,7 +173,7 @@ Click Minus Button
 Query Model With GRPCURL
     [Arguments]    ${host}    ${port}    ${endpoint}    ${json_body}
     ...            ${json_header}=${NONE}    ${insecure}=${FALSE}    ${background}=${NONE}
-    ...            &{args}
+    ...            ${skip_res_json}=${FALSE}    &{args}
     ${cmd}=    Set Variable    grpcurl -d ${json_body}
     IF    $json_header != None
         ${cmd}=    Catenate    ${cmd}    -H ${json_header}
@@ -201,9 +201,14 @@ Query Model With GRPCURL
           # Log    ${query_process.stdout}    console=yes
           Log    ${response}    console=yes
           # ${json_res}=    Load Json String    ${query_process.stdout}
-          ${json_res}=    Load Json String    ${response}
-          # ...    strict=False
-          RETURN    ${json_res}
+          IF    ${skip_res_json} == ${TRUE}
+            Log    ${response}
+            RETURN    ${response}
+          ELSE
+            ${json_res}=    Load Json String    ${response}
+            # ...    strict=False
+            RETURN    ${json_res}
+          END
     ELSE
           ${rc}    ${response}=    Run And Return Rc And Output    ${cmd}&
           Run Keyword And Continue On Failure    Should Be Equal As Integers    ${rc}    ${0}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -213,3 +213,10 @@ Query Model With GRPCURL
           ${rc}    ${response}=    Run And Return Rc And Output    ${cmd}&
           Run Keyword And Continue On Failure    Should Be Equal As Integers    ${rc}    ${0}
     END
+
+Enable Toleration Feature In KNativeServing
+    [Documentation]    Enables the usage of node tolerations in inference services
+    [Arguments]    ${knative_serving_ns}
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    oc patch configmap config-features -n ${knative_serving_ns} --type=merge -p '{"data":{"kubernetes.podspec-tolerations": "enabled"}}'
+    Should Be Equal As Integers    ${rc}    ${0}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -271,7 +271,7 @@ Deploy Model Via CLI
 Get KServe Inference Host Via CLI
     [Arguments]    ${isvc_name}    ${namespace}
     ${rc}    ${ksvc_host}=    Run And Return Rc And Output
-    ...    oc get ksvc ${isvc_name}-predictor -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
+    ...    oc get ksvc ${isvc_name}-predictor-default -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
     Should Be Equal As Integers    ${rc}    ${0}
     Should Not Be Empty    ${ksvc_host}
     RETURN    ${ksvc_host}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -255,8 +255,13 @@ Remove Namespace From ServiceMeshMemberRoll
     ${rc}    ${ns_idx}=    Run And Return Rc And Output
     ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members | map(. == "${namespace}") | index(true)'
     Should Be Equal As Integers    ${rc}    ${0}
-    ${rc}    ${out}=    Run And Return Rc And Output    oc patch smmr/default -n ${servicemesh_ns} --type='json' -p="[{'op': 'remove', 'path': '/spec/members/${ns_idx}'}]"
-    Should Be Equal As Integers    ${rc}    ${0}
+    IF    "${ns_idx}" == "null"
+        Log    message=${namespace} was not in the SMMR..
+        ...    level=WARN
+    ELSE
+        ${rc}    ${out}=    Run And Return Rc And Output    oc patch smmr/default -n ${servicemesh_ns} --type='json' -p="[{'op': 'remove', 'path': '/spec/members/${ns_idx}'}]"
+        Should Be Equal As Integers    ${rc}    ${0}
+    END
 
 Deploy Model Via CLI
     [Documentation]    Deploys a model using Model Serving feature by applying the InfereceService

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -315,3 +315,17 @@ Set Model Hardware Resources
     Log    ${body}
     ${rc}    ${out}=    Run And Return Rc And Output    oc patch isvc ${model_name} -n ${namespace} --type=merge -p '${body}'
     Should Be Equal As Integers    ${rc}    ${0}
+
+Model Pod Should Be Scheduled On A GPU Node
+    [Documentation]    Checks that the pods with the given ${label_selector} are actually scheduled on
+    ...                a GPU node
+    [Arguments]    ${label_selector}    ${namespace}
+    ${pods}=    Oc Get    kind=Pod    namespace=${namespace}
+    ...    label_selector=${label_selector}
+    FOR    ${index}    ${pod}    IN ENUMERATE    @{pods}
+        Log    ${index}: ${pod}[spec][nodeName]
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    oc get node ${pod}[spec][nodeName] -ojson | jq '.metadata.labels."nvidia.com/gpu.present"'
+        Should Be Equal As Integers    ${rc}    ${0}
+        Should Be Equal As Strings    ${out}    "true"
+    END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -271,7 +271,8 @@ Deploy Model Via CLI
 Get KServe Inference Host Via CLI
     [Arguments]    ${isvc_name}    ${namespace}
     ${rc}    ${ksvc_host}=    Run And Return Rc And Output
-    ...    oc get ksvc ${isvc_name}-predictor -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
+    ...    oc get isvc ${isvc_name} -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
+    # ...    oc get ksvc ${isvc_name}-predictor -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
     Should Be Equal As Integers    ${rc}    ${0}
     Should Not Be Empty    ${ksvc_host}
     RETURN    ${ksvc_host}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -44,7 +44,7 @@ Open Model Serving Home Page
 
 Serve Model
     [Documentation]    Deploys a model via the Model Serving page (NOT the Model Server section of a DSP)
-    ...    the framework should be either "onnx" or "openvino_ir". 
+    ...    the framework should be either "onnx" or "openvino_ir".
     [Arguments]    ${project_name}    ${model_name}    ${framework}    ${data_connection_name}    ${model_path}
     ...    ${existing_data_connection}=${TRUE}    ${model_server}=Model Serving Test
     # TODO: Does not work if there's already a model deployed
@@ -56,7 +56,7 @@ Serve Model
     Select Model Server    ${model_server}
     Wait Until Page Contains Element    xpath://span[.="Model framework (name - version)"]
     Select Framework    ${framework}
-    IF    ${existing_data_connection}==${TRUE} 
+    IF    ${existing_data_connection}==${TRUE}
         # Select Radio Button    group_name=radiogroup    value=existing-data-connection-radio
         # Selected by default, let's skip for now
         Select Existing Data Connection    ${data_connection_name}
@@ -72,7 +72,7 @@ Serve Model
     Wait Until Page Does Not Contain    xpath://h1[.="Deploy model"]
 
 Select Project
-    [Documentation]    Selects a project in the "deploy model" modal. 
+    [Documentation]    Selects a project in the "deploy model" modal.
     ...    If the user has access to a single project or this is being done from within a DSP
     ...    there's no need to do anything but it checks that the project name is the expected one.
     [Arguments]    ${project_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -277,10 +277,16 @@ Get KServe Inference Host Via CLI
     Should Not Be Empty    ${ksvc_host}
     RETURN    ${ksvc_host}
 
+Get Current Revision ID
+    [Arguments]    ${model_name}    ${namespace}
+    ${rc}    ${id}=    Run And Return Rc And Output
+    ...    oc get pod -n ${namespace} -l serving.kserve.io/inferenceservice=${model_name} -ojson | jq '.items[0].metadata.labels."serving.knative.dev/revisionUID"' | tr -d '"'
+    Should Be Equal As Integers    ${rc}    ${0}
+    RETURN    ${id}
+
 Set Minimum Replicas Number
     [Arguments]    ${n_replicas}    ${model_name}    ${namespace}
-    ${rc}    ${old_revision_id}=    Run And Return Rc And Output
-    ...    oc get pod -n ${namespace} -l serving.kserve.io/inferenceservice=${model_name} -ojson | jq '.items[0].metadata.labels."serving.knative.dev/revisionUID"' | tr -d '"'
+    ${old_revision_id}=    Get Current Revision ID    model_name=${model_name}    namespace=${namespace}
     ${rc}    ${out}=    Run And Return Rc And Output
     ...    oc patch InferenceService ${model_name} -n ${namespace} --type=json -p="[{'op': 'replace', 'path': '/spec/predictor/minReplicas', 'value': ${n_replicas}}]"
     Should Be Equal As Integers    ${rc}    ${0}
@@ -294,4 +300,18 @@ Delete InfereceService
 Update Scale To Zero For Knative Serving
     [Arguments]    ${serving_name}    ${namespace}    ${status}
     ${rc}    ${out}=    Run And Return Rc And Output    oc patch KnativeServing ${serving_name} -n ${namespace} --type=json -p="[{'op': 'replace', 'path': '/spec/config/autoscaler/enable-scale-to-zero', 'value': '${status}'}]"
+    Should Be Equal As Integers    ${rc}    ${0}
+
+Set Model Hardware Resources
+    [Arguments]    ${model_name}    ${namespace}    ${requests}=&{EMPTY}    ${limits}=&{EMPTY}
+    IF    ${limits} == ${NONE}
+        ${limits}=    Set Variable    null
+    END
+    IF    ${requests} == ${NONE}
+        ${requests}=    Set Variable    null
+    END
+    ${body}=    Set Variable    {"spec":{"predictor": {"model": {"resources": {"requests": ${requests}, "limits": ${limits} }}}}}
+    ${body}=    Replace String    ${body}    '    "
+    Log    ${body}
+    ${rc}    ${out}=    Run And Return Rc And Output    oc patch isvc ${model_name} -n ${namespace} --type=merge -p '${body}'
     Should Be Equal As Integers    ${rc}    ${0}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -271,7 +271,7 @@ Deploy Model Via CLI
 Get KServe Inference Host Via CLI
     [Arguments]    ${isvc_name}    ${namespace}
     ${rc}    ${ksvc_host}=    Run And Return Rc And Output
-    ...    oc get ksvc ${isvc_name}-predictor-default -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
+    ...    oc get ksvc ${isvc_name}-predictor -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
     Should Be Equal As Integers    ${rc}    ${0}
     Should Not Be Empty    ${ksvc_host}
     RETURN    ${ksvc_host}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -56,7 +56,7 @@ Verify External Dependency Operators Can Be Deployed
 Verify User Can Serve And Query A Model
     [Tags]    ODS-2341    WatsonX
     [Setup]    Set Project And Runtime    namespace=${TEST_NS}
-    ${test_namespace}=    ${TEST_NS}
+    ${test_namespace}=    Set Variable     ${TEST_NS}
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
@@ -81,7 +81,7 @@ Verify User Can Serve And Query A Model
 Verify User Can Deploy Multiple Models In The Same Namespace
     [Tags]    ODS-2371    WatsonX
     [Setup]    Set Project And Runtime    namespace=${TEST_NS}-multisame
-    ${test_namespace}=    ${TEST_NS}-multisame
+    ${test_namespace}=    Set Variable     ${TEST_NS}-multisame
     ${model_one_name}=    Set Variable    bloom-560m-caikit
     ${model_two_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${model_one_name}    ${model_two_name}
@@ -183,7 +183,7 @@ Verify Model Pods Are Deleted When No Inference Service Is Present
 Verify User Can Change The Minimum Number Of Replicas For A Model
     [Tags]    ODS-2376    WatsonX
     [Setup]    Set Project And Runtime    namespace=${TEST_NS}-reps
-    ${test_namespace}=    ${TEST_NS}-reps
+    ${test_namespace}=    Set Variable     ${TEST_NS}-reps
     ${model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${model_name}
     Compile Inference Service YAML    isvc_name=${model_name}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -56,30 +56,32 @@ Verify External Dependency Operators Can Be Deployed
 Verify User Can Serve And Query A Model
     [Tags]    ODS-2341    WatsonX
     [Setup]    Set Project And Runtime    namespace=${TEST_NS}
+    ${test_namespace}=    ${TEST_NS}
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${FLAN_STORAGE_URI}
     Deploy Model Via CLI    isvc_filepath=${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
-    ...    namespace=${TEST_NS}
-    ${host}=    Get KServe Inference Host Via CLI    isvc_name=${flan_model_name}   namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
+    ${host}=    Get KServe Inference Host Via CLI    isvc_name=${flan_model_name}   namespace=${test_namespace}
     ${body}=    Set Variable    '{"text": "${EXP_RESPONSES}[queries][0][query_text]"}'
     ${header}=    Set Variable    'mm-model-id: ${flan_model_name}'
     Query Models And Check Responses Multiple Times    models_names=${models_names}
     ...    endpoint=${CAIKIT_ALLTOKENS_ENDPOINT}    n_times=1
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Query Models And Check Responses Multiple Times    models_names=${models_names}
     ...    endpoint=${CAIKIT_STREAM_ENDPOINT}    n_times=1    streamed_response=${TRUE}
-    ...    namespace=${TEST_NS}
-    [Teardown]    Clean Up Test Project    test_ns=${TEST_NS}
+    ...    namespace=${test_namespace}
+    [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}
 
 Verify User Can Deploy Multiple Models In The Same Namespace
     [Tags]    ODS-2371    WatsonX
-    [Setup]    Set Project And Runtime    namespace=${TEST_NS}
+    [Setup]    Set Project And Runtime    namespace=${TEST_NS}-multisame
+    ${test_namespace}=    ${TEST_NS}-multisame
     ${model_one_name}=    Set Variable    bloom-560m-caikit
     ${model_two_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${model_one_name}    ${model_two_name}
@@ -87,19 +89,19 @@ Verify User Can Deploy Multiple Models In The Same Namespace
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${BLOOM_STORAGE_URI}
     Deploy Model Via CLI    isvc_filepath=${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Compile Inference Service YAML    isvc_name=${model_two_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${FLAN_STORAGE_URI}
     Deploy Model Via CLI    isvc_filepath=${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_one_name}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_two_name}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=10
-    ...    namespace=${TEST_NS}
-    [Teardown]    Clean Up Test Project    test_ns=${TEST_NS}
+    ...    namespace=${test_namespace}
+    [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}
 
 Verify User Can Deploy Multiple Models In Different Namespaces
@@ -180,7 +182,8 @@ Verify Model Pods Are Deleted When No Inference Service Is Present
 
 Verify User Can Change The Minimum Number Of Replicas For A Model
     [Tags]    ODS-2376    WatsonX
-    [Setup]    Set Project And Runtime    namespace=${TEST_NS}
+    [Setup]    Set Project And Runtime    namespace=${TEST_NS}-reps
+    ${test_namespace}=    ${TEST_NS}-reps
     ${model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${model_name}
     Compile Inference Service YAML    isvc_name=${model_name}
@@ -188,28 +191,28 @@ Verify User Can Change The Minimum Number Of Replicas For A Model
     ...    model_storage_uri=${FLAN_STORAGE_URI}
     ...    min_replicas=1
     Deploy Model Via CLI    isvc_filepath=${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${TEST_NS}    exp_replicas=1
+    ...    namespace=${test_namespace}    exp_replicas=1
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=3
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     ${rev_id}=    Set Minimum Replicas Number    n_replicas=3    model_name=${model_name}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Terminated    label_selector=serving.knative.dev/revisionUID=${rev_id}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${TEST_NS}    exp_replicas=3
+    ...    namespace=${test_namespace}    exp_replicas=3
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=3
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     ${rev_id}=    Set Minimum Replicas Number    n_replicas=1    model_name=${model_name}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Terminated    label_selector=serving.knative.dev/revisionUID=${rev_id}
-    ...    namespace=${TEST_NS}
+    ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${TEST_NS}    exp_replicas=1
+    ...    namespace=${test_namespace}    exp_replicas=1
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=3
-    ...    namespace=${TEST_NS}
-    [Teardown]   Clean Up Test Project    test_ns=${TEST_NS}
+    ...    namespace=${test_namespace}
+    [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}
 
 Verify User Can Autoscale Using Concurrency
@@ -376,7 +379,7 @@ Clean Up Test Project
     ...    servicemesh_ns=${SERVICEMESH_CR_NS}
     ${rc}    ${out}=    Run And Return Rc And Output    oc delete project ${test_ns}
     Should Be Equal As Integers    ${rc}    ${0}
-    ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=120s
+    ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=300s
     Should Be Equal As Integers    ${rc}    ${0}
 
 Load Expected Responses

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -750,6 +750,7 @@ Compile And Query LLM model
     ${header}=    Set Variable    'mm-model-id: ${model_name}'
     IF   '${multiple_query}' != '${EMPTY}'
           Query Models And Check Responses Multiple Times    models_names=${models_name}    n_times=10
+          ...    namespace=${namespace}
     ELSE
           ${res}=      Query Model With GRPCURL   host=${host}    port=443
           ...    endpoint="caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict"

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -320,8 +320,8 @@ Verify User Can Set Requests And Limits For A Model
 
 Verify Model Can Be Serverd And Query On A GPU Node
     [Tags]    ODS-2381    WatsonX    Resource-GPU
-    [Setup]    Set Project And Runtime    namespace=watson-gpu
-    ${test_namespace}=    Set Variable    watson-gpu
+    [Setup]    Set Project And Runtime    namespace=watsonx-gpu
+    ${test_namespace}=    Set Variable    watsonx-gpu
     ${model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${model_name}
     ${requests}=    Create Dictionary    nvidia.com/gpu=1
@@ -341,7 +341,9 @@ Verify Model Can Be Serverd And Query On A GPU Node
     ...    namespace=${test_namespace}
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=2
     ...    namespace=${test_namespace}    endpoint=${CAIKIT_STREAM_ENDPOINT}
-    # check node label: nvidia.com/gpu.present=true
+    Model Pod Should Be Scheduled On A GPU Node    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}
+
 
 *** Keywords ***
 Install Model Serving Stack Dependencies
@@ -519,6 +521,7 @@ Deploy Serverless CRs
     ...    namespace=${SERVERLESS_CR_NS}
     Wait For Pods To Be Ready    label_selector=app=autoscaler
     ...    namespace=${SERVERLESS_CR_NS}
+    Enable Toleration Feature In KNativeServing    knative_serving_ns=${SERVERLESS_CR_NS}
 
 Configure KNative Gateways
     [Documentation]    Sets up the KNative (Serverless) Gateways

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -186,11 +186,11 @@ Verify User Can Change The Minimum Number Of Replicas For A Model
     Compile Inference Service YAML    isvc_name=${model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${FLAN_STORAGE_URI}
-    ...    min_replicas=2
+    ...    min_replicas=1
     Deploy Model Via CLI    isvc_filepath=${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
     ...    namespace=${TEST_NS}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${TEST_NS}    exp_replicas=2
+    ...    namespace=${TEST_NS}    exp_replicas=1
     Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=3
     ...    namespace=${TEST_NS}
     ${rev_id}=    Set Minimum Replicas Number    n_replicas=3    model_name=${model_name}
@@ -338,9 +338,9 @@ Verify Model Can Be Serverd And Query On A GPU Node
     ...    namespace=${test_namespace}    exp_requests=${requests}    exp_limits=${limits}
     Model Pod Should Be Scheduled On A GPU Node    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}
-    Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=2
+    Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=10
     ...    namespace=${test_namespace}
-    Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=2
+    Query Models And Check Responses Multiple Times    models_names=${models_names}    n_times=5
     ...    namespace=${test_namespace}    endpoint=${CAIKIT_STREAM_ENDPOINT}
     ...    streamed_response=${TRUE}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
@@ -376,7 +376,8 @@ Clean Up Test Project
     ...    servicemesh_ns=${SERVICEMESH_CR_NS}
     ${rc}    ${out}=    Run And Return Rc And Output    oc delete project ${test_ns}
     Should Be Equal As Integers    ${rc}    ${0}
-
+    ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=120s
+    Should Be Equal As Integers    ${rc}    ${0}
 
 Load Expected Responses
     [Documentation]    Loads the json file containing the expected answer for each


### PR DESCRIPTION
This PR is adding the following tests:
- StreamingOutput API (extending ODS-2341)
- Serve models in different namespaces of the same cluster (ODS-2378)
- Change Deployment HW requests (ODS-2380)
- Serve models with GPU (ODS-2381) 

Plus:
- replace ksvc URL with isvc URL (https://github.com/opendatahub-io/odh-model-controller/issues/59)
- remove manual add of NS to SMMR and add NS annotation (https://github.com/opendatahub-io/odh-model-controller/pull/65): this is currently broken due to a [product bug](https://github.com/opendatahub-io/odh-model-controller/issues/75). No change commited here yet)
- misc fixes to make remove gapes btw test cases when running in the same run