### PR TITLE
[Fix] Update the expected CUDA version to 12.2

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
@@ -13,7 +13,7 @@ Force Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         minimal-gpu
-${EXPECTED_CUDA_VERSION} =  12.0
+${EXPECTED_CUDA_VERSION} =  12.2
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -15,7 +15,7 @@ Force Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         pytorch
-${EXPECTED_CUDA_VERSION} =  12.0
+${EXPECTED_CUDA_VERSION} =  12.2
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -16,7 +16,7 @@ Force Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         tensorflow
-${EXPECTED_CUDA_VERSION} =  12.0
+${EXPECTED_CUDA_VERSION} =  12.2
 
 
 *** Test Cases ***


### PR DESCRIPTION
After we moved from the GPU Add-on installation to the GPU operator installation, there is a different version of CUDA installed and provided to the affected JupyterLab Notebooks.