### PR TITLE
[Fix] Update version of numpy to 1.24.4

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
@@ -18,7 +18,7 @@ Verify Pytorch Can See GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
         # TODO: use Install And Import Package In JupyterLab after #202 is merged
-        Run Cell And Check For Errors    !pip install torch==1.8 numpy==1.19    timeout=300s
+        Run Cell And Check For Errors    !pip install torch==1.8 numpy==1.24.4    timeout=300s
     END
     Run Cell And Check Output
     ...    import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")


### PR DESCRIPTION
There was some issue when installing `numpy` with version fixed to 1.19.0 because of it's dependency on cython. Cython couldn't compile. Anyway, this `numpy` version isn't officially supported with Python 3.9 so we should update at least to v1.19.3 [1]. But since we're expecting to move to Python 3.11 soon, let's use v1.24.4 [2] which seems to be the latest one that supports Python 3.8 through 3.11.

I was also thinking about updating the `torch` dependency but it looks like recent version downloads much more dependencies resulting in extra download of almost 1.5 GB, so I kept the current version there for now.

[1] https://github.com/numpy/numpy/releases/tag/v1.19.3
[2] https://github.com/numpy/numpy/releases/tag/v1.24.4