### PR TITLE
Update expected external links for Starburst Enterprise test

### DIFF
--- a/ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
+++ b/ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
@@ -287,7 +287,7 @@
                 },
                 "1": {
                     "text": "correctly-sized nodes",
-                    "url": "https://docs.starburst.io/356-e/k8s/requirements.html#k8s-cluster-requirements",
+                    "url": "https://docs.starburst.io/latest/k8s/requirements",
                     "matching": ""
                 },
                 "2": {


### PR DESCRIPTION
A broken link in the dashboard has been fixed, now we need to update our test to look for the new link