### PR TITLE
[Fix] Typo in the variable name

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -20,7 +20,7 @@ ${REPLICAS_MIN_BTN_XP}=         xpath=//div/button[@aria-label="Minus"]
 ${SERVING_RUNTIME_NAME}=        xpath=//input[@id="serving-runtime-name-input"]
 ${SERVING_ACCELERATOR_DROPDOWN_XPATH}=    xpath=//label[@for='modal-notebook-accelerator']/ancestor::div[@class='pf-c-form__group']/descendant::button
 ${SERVING_ACCELERATOR_INPUT_XPATH}=    xpath=//input[@aria-label='Number of accelerators']
-${SERVING_ACCELERATOR_MINUS_BUTTON_XPATH}=    xpath=${SERVING_INPUT_XPATH}/preceding-sibling::button
+${SERVING_ACCELERATOR_MINUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/preceding-sibling::button
 ${SERVING_ACCELERATOR_PLUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/following-sibling::button
 ${SERVING_MODEL_SERVERS_SIDE_MENU}=    xpath=//span[text()='Models and model servers']
 


### PR DESCRIPTION
This fixes the errors in the GitHub dryrun action:

```
------------------------------------------------------------------------------
Tests.Ods Dashboard.Model Serving.Model Serving Llm :: Collection ... | PASS |
16 tests, 16 passed, 0 failed
==============================================================================
[ ERROR ] Error in file '/home/runner/work/ods-ci/ods-ci/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource' on line 23: Setting variable '${SERVING_ACCELERATOR_MINUS_BUTTON_XPATH}' failed: Variable '${SERVING_INPUT_XPATH}' not found.
Tests.Ods Dashboard.Model Serving.Model Serving Customruntimes :: Collectio...
==============================================================================
Verify RHODS Admins Can Import A Custom Serving Runtime Template B... | PASS |
------------------------------------------------------------------------------
```