### PR TITLE
Bump kfp-tekton to 1.5.9

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesKfpTekton.py
+++ b/ods_ci/libs/DataSciencePipelinesKfpTekton.py
@@ -3,8 +3,6 @@ import importlib
 import json
 import os
 import sys
-from kfp_tekton.compiler.pipeline_utils import TektonPipelineConf
-import kfp_tekton
 from DataSciencePipelinesAPI import DataSciencePipelinesAPI
 from robotlibcore import keyword
 from urllib3.exceptions import MaxRetryError, SSLError
@@ -20,6 +18,16 @@ class DataSciencePipelinesKfpTekton:
         if self.client is None:
             self.api = DataSciencePipelinesAPI()
             self.api.login_and_wait_dsp_route(user, pwd, project, route_name)
+
+            # initialize global environment variables
+            # https://github.com/kubeflow/kfp-tekton/issues/1345
+            default_image = 'registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61'
+            os.environ["DEFAULT_STORAGE_CLASS"] = self.api.get_default_storage()
+            os.environ["TEKTON_BASH_STEP_IMAGE"] = default_image
+            os.environ["TEKTON_COPY_RESULTS_STEP_IMAGE"] = default_image
+            os.environ["CONDITION_IMAGE_NAME"] = default_image
+            import kfp_tekton
+
             # the following fallback it is to simplify the test development
             try:
                 # we assume it is a secured cluster
@@ -81,11 +89,6 @@ class DataSciencePipelinesKfpTekton:
             f"{current_path}/ods_ci/tests/Resources/Files/pipeline-samples/{source_code}"
         )
         pipeline = getattr(my_source, fn)
-        default_image = 'registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61'
-        os.environ["DEFAULT_STORAGE_CLASS"] = self.api.get_default_storage()
-        os.environ["TEKTON_BASH_STEP_IMAGE"] = default_image
-        os.environ["TEKTON_COPY_RESULTS_STEP_IMAGE"] = default_image
-        os.environ["CONDITION_IMAGE_NAME"] = default_image
 
         # create_run_from_pipeline_func will compile the code
         # if you need to see the yaml, for debugging purpose, call: TektonCompiler().compile(pipeline, f'{fn}.yaml')

--- a/poetry.lock
+++ b/poetry.lock
@@ -1678,34 +1678,17 @@ urllib3 = ">=1.15"
 
 [[package]]
 name = "kfp-tekton"
-version = "1.5.8"
+version = "1.5.9"
 description = "Tekton Compiler for Kubeflow Pipelines"
 optional = false
 python-versions = ">=3.6.1"
 files = [
-    {file = "kfp-tekton-1.5.8.tar.gz", hash = "sha256:2b74008f73a4ab0c97b2694bbdeaf1b20d3d7cb08b753b6f529176167e98b7e4"},
+    {file = "kfp-tekton-1.5.9.tar.gz", hash = "sha256:62e745dba6a4c56e50b8ef23e7eeeac4d85893dbacf398a53355672b29643722"},
 ]
 
 [package.dependencies]
 kfp = ">=1.8.10,<1.8.23"
-kfp-tekton-server-api = ">=1.5.0"
 PyYAML = ">=6,<7"
-
-[[package]]
-name = "kfp-tekton-server-api"
-version = "1.5.0"
-description = "Kubeflow Pipelines on Tekton API"
-optional = false
-python-versions = "*"
-files = [
-    {file = "kfp-tekton-server-api-1.5.0.tar.gz", hash = "sha256:2765575419a838dc6f513cfd3c9c53ffca8719cdafac49f36a0e1cec3ca65e39"},
-]
-
-[package.dependencies]
-certifi = "*"
-python-dateutil = "*"
-six = ">=1.10"
-urllib3 = ">=1.15"
 
 [[package]]
 name = "korean-lunar-calendar"
@@ -4972,4 +4955,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "86bb99b54abb93c43d2eafc8a6a0c8eec9c84d6076e9f4721806145a1ea217d4"
+content-hash = "b1f38b9dd7db33ad9a28d3f58dd2f0b31beb164ed98c756cc190bfc91f9e9f00"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ yq = "^3.1.0"
 pexpect = "^4.8.0"
 python-openstackclient = "^6.2.0"
 awscli = "^1.27.100"
-kfp-tekton = "==1.5.8"
+kfp-tekton = "==1.5.9"
 pyyaml = "^6.0.1"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
The second fix is related to the rate limit. This is why wasn't catch before

Jenkins: job/rhods-ci-pr-test/2004/console