### PR TITLE
[Fix] run_robot_test.sh - OC login and return value

### DIFF
--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -263,15 +263,15 @@ if command -v yq &> /dev/null
                     then
                         oc_host=${api_server}
                     else
-                        oc_host=$(yq  e '.OCP_API_URL' "${TEST_VARIABLES_FILE}")
+                        oc_host=$(yq -er '.OCP_API_URL' "${TEST_VARIABLES_FILE}")
                 fi
 
 
                 if [ -z "${SERVICE_ACCOUNT}" ]
                     then
                         echo "Performing oc login using username and password"
-                        oc_user=$(yq  e '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}")
-                        oc_pass=$(yq  e '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}")
+                        oc_user=$(yq -er '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}")
+                        oc_pass=$(yq -er '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}")
                         oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
                     else
                         echo "Performing oc login using service account"

--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -263,15 +263,27 @@ if command -v yq &> /dev/null
                     then
                         oc_host=${api_server}
                     else
-                        oc_host=$(yq -er '.OCP_API_URL' "${TEST_VARIABLES_FILE}")
+                        oc_host=$(yq -er '.OCP_API_URL' "${TEST_VARIABLES_FILE}") || {
+                            echo "Couldn't find '.OCP_API_URL' variable in provided '${TEST_VARIABLES_FILE}'."
+                            echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
+                            exit 1
+                        }
                 fi
 
 
                 if [ -z "${SERVICE_ACCOUNT}" ]
                     then
                         echo "Performing oc login using username and password"
-                        oc_user=$(yq -er '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}")
-                        oc_pass=$(yq -er '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}")
+                        oc_user=$(yq -er '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}") || {
+                            echo "Couldn't find '.OCP_ADMIN_USER.USERNAME' variable in provided '${TEST_VARIABLES_FILE}'."
+                            echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
+                            exit 1
+                        }
+                        oc_pass=$(yq -er '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}") || {
+                            echo "Couldn't find '.OCP_ADMIN_USER.PASSWORD' variable in provided '${TEST_VARIABLES_FILE}'."
+                            echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
+                            exit 1
+                        }
                         oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
                         retVal=$?
                     else

--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -273,22 +273,24 @@ if command -v yq &> /dev/null
                         oc_user=$(yq -er '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}")
                         oc_pass=$(yq -er '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}")
                         oc login "${oc_host}" --username "${oc_user}" --password "${oc_pass}" --insecure-skip-tls-verify=true
+                        retVal=$?
                     else
                         echo "Performing oc login using service account"
                         sa_token=$(oc create token "${SERVICE_ACCOUNT}" -n "${SA_NAMESPACE}" --duration 6h)
                         oc login --token="$sa_token" --server="${oc_host}" --insecure-skip-tls-verify=true
+                        retVal=$?
                         sa_fullname=$(oc whoami)
                         TEST_VARIABLES="${TEST_VARIABLES} --variable SERVICE_ACCOUNT.NAME:${SERVICE_ACCOUNT} --variable SERVICE_ACCOUNT.FULL_NAME:${sa_fullname}"
 
                 fi
 
                 ## no point in going further if the login is not working
-                retVal=$?
                 if [ $retVal -ne 0 ]; then
                     echo "The oc login command seems to have failed"
                     echo "Please review the content of ${TEST_VARIABLES_FILE}"
-                    exit $retVal
+                    exit "${retVal}"
                 fi
+
                 oc cluster-info
                 printf "\nconnected as openshift user ' %s '\n" "$(oc whoami)"
                 echo "since the oc login was successful, continuing."


### PR DESCRIPTION
This fixes OC login on my local Fedora 38 machine. Without this change,
the strings contain also `"`.

Also missing `-` in front of the switch isn't allowed.

Tested with Python based `yq` tool:

```
$ yq --version # https://github.com/kislyuk/yq
yq 3.2.3

$ yq --help
...
  -e               set the exit status code based on the output;
...
  -r               output raw strings, not JSON texts;
...
```
and also with GoLang based `yq` tool:
```
$ ./yq_linux_amd64 --version # https://github.com/mikefarah/yq
yq (https://github.com/mikefarah/yq/) version v4.35.2
$ ./yq_linux_amd64 --help
...
  -e, --exit-status                   set exit status if there are no matches or null or false is returned
...
  -r, --unwrapScalar                  unwrap scalar, print the value with no quotes, colors or comments. Defaults to true for yaml (default true)
...
```