### PR TITLE
Fix starburst enteprise tests

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -158,3 +158,9 @@ Container Hardware Resources Should Match Expected
             Should Be Equal As Strings    ${limits}[${resource}]    ${exp_limits}[${resource}]
         END
     END
+
+Wait Until CRD Exists
+    [Documentation]    Repeatedly searches for the expected CRD. Stops when it finds it
+    [Arguments]    ${crd_fullname}
+    Wait Until Keyword Succeeds    10 times    2s
+    ...    Oc Get    kind=CustomResourceDefinition    name=${crd_fullname}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -162,5 +162,5 @@ Container Hardware Resources Should Match Expected
 Wait Until CRD Exists
     [Documentation]    Repeatedly searches for the expected CRD. Stops when it finds it
     [Arguments]    ${crd_fullname}
-    Wait Until Keyword Succeeds    10 times    2s
+    Wait Until Keyword Succeeds    15 times    5s
     ...    Oc Get    kind=CustomResourceDefinition    name=${crd_fullname}

--- a/ods_ci/tests/Tests/600__ai_apps/680__starburst/682__starburst_enterprise_sm.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/680__starburst/682__starburst_enterprise_sm.robot
@@ -105,6 +105,7 @@ Starburst Enterprise Suite Setup    # robocop: disable
     ...    reason=AllCatalogSourcesHealthy    subcription_name=${SUBSCRIPTION_NAME}
     ...    namespace=${NAMESPACE}
     Create Starburst Enteprise License Secret
+    Wait Until CRD Exists    crd_fullname=starburstenterprises.charts.starburstdata.com
     Deploy Custom Resource    kind=StarburstEnterprise    namespace=${namespace}
     ...    filepath=${SEP_CR_FILEPATH}
     Wait Until Operator Pods Are Running    namespace=${NAMESPACE}


### PR DESCRIPTION
**Problem**
Test suite for SEP is often failing because the robot tries to deploy the CustomResource before the CustomResourceDefinition is available in the cluster.
**Solution**
Wait for the CRD to be available before proceeding with the rest of the test case.