### PR TITLE
Use Addon CatalogSource from openshift-marketplace

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
@@ -31,7 +31,7 @@ Is RHODS Installed
           ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-monitoring  AND
           ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-applications  AND
           ...  Oc Get  kind=Namespace  field_selector=metadata.name=redhat-ods-operator  AND
-          ...  Oc Get  kind=CatalogSource  namespace=redhat-ods-operator
+          ...  Oc Get  kind=CatalogSource  namespace=openshift-marketplace
           ...          field_selector=metadata.name=addon-managed-odh-catalog
       END
   END

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -68,7 +68,7 @@ Is RHODS Self-Managed
     ${is_managed} =    Run Keyword And Return Status    OpenshiftLibrary.Oc Get
     ...                                                      kind=CatalogSource
     ...                                                      name=addon-managed-odh-catalog
-    ...                                                      namespace=${OPERATOR_NAMESPACE}
+    ...                                                      namespace=openshift-marketplace
     Run Keyword And Return    Evaluate    not ${is_managed}
 
 Get MachineSets


### PR DESCRIPTION
The RHODS addon CatalogSource has moved to the openshift-marketplace namespace [1].

[1] https://gitlab.cee.redhat.com/data-hub/olminstall/-/merge_requests/30/