### PR TITLE
Fix Openshift Pipelines installation in OCP 4.14 & fix timing issue

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesAPI.py
+++ b/ods_ci/libs/DataSciencePipelinesAPI.py
@@ -87,8 +87,8 @@ class DataSciencePipelinesAPI:
             count += 1
 
         assert self.route != "", "Route must not be empty"
-        print(f"Waiting for Data Science Pipeline route to be ready: {self.route}")
-        time.sleep(30)
+        print(f"Waiting for Data Science Pipeline route to be ready to avoid firing false alerts: {self.route}")
+        time.sleep(45)
         status = -1
         count = 0
         while status != 200 and count < timeout:

--- a/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
+++ b/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
@@ -20,20 +20,21 @@ Install Red Hat OpenShift Pipelines
     [Documentation]    Install Red Hat OpenShift Pipelines operator depending on
     ...     OpenShift version, platform (AWS/GCP/...) and RHODS flavor (Managed/Self-Managed) with the objective of
     ...     testing all the operator versions without having to test all possible combinations:
-    ...     - OpenShift 4.10:                  OpenShift Pipelines 1.8
-    ...     - OpenShift 4.11:                  OpenShift Pipelines 1.9
-    ...     - OpenShift >= 4.12 (AWS and GCP): OpenShift Pipelines 1.10 / 1.11 (depending on platform and flavor)
-    ...     - OpenShift >= 4.12 (other):       OpenShift Pipelines 1.11
+    ...     - OpenShift 4.10:                      OpenShift Pipelines 1.8
+    ...     - OpenShift 4.11:                      OpenShift Pipelines 1.9
+    ...     - OpenShift 4.12, 4.13 (AWS and GCP):  OpenShift Pipelines 1.10 / 1.11 (depending on platform and flavor)
+    ...     - OpenShift >= 4.12 (OpenStack):       OpenShift Pipelines 1.11
+    ...     - OpenShift 4.14:                      OpenShift Pipelines 1.11
     ...     Note: the complete operator compatiblity matrix is published at
     ...      https://docs.openshift.com/container-platform/4.13/cicd/pipelines/op-release-notes.html
     ${oc_version}=    Get OpenShift Version
     ${is_self_managed}=    Is RHODS Self-Managed
     ${platform}=    Fetch Cluster Platform Type
-    IF    "${oc_version}" == "4.10"
+    IF    "4.10" in "${oc_version}"
         ${openshift_pipelines_version}=    Set Variable    pipelines-1.8"
-    ELSE IF    "${oc_version}" == "4.11"
+    ELSE IF    "4.11" in "${oc_version}"
         ${openshift_pipelines_version}=    Set Variable    pipelines-1.9
-    ELSE
+    ELSE IF    "4.12" in "${oc_version}"
         IF    ${is_self_managed} == ${TRUE} and "${platform}" == "AWS"
             ${openshift_pipelines_version}=    Set Variable    pipelines-1.10
         ELSE IF    ${is_self_managed} == ${FALSE} and "${platform}" == "AWS"
@@ -45,6 +46,8 @@ Install Red Hat OpenShift Pipelines
         ELSE
             ${openshift_pipelines_version}=    Set Variable    pipelines-1.11
         END
+    ELSE
+        ${openshift_pipelines_version}=    Set Variable    pipelines-1.11
     END
     Log    message=Installing OpenShift Pipelines operator: ${openshift_pipelines_version} (${platform} ${oc_version} Self-Managed: ${is_self_managed})
     ...    console=True

--- a/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
+++ b/ods_ci/tests/Resources/Page/Operators/OpenShiftPipelines.resource
@@ -34,7 +34,7 @@ Install Red Hat OpenShift Pipelines
         ${openshift_pipelines_version}=    Set Variable    pipelines-1.8"
     ELSE IF    "4.11" in "${oc_version}"
         ${openshift_pipelines_version}=    Set Variable    pipelines-1.9
-    ELSE IF    "4.12" in "${oc_version}"
+    ELSE IF    "4.12" in "${oc_version}" or "4.13" in "${oc_version}"
         IF    ${is_self_managed} == ${TRUE} and "${platform}" == "AWS"
             ${openshift_pipelines_version}=    Set Variable    pipelines-1.10
         ELSE IF    ${is_self_managed} == ${FALSE} and "${platform}" == "AWS"

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
@@ -43,7 +43,8 @@ Verify Ods Users Can Do Http Request That Must Be Redirected to Https
 
 *** Keywords ***
 End To End Pipeline Workflow Via Api
-    [Documentation]    Create, run and double check the pipeline result using API. In the end, clean the pipeline resources.    # robocop: disable:line-too-long
+    [Documentation]    Create, run and double check the pipeline result using API.
+    ...    In the end, clean the pipeline resources.
     [Arguments]     ${username}    ${password}    ${project}
     Remove Pipeline Project    ${project}
     New Project    ${project}

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/432__data-science-pipelines-tekton.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/432__data-science-pipelines-tekton.robot
@@ -39,7 +39,7 @@ Verify Ods Users Can Create And Run A Data Science Pipeline Using The Kfp_tekton
     ...    project=${PROJECT_NAME}
     ...    python_file=upload_download.py
     ...    method_name=wire_up_pipeline
-    ...    status_check_timeout=160
+    ...    status_check_timeout=220
     [Teardown]    Remove Pipeline Project    ${PROJECT_NAME}
 
 


### PR DESCRIPTION
- Fixes installation of OpenShift Pipelines 1.11, in OCP 4.14
- Increases sleep before checking dsp route in order to avoid firing false alarms when route is not ready yet

Tested successfully for OCP  4.14 in rhods-sanity/1511 (operator was installed, there is one test failing for unrelated reasons)