### PR TITLE
Test Pipeline YAML context menu and verify read only

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -112,6 +112,24 @@ Click Action From Actions Menu
     Wait Until Page Contains Element    //table//tr[td[*[a[text()='${pipeline_name}']]]]//td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[contains(text(), '${action}')]
     Click Element    //table//tr[td[*[a[text()='${pipeline_name}']]]]//td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[contains(text(), '${action}')]
 
+Pipeline Context Menu Should Be Readonly
+    [Documentation]   Test Pipeline YAML context menu and verify read only (https://github.com/opendatahub-io/odh-dashboard/issues/1689)
+    [Arguments]    ${pipeline_name}
+    ${orig wait}=    SeleniumLibrary.Set Selenium Implicit Wait    10s
+    Wait Until Element is Visible     //button[contains(text(), "Data Science Pipelines")]          timeout=30
+    Click Button      Data Science Pipelines
+    Click Link      Pipelines
+    Wait Until Element is Visible     //a[text()="${pipeline_name}"]          timeout=30s
+    Click Link      ${pipeline_name}
+    Click Element     //button[@aria-label="Pipeline YAML Tab"]
+    Open Context Menu    //div[contains(@class, 'lines-content')]
+    Click Element     //button[@aria-label="Pipeline YAML Tab"]
+    Press Keys    //div[contains(@class, 'lines-content')]    F1+fold+SPACE+all+ENTER
+    Press Keys    //div[contains(@class, 'lines-content')]    cannot_enter_read_only
+    Wait Until Element Is Visible    //div[@class="pf-c-code-editor pf-m-read-only odh-dashboard__code-editor"]    timeout=10
+    Capture Page Screenshot
+    SeleniumLibrary.Set Selenium Implicit Wait    ${orig wait}
+
 Pipeline Should Be Listed
     [Documentation]    Checks a pipeline is listed in the DS Project details page
     [Arguments]     ${pipeline_name}    ${pipeline_description}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -112,19 +112,28 @@ Click Action From Actions Menu
     Wait Until Page Contains Element    //table//tr[td[*[a[text()='${pipeline_name}']]]]//td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[contains(text(), '${action}')]
     Click Element    //table//tr[td[*[a[text()='${pipeline_name}']]]]//td[contains(@class, 'pf-c-table__action')]/div/ul/li/button[contains(text(), '${action}')]
 
-Pipeline Context Menu Should Be Readonly
-    [Documentation]   Test Pipeline YAML context menu and verify read only (https://github.com/opendatahub-io/odh-dashboard/issues/1689)
+Pipeline Context Menu Should Be Working
+    [Documentation]   Test Pipeline YAML context menu works with mouse right-click and with keyboard
     [Arguments]    ${pipeline_name}
     ${orig wait}=    SeleniumLibrary.Set Selenium Implicit Wait    10s
-    Wait Until Element is Visible     //button[contains(text(), "Data Science Pipelines")]          timeout=30
-    Click Button      Data Science Pipelines
-    Click Link      Pipelines
+    Menu.Navigate To Page    Data Science Pipelines    Pipelines
     Wait Until Element is Visible     //a[text()="${pipeline_name}"]          timeout=30s
     Click Link      ${pipeline_name}
     Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Open Context Menu    //div[contains(@class, 'lines-content')]
     Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Press Keys    //div[contains(@class, 'lines-content')]    F1+fold+SPACE+all+ENTER
+    Capture Page Screenshot
+    SeleniumLibrary.Set Selenium Implicit Wait    ${orig wait}
+
+Pipeline Yaml Should Be Readonly
+    [Documentation]   Verify Pipeline Yaml is read only (https://github.com/opendatahub-io/odh-dashboard/issues/1689)
+    [Arguments]    ${pipeline_name}
+    ${orig wait}=    SeleniumLibrary.Set Selenium Implicit Wait    10s
+    Menu.Navigate To Page    Data Science Pipelines    Pipelines
+    Wait Until Element is Visible     //a[text()="${pipeline_name}"]          timeout=30s
+    Click Link      ${pipeline_name}
+    Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Press Keys    //div[contains(@class, 'lines-content')]    cannot_enter_read_only
     Wait Until Element Is Visible    //div[@class="pf-c-code-editor pf-m-read-only odh-dashboard__code-editor"]    timeout=10
     Capture Page Screenshot

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -43,7 +43,8 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    project_title=${PRJ_TITLE}
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${FALSE}
-    Pipeline Context Menu Should Be Readonly    pipeline_name=${PIPELINE_TEST_NAME}
+    Pipeline Context Menu Should Be Working    pipeline_name=${PIPELINE_TEST_NAME}
+    Pipeline Yaml Should Be Readonly    pipeline_name=${PIPELINE_TEST_NAME}
     Open Data Science Project Details Page    ${PRJ_TITLE}
     Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
     ...    pipeline_description=${PIPELINE_TEST_DESC}

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -13,6 +13,8 @@ Suite Teardown     Pipelines Suite Teardown
 # lower case because it will be the OpenShift project
 ${PRJ_BASE_TITLE}=   dsp
 ${PRJ_DESCRIPTION}=   ${PRJ_BASE_TITLE} is a test project for validating DS Pipelines feature
+${PRJ_TITLE}=    ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+${PIPELINE_TEST_NAME}=    ${PIPELINE_TEST_BASENAME}-${TEST_USER_3.USERNAME}
 ${DC_NAME}=    ds-pipeline-conn
 ${PIPELINE_TEST_BASENAME}=    iris
 ${PIPELINE_TEST_DESC}=    test pipeline definition
@@ -41,6 +43,8 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    project_title=${PRJ_TITLE}
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${FALSE}
+    Pipeline Context Menu Should Be Readonly    pipeline_name=${PIPELINE_TEST_NAME}
+    Open Data Science Project Details Page    ${PRJ_TITLE}
     Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
     ...    pipeline_description=${PIPELINE_TEST_DESC}
     Capture Page Screenshot
@@ -105,11 +109,8 @@ Verify Pipeline Metadata Pods Are Not Deployed When Running Pipelines
 Pipelines Suite Setup    # robocop: disable
     [Documentation]    Sets global test variables, create a DS project and a data connection
     Set Library Search Order    SeleniumLibrary
+    # TODO: Install Pipeline only if it does not already installed
     Install Red Hat OpenShift Pipelines
-    ${prj_title}=    Set Variable    ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
-    ${iris_pipeline_name}=    Set Variable    ${PIPELINE_TEST_BASENAME}-${TEST_USER_3.USERNAME}
-    Set Suite Variable    ${PRJ_TITLE}    ${prj_title}
-    Set Suite Variable    ${PIPELINE_TEST_NAME}    ${iris_pipeline_name}
     ${to_delete}=    Create List    ${PRJ_TITLE}
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}


### PR DESCRIPTION
- Test that the context menu (right click) of a Pipeline YAML has a command menu, and responds to user typing "Fold all" yaml tags.
- Verify YAML text is readonly (Bug https://github.com/opendatahub-io/odh-dashboard/issues/1689)