### PR TITLE
[Fix] indentation of the robotframework keyword

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
@@ -71,7 +71,7 @@ Check A RHODS Family Operator Is Installed
       ${result} =  Run Keyword And Return Status
       ...  Oc Get  kind=ClusterServiceVersion  namespace=${namespace}  name=${current_csv_name}
   ELSE
-      ${result} = Set Variable    False
+      ${result} =  Set Variable    False
   END
   Log   Operator with sub ${subscription} is installed result: ${result}      console=yes
   IF  not ${result}     FAIL    The operator with sub ${subscription} is not installed.


### PR DESCRIPTION
This indentation bug resulted in the test failure:

```
==============================================================================
Install "Embedded Operator" RHODS                                     | FAIL |
No keyword with name '${result} = Set Variable' found.
------------------------------------------------------------------------------
Verify Embedded RHODS Installation                                    | PASS |
------------------------------------------------------------------------------
Tests.Deploy.Operators.Rhods Operator.Embedded Operator               | FAIL |
2 tests, 1 passed, 1 failed
```