### PR TITLE
Update watsonX tests

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/peer_auth.yaml
+++ b/ods_ci/tests/Resources/Files/llm/peer_auth.yaml
@@ -6,3 +6,11 @@ metadata:
 spec:
   mtls:
     mode: STRICT
+  portLevelMtls:
+    '3000':
+      mode: PERMISSIVE
+    '8086':
+      mode: PERMISSIVE
+  selector:
+    matchLabels:
+      component: predictor

--- a/ods_ci/tests/Tests/100__deploy/100__installation/110__model_serving_watsonx.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/110__model_serving_watsonx.robot
@@ -9,7 +9,8 @@ Resource            ../../../Resources/Page/ODH/JupyterHub/HighAvailability.robo
 
 
 *** Variables ***
-${KSERVE_NS}=    kserve    # will be replaced by ${APPLICATIONS_NAMESPACE}
+${KSERVE_NS}=    ${APPLICATIONS_NAMESPACE}
+
 
 *** Test Cases ***
 Verify KServe Is Shipped
@@ -88,7 +89,7 @@ Verify Kserve Deployment
     @{kserve} =  Oc Get    kind=Pod    namespace=${KSERVE_NS}    api_version=v1
     ...    label_selector=app.kubernetes.io/part-of=kserve
     ${containerNames} =    Create List    manager
-    Verify Deployment    ${kserve}    1    1    ${containerNames}
+    Verify Deployment    ${kserve}    4    1    ${containerNames}
 
 ServingRuntime CustomResourceDefinition Should Exist
     [Documentation]    Checks that the ServingRuntime CRD is present

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -570,8 +570,8 @@ Set Up Test OpenShift Project
     END
     ${rc}    ${out}=    Run And Return Rc And Output    oc new-project ${test_ns}
     Should Be Equal As Numbers    ${rc}    ${0}
-    Add Peer Authentication    namespace=${test_ns}
-    Add Namespace To ServiceMeshMemberRoll    namespace=${test_ns}
+    # Add Peer Authentication    namespace=${test_ns}
+    # Add Namespace To ServiceMeshMemberRoll    namespace=${test_ns}
 
 Deploy Caikit Serving Runtime
     [Documentation]    Create the ServingRuntime CustomResource in the test ${namespace}.


### PR DESCRIPTION
This PR is fixing the following:
- ODS-2325: post-install test which needed to be fixed after changes in the product
- Test Setup of the main test suite, updating the SMMR tasks to work with metrics - we have also commented the lines, since odh-model-controller should now do it automatically once the isvc got created