### PR TITLE
Restore two tensor flow tests into sanity

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -30,7 +30,7 @@ Verify Tensorflow Image Can Be Spawned
 Tensorflow Workload Test
     [Documentation]    Runs tensorflow workload
     [Tags]  Sanity
-    ...     PLACEHOLDER  # category tags
+    ...     Tier1
     ...     ODS-1156
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
     Capture Page Screenshot
@@ -39,7 +39,7 @@ Tensorflow Workload Test
 Verify Tensorboard Is Accessible
     [Documentation]  Verifies that tensorboard is accessible
     [Tags]  Sanity
-    ...     PLACEHOLDER
+    ...     Tier1
     ...     ODS-1413
     Close Previous Server
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -32,7 +32,6 @@ Tensorflow Workload Test
     [Tags]  Sanity
     ...     PLACEHOLDER  # category tags
     ...     ODS-1156
-    ...     AutomationBug
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
     Capture Page Screenshot
     JupyterLab Code Cell Error Output Should Not Be Visible
@@ -42,7 +41,6 @@ Verify Tensorboard Is Accessible
     [Tags]  Sanity
     ...     PLACEHOLDER
     ...     ODS-1413
-    ...     AutomationBug
     Close Previous Server
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small
     Run Keyword And Ignore Error  Clone Git Repository And Run  https://github.com/redhat-rhods-qe/ods-ci-notebooks-main


### PR DESCRIPTION
`Tensorflow Workload Test` and `Verify Tensorboard Is Accessible` are in the known issues quality gate, however they are passing the execution: `rhods-known-issues/24`.

This PR is moving both back to Sanity/Tier1