### PR TITLE
[Fix] name of the robotframework keyword `Set NVidia GPU Accelerator`

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/autoscaling-gpus.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/autoscaling-gpus.robot
@@ -58,7 +58,7 @@ Spawn Notebook And Trigger Autoscale
     ...    of the GPU node.
     Select Notebook Image    ${NOTEBOOK_IMAGE}
     Select Container Size    Small
-    Set NVidia GPU Accelerator
+    Set GPU Accelerator
     Set Number Of Required Accelerators    1
     Spawn Notebook    spawner_timeout=20 minutes  expect_autoscaling=${True}
     Run Keyword And Warn On Failure    Wait Until Page Contains    Log in with OpenShift    timeout=15s


### PR DESCRIPTION
Proper name is `Set GPU Accelerator`.

Without this change the test fails with following error:

```
==============================================================================
1046
Verify Number Of Available GPUs Is Correct With Machine Autoscaler... | PASS |
1047
------------------------------------------------------------------------------
1048
Verify Node Autoscales And Then Scales Down :: Tries spawning a se... | FAIL |
1049
No keyword with name 'Set NVidia GPU Accelerator' found. Did you mean:
1050
    JupyterHubSpawner.Set GPU Accelerator
1051
------------------------------------------------------------------------------
1052
Tests.Jupyterhub.Autoscaling-Gpus :: Tests for a scenario in which... | FAIL |
1053
2 tests, 1 passed, 1 failed
```