### PR TITLE
Fix always passing namespace deletion verification

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/oc_uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/oc_uninstall.robot
@@ -39,5 +39,6 @@ Wait Until Project Is Deleted
         ${project_exists}=  Run Keyword and return status
         ...  Oc Get  kind=Namespace  field_selector=metadata.name=${project}
         Exit For Loop If     not ${project_exists}
-
    END
+   IF  ${project_exists}
+   ...  Fail    Project ${project} has not been deleted after ${timeout} attempts!


### PR DESCRIPTION
Fix the `Wait Until Project Is Deleted` keyword always passing after timeout even when the project/namespace still exists.

Please note that the keyword `Wait Until Project is Deleted` will fail fast when the PR is merged.