### PR TITLE
Add WatsonX metrics test

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -6,7 +6,7 @@
                 "flan-t5-small-caikit": {
                     "generatedTokenCount":  5,
                     "response_text": "74 degrees F",
-                    "streamed_response_text":   "{'details':{}}{'tokens':[{'text':'▁','logprob':-1.6961849927902222}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.2507317066192627}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324553906917572}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.3610913753509521}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}"
+                    "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}"
                 },
                 "bloom-560m-caikit": {
                     "generatedTokenCount":  20,

--- a/ods_ci/tests/Resources/Files/llm/uwm_cm_conf.yaml
+++ b/ods_ci/tests/Resources/Files/llm/uwm_cm_conf.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      logLevel: debug 
+      retention: 15d #Change as needed

--- a/ods_ci/tests/Resources/Files/llm/uwm_cm_enable.yaml
+++ b/ods_ci/tests/Resources/Files/llm/uwm_cm_enable.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    enableUserWorkload: true

--- a/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -157,7 +157,6 @@ Get Thanos Metrics List
         ${cmd}=    Catenate    ${cmd}    | jq '.data'
     ELSE
         ${cmd}=    Catenate    ${cmd} | jq '.data[]' | grep ${search_text}
-        # ${cmd}=    Catenate    ${cmd} | jq '.data | to_entries[] | select(.value | contains("${search_text}") )'
     END
     ${rc}    ${out}=    Run And Return Rc And Output    ${cmd} | tr -d '"'
     RETURN    ${out}

--- a/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -135,3 +135,29 @@ Suite Availability Teardown
     Run Keyword And Warn On Failure    Alerts Should Not Be Firing
     ...    pm_url=${pm_url}    pm_token=${pm_token}    expected-firing-alert=DeadManSnitch
     ...    message_prefix=Suite Trdwn: ${SUITE NAME}:
+
+Get OpenShift Thanos URL
+    [Documentation]    Fetches the thanos URL from the OpenShift cluster
+    ${url}=    Oc Get    kind=Route    name=thanos-querier    namespace=openshift-monitoring
+    ...    fields=['status.ingress[0].host']
+    RETURN   ${url}[0][status.ingress[0].host]
+
+Generate Thanos Token
+    [Documentation]    Fetch user token to access thanos-querier.
+    ${rc}    ${out}=    Run And Return Rc And Output    oc whoami -t
+    Should Be Equal As Integers    ${rc}    ${0}
+    RETURN    ${out}
+
+Get Thanos Metrics List
+    [Documentation]    Gets the list of metrics available in thanos-querier and their type
+    ...                (e.g., counter, histogram, etc)
+    [Arguments]    ${thanos_url}    ${thanos_token}    ${search_text}=${EMPTY}
+    ${cmd}=    Set Variable    curl -k -H "Authorization: Bearer ${thanos_token}" https://${thanos_url}/api/v1/label/__name__/values
+    IF    "${search_text}" == "${EMPTY}"
+        ${cmd}=    Catenate    ${cmd}    | jq '.data'
+    ELSE
+        ${cmd}=    Catenate    ${cmd} | jq '.data[]' | grep ${search_text}
+        # ${cmd}=    Catenate    ${cmd} | jq '.data | to_entries[] | select(.value | contains("${search_text}") )'
+    END
+    ${rc}    ${out}=    Run And Return Rc And Output    ${cmd} | tr -d '"'
+    RETURN    ${out}

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -42,6 +42,7 @@ Resource            Common.robot
 ...                         Fill Data Connection Form
 ...                         Create Secret For S3-Like Buckets
 ...                         Login To OCP Using API
+...                         Generate Thanos Token
 
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -988,11 +988,9 @@ TGI Caikit And Istio Metrics Should Exist
     ${caikit_metrics_names}=    Get Thanos Metrics List    thanos_url=${thanos_url}    thanos_token=${thanos_token}
     ...    search_text=caikit
     ${caikit_metrics_names}=    Split To Lines    ${caikit_metrics_names}
-    Set Suite Variable    ${CAIKIT_METRICS_NAMES}    ${caikit_metrics_names}
     ${istio_metrics_names}=    Get Thanos Metrics List    thanos_url=${thanos_url}    thanos_token=${thanos_token}
     ...    search_text=istio
     ${istio_metrics_names}=    Split To Lines    ${istio_metrics_names}
-    Set Suite Variable    ${ISTIO_METRICS_NAMES}    ${istio_metrics_names}
     ${metrics}=    Append To List    ${tgi_metrics_names}    @{caikit_metrics_names}    @{istio_metrics_names}
     RETURN    ${metrics}
 
@@ -1012,10 +1010,12 @@ Check Query Response Values
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${source_namespace}    ${exp_namespace}
     IF    "${exp_model_name}" != "${EMPTY}"
         ${source_model}=    Set Variable    ${json_resp["metric"]["job"]}
-        Run Keyword And Continue On Failure    Should Be Equal As Strings    ${source_model}    ${exp_model_name}-metrics
+        Run Keyword And Continue On Failure    Should Be Equal As Strings    ${source_model}
+        ...    ${exp_model_name}-metrics
         IF    "${exp_query_kind}" != "${EMPTY}"
             ${source_query_kind}=    Set Variable    ${json_resp["metric"]["kind"]}
-            Run Keyword And Continue On Failure    Should Be Equal As Strings    ${source_query_kind}    ${exp_query_kind}
+            Run Keyword And Continue On Failure    Should Be Equal As Strings    ${source_query_kind}
+            ...    ${exp_query_kind}
         END
     END
     IF    "${exp_pod_name}" != "${EMPTY}"

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -472,7 +472,7 @@ Verify User Can Access Model Metrics From UWM
     ...                PARTIALLY DONE: it is checking number of requests, number of successful requests
     ...                and model pod cpu usage. Waiting for a complete list of expected metrics and
     ...                derived metrics.
-    [Tags]    ODS-XYZ    WatsonX
+    [Tags]    ODS-2401    WatsonX
     [Setup]    Set Project And Runtime    namespace=watsonx-metrics    enable_metrics=${TRUE}
     ${test_namespace}=    Set Variable     watsonx-metrics
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -512,7 +512,7 @@ Install Model Serving Stack Dependencies
     [Documentation]    Instaling And Configuring dependency operators: Service Mesh and Serverless.
     ...                This is likely going to change in the future and it will include a way to skip installation.
     ...                Caikit runtime will be shipped Out-of-the-box and will be removed from here.
-    # RHOSi Setup
+    RHOSi Setup
     IF    ${SKIP_PREREQS_INSTALL} == ${FALSE}
         IF    ${SCRIPT_BASED_INSTALL} == ${FALSE}
             Install Service Mesh Stack
@@ -748,6 +748,8 @@ Deploy Caikit Serving Runtime
     ...    oc apply -f ${CAIKIT_FILEPATH} -n ${namespace}
 
 Set Project And Runtime
+    [Documentation]    Creates the DS Project (if not exists), creates the data connection for the models,
+    ...                creates caikit runtime. This can be used as test setup
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}
     Set Up Test OpenShift Project    test_ns=${namespace}
     Create Secret For S3-Like Buckets    endpoint=${MODELS_BUCKET.ENDPOINT}
@@ -944,6 +946,8 @@ Get Model Pods Creation Date And Image URL
     RETURN    ${created_at}    ${caikitsha}
 
 User Can Fetch Number Of Requests Over Defined Time
+    [Documentation]    Fetches the `tgi_request_count` metric and checks that it reports the expected
+    ...                model information (name, namespace and type of request)
     [Arguments]    ${thanos_url}    ${thanos_token}    ${model_name}    ${namespace}
     ...           ${query_kind}=single    ${period}=30m    ${exp_value}=${EMPTY}
     ${resp}=    Prometheus.Run Query    https://${thanos_url}    ${thanos_token}    tgi_request_count[${period}]
@@ -952,6 +956,8 @@ User Can Fetch Number Of Requests Over Defined Time
     ...    exp_model_name=${model_name}    exp_query_kind=${query_kind}    exp_value=${exp_value}
 
 User Can Fetch Number Of Successful Requests Over Defined Time
+    [Documentation]    Fetches the `tgi_request_success` metric and checks that it reports the expected
+    ...                model information (name, namespace and type of request) and metric value, given a time window.
     [Arguments]    ${thanos_url}    ${thanos_token}    ${model_name}    ${namespace}
     ...            ${query_kind}=single    ${period}=30m    ${exp_value}=${EMPTY}
     ${resp}=    Prometheus.Run Query    https://${thanos_url}    ${thanos_token}    tgi_request_success[${period}]
@@ -960,6 +966,8 @@ User Can Fetch Number Of Successful Requests Over Defined Time
     ...    exp_model_name=${model_name}    exp_query_kind=${query_kind}    exp_value=${exp_value}
 
 User Can Fetch CPU Utilization
+    [Documentation]    Fetches the `pod:container_cpu_usage:sum` metric and checks that it reports the expected
+    ...                model information (pod name and namespace)
     [Arguments]    ${thanos_url}    ${thanos_token}    ${namespace}    ${model_name}    ${period}=30m    ${exp_value}=${EMPTY}
     ${resp}=    Prometheus.Run Query    https://${thanos_url}    ${thanos_token}    pod:container_cpu_usage:sum{namespace="${namespace}"}[${period}]
     ${pod_name}=    Oc Get    kind=Pod    namespace=${namespace}
@@ -970,6 +978,8 @@ User Can Fetch CPU Utilization
     ...    exp_pod_name=${pod_name}[0][metadata.name]    exp_value=${exp_value}
 
 TGI Caikit And Istio Metrics Should Exist
+    [Documentation]    Checks that the `tgi_`, `caikit_` and `istio_` metrics exist.
+    ...                Returns the list of metrics names
     [Arguments]    ${thanos_url}    ${thanos_token}
     ${tgi_metrics_names}=    Get Thanos Metrics List    thanos_url=${thanos_url}    thanos_token=${thanos_token}
     ...    search_text=tgi
@@ -987,6 +997,8 @@ TGI Caikit And Istio Metrics Should Exist
     RETURN    ${metrics}
 
 Check Query Response Values
+    [Documentation]    Implements the metric checks for `User Can Fetch Number Of Requests Over Defined Time`
+    ...                `User Can Fetch Number Of Successful Requests Over Defined Time` and `User Can Fetch CPU Utilization`.
     [Arguments]    ${response}    ${exp_namespace}    ${exp_model_name}=${EMPTY}    ${exp_query_kind}=${EMPTY}    ${exp_value}=${EMPTY}    ${exp_pod_name}=${EMPTY}
     ${json_resp}=    Set Variable    ${response.json()["data"]["result"][-1]}
     ${value_keyname}=    Run Keyword And Return Status


### PR DESCRIPTION
This PR is adding a test for checking model metrics for WatsonX/Kserve. 

The PR checks:
1. metrics with `tgi_`, `caikit_` and `istio_` are present in the Openshift metrics
2. user can get `# of inference requests over defined time period` , `# of successful inference requests over defined time period` and `CPU Utilization`

This is a base for the final test which should check that all the expected metrics are present (_waiting for a final list_) and will check also more derived metrics (_waiting for a final list and their formulas) 