### PR TITLE
Use 'Create File From Template' KW in 'Compile Inference Service YAML'

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/caikit_isvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/caikit_isvc.yaml
@@ -12,7 +12,6 @@ spec:
     minReplicas: ${min_replicas}
     scaleTarget: ${scaleTarget}
     canaryTrafficPercent: ${canaryTrafficPercent}
-    minReplicas: ${min_replicas}
     serviceAccountName: ${sa_name}
     model:
       modelFormat:

--- a/ods_ci/tests/Resources/Files/llm/caikit_isvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/caikit_isvc.yaml
@@ -5,17 +5,17 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
-  name: {{INFERENCE_SERVICE_NAME}}
+  name: ${isvc_name}
 spec:
   predictor:
-    scaleMetric: {{SCALE_METRIC}}
-    minReplicas: {{MIN_REPLICAS}}
-    scaleTarget: {{SCALE_TARGET}}
-    canaryTrafficPercent: {{CanaryTrafficPercent}}
-    minReplicas: {{MIN_REPLICAS}}
-    serviceAccountName: {{SA_NAME}}
+    scaleMetric: ${scaleMetric}
+    minReplicas: ${min_replicas}
+    scaleTarget: ${scaleTarget}
+    canaryTrafficPercent: ${canaryTrafficPercent}
+    minReplicas: ${min_replicas}
+    serviceAccountName: ${sa_name}
     model:
       modelFormat:
         name: caikit
       runtime: caikit-runtime
-      storageUri: {{STORAGE_URI}}
+      storageUri: ${model_storage_uri}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -679,6 +679,7 @@ Compile Inference Service YAML
             Log    ${index}- ${resource}:${requests_dict}[${resource}]
             ${rc}    ${out}=    Run And Return Rc And Output
             ...    yq -i '.spec.predictor.model.resources.requests."${resource}" = "${requests_dict}[${resource}]"' ${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
+            Should Be Equal As Integers    ${rc}    ${0}    msg=${out}
         END
     END
     IF    ${limits_dict} != &{EMPTY}
@@ -687,6 +688,7 @@ Compile Inference Service YAML
             Log    ${index}- ${resource}:${limits_dict}[${resource}]
             ${rc}    ${out}=    Run And Return Rc And Output
             ...    yq -i '.spec.predictor.model.resources.limits."${resource}" = "${limits_dict}[${resource}]"' ${LLM_RESOURCES_DIRPATH}/caikit_isvc_filled.yaml
+            Should Be Equal As Integers    ${rc}    ${0}    msg=${out}
         END
     END
 


### PR DESCRIPTION
Replace the SED commands in 'Compile Inference Service YAML', 
with the Common keyword 'Create File From Template'.

This removes the multiple call to external SED commands (i.e. multiple processes), 
by invoking a single keyword to replace variables in the template: caikit_isvc.yaml