### PR TITLE
fix the machine pool exiting function

### DIFF
--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -417,7 +417,7 @@ class OpenshiftClusterManager:
             self.cluster_name, self.pool_name
         )
         ret = execute_command(cmd)
-        if ret is None:
+        if not ret:
             return False
         return True
 


### PR DESCRIPTION
Observed that this function always retrun True evnthough machine poll doesn't exist. Whne machine pool doesn't exists ocm return empty string