### PR TITLE
Fix check uninstall osd cluster

### DIFF
--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -119,7 +119,7 @@ class OpenshiftClusterManager:
         if filter != "":
             cmd += " " + filter
         ret = execute_command(cmd)
-        if ret is None:
+        if ret is None or "Error: Can't retrieve cluster for key" in ret:
             log.info("ocm describe for cluster " "{} failed".format(self.cluster_name))
             return None
         return ret


### PR DESCRIPTION
I saw several times in jenkins that unstall osd job failed due to wrong check if cluster exists. I saw that cluster was unstalled but `ocm describe` returned non zero ecode but contains string about exception and it is not evaluated as None. 