### PR TITLE
[RHODS-12068] Verify user can edit a PV storage in RHODS project [aut…

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -15,6 +15,7 @@ ${STORAGE_MOUNT_DIR_INPUT_XP}=         xpath=//input[@aria-label="mount-path-fol
 ${STORAGE_WORKBENCH_SELECTOR_XP}=         xpath=//div[contains(@class,"modal")]//div[contains(@class,"pf-c-select")]/ul/li
 ${STORAGE_ADD_BTN_1_XP}=           ${STORAGE_SECTION_XP}//button[.="Add cluster storage"]
 ${STORAGE_ADD_BTN_2_XP}=           xpath=//footer//button[.="Add storage"]
+${STORAGE_UPDATE_BTN}=             xpath=//footer//button[.="Update"]
 
 
 *** Keywords ***
@@ -69,6 +70,16 @@ Create PersistentVolume Storage
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
 
+Edit PersistentVolume Storage
+    [Documentation]    Edit a PersistenVolume storage in DS Project details page - edits name, description and size only
+    [Arguments]    ${project_title}    ${name}    ${new_name}    ${new_description}    ${new_size}
+    Edit Storage    name=${name}
+    Fill In New PV Data    name=${new_name}    description=${new_description}    size=${new_size}
+    Wait Until Element Is Enabled    ${STORAGE_UPDATE_BTN}
+    Click Button    ${STORAGE_UPDATE_BTN}
+    Wait Until Generic Modal Disappears
+    Wait Until Project Is Open    project_title=${project_title}
+
 Fill In New PV Data
     [Documentation]    Compiles the modal for creating a new PersistenVolume storage in DS Project details page
     [Arguments]    ${name}    ${description}    ${size}    ${connected_workbench}=${NONE}
@@ -111,8 +122,14 @@ Set Connection Between PV And Workbench
 Delete Storage
     [Documentation]    Deletes a cluster storage from DS Project details page
     [Arguments]     ${name}    ${press_cancel}=${FALSE}
-    Workbenches.Click Action From Actions Menu    item_title=${name}    item_type=storage    action=Delete
+    ODHDashboard.Click Action From Actions Menu    item_title=${name}    item_type=storage    action=Delete
     Handle Deletion Confirmation Modal    item_title=${name}    item_type=storage    press_cancel=${press_cancel}
+
+Edit Storage
+    [Documentation]    Edits a cluster storage from DS Project details page
+    [Arguments]     ${name}
+    ODHDashboard.Click Action From Actions Menu    item_title=${name}    item_type=storage    action=Edit
+    Wait Until Page Contains Element    ${STORAGE_NAME_INPUT_XP}
 
 Get Openshift PVC From Storage
     [Documentation]    Retrieves the PVC resource name from Openshift given the Displayed Name in DS Project details page

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_edit.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_edit.robot
@@ -4,6 +4,7 @@ Library            SeleniumLibrary
 Library            OpenShiftLibrary
 Resource           ../../../Resources/OCP.resource
 Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
 Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
 Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
 Suite Setup        Project Suite Setup
@@ -24,9 +25,11 @@ ${WORKBENCH_TITLE}=            ODS-CI Workbench 1
 ${WORKBENCH_TITLE_UPDATED}=    ${WORKBENCH_TITLE} Updated
 ${WORKBENCH_DESCRIPTION}=      ODS-CI Workbench 1 is a test workbench using ${NB_IMAGE} image to test DS Projects feature
 ${WORKBENCH_DESC_UPDATED}=     ${WORKBENCH_DESCRIPTION} Updated
-${PV_BASENAME}=                ods-ci-pv
-${PV_DESCRIPTION}=             ods-ci-pv is a PV created to test DS Projects feature
-${PV_SIZE}=                    2    # PV sizes are in GB
+${PV_BASENAME}=                ods-ci-pv-edit
+${PV_DESCRIPTION}=             ods-ci-pv-edit is a PV created to test DS Projects feature
+# PV size are in GB
+${PV_SIZE}=                    2
+${PV_SIZE2}=                   3
 ${DC_S3_NAME}=                 ods-ci-dc
 ${DC_S3_AWS_SECRET_ACCESS_KEY}=    custom dummy secret access key
 ${DC_S3_AWS_ACCESS_KEY}=    custom dummy access key id
@@ -94,6 +97,29 @@ Verify User Can Edit A S3 Data Connection
     Should Be Equal  ${s3_bucket}  ods-ci-ds-pipelines-test
     SeleniumLibrary.Click Button    ${GENERIC_CANCEL_BTN_XP}
     Delete Data Connection    name=${DC_S3_NAME}-test
+
+Verify User Can Edit A PV Storage in DS project
+    [Documentation]    Verifies user can edit a PV storage name, description and size in DS project
+    ...                ProductBug: https://github.com/opendatahub-io/odh-dashboard/issues/1924
+    ...                            https://github.com/opendatahub-io/odh-dashboard/issues/1565
+    [Tags]    Sanity
+    ...       Tier1
+    ...       ODS-1974
+    ...       ProductBug
+    [Setup]    Open Data Science Project Details Page    project_title=${PRJ_TITLE}
+    ${pv_name}=    Set Variable    ${PV_BASENAME}-A
+    ${pv_new_name}=    Set Variable    ${pv_name}-Updated
+    ${pv_new_description}=    Set Variable    ${PV_DESCRIPTION}-Updated
+    ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
+    Create PersistentVolume Storage    project_title=${PRJ_TITLE}    name=${pv_name}    description=${PV_DESCRIPTION}
+    ...                                size=${PV_SIZE}
+    Storage Should Be Listed    name=${pv_name}    description=${PV_DESCRIPTION}
+    ...                         type=Persistent storage    connected_workbench=${NONE}
+    Edit PersistentVolume Storage    ${PRJ_TITLE}    ${pv_name}    ${pv_new_name}
+    ...                              ${pv_new_description}    ${PV_SIZE2}
+    Storage Should Be Listed    name=${pv_new_name}    description=${pv_new_description}
+    ...                         type=Persistent storage    connected_workbench=${NONE}
+    Storage Size Should Be    name=${pv_new_name}    size=${PV_SIZE2}    namespace=${ns_name}
 
 
 *** Keywords ***


### PR DESCRIPTION
...omation]

This commit automates a manual test to check that user can edit name,
description and size of the persistent volume storage created for the
RHODS Data Science project.

Tracking issues [1,2].

[1] https://issues.redhat.com/browse/RHODS-12068
[2] https://issues.redhat.com/browse/RHODS-12869

---

CI: `rhods-ci-pr-test/2104` TODO

---

At the moment the test fails because of the https://github.com/opendatahub-io/odh-dashboard/issues/1565 (discussed also in https://github.com/opendatahub-io/odh-dashboard/issues/1876). It hasn't got into the `main` branch, it's tracked in https://github.com/opendatahub-io/odh-dashboard/issues/1924 and current estimation is the `rhods-2.5` release.

**Note: since the feature branch that fixes this issue contains also UX changes, this test will probably need an update once this is fixed in the product.**