### PR TITLE
Add support to create DSC without any conditon for rhods24

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -16,6 +16,8 @@ spec:
       managementState: <modelmeshserving_value>
     ray:
       managementState: <ray_value>
+    trustyai:
+      managementState: <trustyai_value>
     workbenches:
       managementState: <workbenches_value>
 

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -6,7 +6,7 @@ Library    OperatingSystem
 
 *** Variables ***
 ${DSC_NAME} =    default
-@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray  # robocop: disable
+@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai  # robocop: disable
 
 
 *** Keywords ***

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -54,10 +54,7 @@ Verify RHODS Installation
   ${is_codeflare_managed} =     Is CodeFlare Managed
   Log  Will verify CodeFlare operator: ${is_codeflare_managed}  console=yes
   IF  ${is_codeflare_managed}  CodeFlare Operator Should Be Installed
-
-  IF  "${UPDATE_CHANNEL}" != "stable" and "${UPDATE_CHANNEL}" != "beta"
-      Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
-  END
+  Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
   ${dashboard} =    Is Component Enabled    dashboard    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true"
     # Needs to be removed ASAP

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -75,6 +75,7 @@ Verify Openvino_IR Model Via UI
     ...    ODS-2054
     Open Model Serving Home Page
     Try Opening Create Server
+    Open Data Science Projects Home Page
     Wait for RHODS Dashboard to Load    wait_for_cards=${FALSE}    expected_page=Data science projects
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=model-serving-connection


### PR DESCRIPTION
From RHODS 2.4 all the channel will have v2 operator. In this PR we are removing the condition to apply DSC and keep it as a default. 

PS: We can also remove the condition for component verification using update channel but for now the above changes should work for RHODS 2.4