### PR TITLE
[Stabilize] Let's wait for DOM ready before we start to edit workbenches

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -375,6 +375,8 @@ Edit Workbench
     [Arguments]     ${workbench_title}
     Workbenches.Click Action From Actions Menu    item_title=${workbench_title}    item_type=workbench    action=Edit
     Wait Until Page Contains Element    ${WORKBENCH_NAME_INPUT_XP}
+    # Also wait until the workbench name is populated in the text field - let's wait for DOM to finish
+    Wait For Condition    return document.readyState == "complete"    timeout=5s
 
 Check Launched Workbench Is The Correct One
     [Documentation]    Checks if the launched workbench is the expected one

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_edit.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_edit.robot
@@ -70,7 +70,7 @@ Verify User Can Edit A Workbench
     Workbench With Description Should Be Listed      workbench_title=${WORKBENCH_TITLE_UPDATED}
     ...                                              workbench_description=${WORKBENCH_DESC_UPDATED}
     Workbench Status Should Be      workbench_title=${WORKBENCH_TITLE_UPDATED}      status=${WORKBENCH_STATUS_RUNNING}
-    [Teardown]    Clean Project From Workbench Resources    workbench_title=${WORKBENCH_TITLE}
+    [Teardown]    Clean Project From Workbench Resources    workbench_title=${WORKBENCH_TITLE_UPDATED}
     ...    project_title=${PRJ_TITLE}    pvc_title=${PV_BASENAME}
 
 Verify User Can Edit A S3 Data Connection


### PR DESCRIPTION
ODS-1931

The test that edits workbench name and description fails intermittently. I wasn't able to reproduce but based on the data, it looks that the page is updated before all the fields are populated. This leads to the situation where there are both old and new value appended in the text box and test failure.

Waiting for the DOM to be ready [1] should avoid these issues.

[1] https://html.spec.whatwg.org/multipage/dom.html#reporting-document-loading-status

Tested by job - rhods-ci-pr-test/2079