### PR TITLE
Add support for CodeFlare operator in managed env

### DIFF
--- a/ods_ci/tasks/Resources/Files/codeflare_cs_template.yaml
+++ b/ods_ci/tasks/Resources/Files/codeflare_cs_template.yaml
@@ -1,0 +1,14 @@
+kind: List
+metadata: {}
+apiVersion: v1
+items:
+    -   apiVersion: operators.coreos.com/v1alpha1
+        kind: CatalogSource
+        metadata:
+            name: rhods-codeflare-catalog
+            namespace: openshift-marketplace
+        spec:
+            displayName: Red Hat OpenShift Data Science - CodeFlare
+            publisher: RHODS Development Catalog
+            image: <CODEFLARE_INDEX_IMAGE>
+            sourceType: grpc

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/codeflare_install.resource
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/codeflare_install.resource
@@ -9,10 +9,11 @@ Library    OpenShiftLibrary
 *** Keywords ***
 Installing CodeFlare Operator
   [Documentation]   Installs the RHODS CodeFlare operator if it is not already installed
+  [Arguments]  ${cluster_type}     ${image_url}
   ${is_operator_installed} =  Is CodeFlare Installed
   IF  not ${is_operator_installed}
         Log  Installing CodeFlare operator  console=yes
-        Install CodeFlare    ${cluster_type}
+        Install CodeFlare    ${cluster_type}  ${image_url}
   END
 
 CodeFlare Operator Should Be Installed
@@ -24,18 +25,41 @@ CodeFlare Operator Should Be Installed
 
 Install CodeFlare
   [Documentation]  Installs the RHODS CodeFlare operator, expects RHODS operator already installed
-  [Arguments]  ${cluster_type}
+  [Arguments]  ${cluster_type}  ${image_url}
   ${file_path} =    Set Variable    tasks/Resources/Files/
-  IF  "${cluster_type}" == "managed"
-        ${catalog_source} =   Set Variable    "addon-managed-odh-catalog"
-  ELSE
+  IF  "${cluster_type}" == "selfmanaged"
+    IF  "${INSTALL_TYPE}" == "CLi"
+        ${catalog_source} =   Set Variable    "rhods-catalog-dev"
+    ELSE IF  "${INSTALL_TYPE}" == "OperatorHub"
         ${catalog_source} =   Set Variable    "redhat-operators"
+    ELSE
+        FAIL    Provided test environment ${cluster_type} and install type ${INSTALL_TYPE} not supported for CodeFlare
+    END
+  ELSE
+    IF  "${INSTALL_TYPE}" == "CLi"
+        ${catalog_source} =   Set Variable    "rhods-codeflare-catalog"
+        # addon-managed-odh-catalog created by olminstall is scoped to redhat-ods-operator namespace,
+        # a cluster-wide catalog source has to be created
+        Create CodeFlare CatalogSource For Managed  ${file_path}  ${image_url}
+    ELSE
+        FAIL    Provided test environment ${cluster_type} and install type ${INSTALL_TYPE} not supported for CodeFlare
+    END
   END
+
   Copy File    source=${file_path}codeflare_sub_template.yaml    destination=${file_path}codeflare_sub_apply.yaml
   Run    sed -i 's/<UPDATE_CHANNEL>/${CODEFLARE_UPDATE_CHANNEL}/' ${file_path}codeflare_sub_apply.yaml
   Run    sed -i 's/<CATALOG_SOURCE>/${catalog_source}/' ${file_path}codeflare_sub_apply.yaml
   Oc Apply   kind=List   src=${file_path}codeflare_sub_apply.yaml
   Remove File    ${file_path}codeflare_sub_apply.yaml
+
+Create CodeFlare CatalogSource For Managed
+  [Documentation]   Creates a new CatalogSource for managed env since the addon CS by olminstall is not cluster-wide
+  [Arguments]  ${resource_file_path}  ${image_url}
+  Copy File    source=${resource_file_path}codeflare_cs_template.yaml
+  ...          destination=${resource_file_path}codeflare_cs_apply.yaml
+  Run    sed -i 's,<CODEFLARE_INDEX_IMAGE>,${image_url},' ${resource_file_path}codeflare_cs_apply.yaml
+  Oc Apply   kind=List   src=${resource_file_path}codeflare_cs_apply.yaml
+  Remove File    ${resource_file_path}codeflare_cs_apply.yaml
 
 Verify CodeFlare Installation
   [Documentation]   Verifies the RHODS CodeFlare operator deployment existence

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
@@ -15,7 +15,7 @@ Installing RHODS Operator ${image_url}
   ...  Install RHODS   ${cluster_type}    ${image_url}
   ${is_codeflare_managed} =    Is CodeFlare Managed
   Log  Will install CodeFlare operator: ${is_codeflare_managed}  console=yes
-  IF  ${is_codeflare_managed}    Installing CodeFlare Operator
+  IF  ${is_codeflare_managed}    Installing CodeFlare Operator  ${cluster_type}  ${image_url}
 
 RHODS Operator Should Be installed
   Verify RHODS Installation

--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/codeflare_uninstall.resource
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/codeflare_uninstall.resource
@@ -21,9 +21,16 @@ Uninstall CodeFlare
     [Documentation]   Removes the RHODS CodeFlare operator subscription and CSV
     # needs to be deleted first to avoid getting stuck on CodeFlare finalizer
     ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete mcads.codeflare.codeflare.dev mcad -n redhat-ods-applications --ignore-not-found
+    ...    oc delete mcads.codeflare.codeflare.dev --all -n redhat-ods-applications --ignore-not-found
     Should Be Equal As Integers	${return_code}	 0   msg=Error deleting CodeFlare MCAD CR
     Uninstall ISV Operator From OperatorHub Via CLI     rhods-codeflare-operator    openshift-operators
+    Uninstall CodeFlare CatalogSource
+
+Uninstall CodeFlare CatalogSource
+    [Documentation]    Removes the CodeFlare cluster-wide catalog source created for managed env, if it exists
+    ${return_code}    ${output}    Run And Return Rc And Output
+    ...    oc delete catalogsource rhods-codeflare-catalog -n openshift-marketplace --ignore-not-found
+    Should Be Equal As Integers	${return_code}	 0   msg=Error deleting CodeFlare CatalogSource
 
 CodeFlare Operator Should Be Uninstalled
     [Documentation]   Verifies and logs that the RHODS CodeFlare operator is uninstalled


### PR DESCRIPTION
Added CodeFlare-specific cluster-wide CatalogSource to handle the issue with the RHODS Addon CatalogSource being scoped to `redhat-ods-operator` namespace only, while the CodeFlare operator is expected to be installed in `openshift-operators`.