### PR TITLE
Model Serving smoke test failure due to incorrect page

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -75,6 +75,7 @@ Verify Openvino_IR Model Via UI
     ...    ODS-2054
     Open Model Serving Home Page
     Try Opening Create Server
+    Open Data Science Projects Home Page
     Wait for RHODS Dashboard to Load    wait_for_cards=${FALSE}    expected_page=Data science projects
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=model-serving-connection


### PR DESCRIPTION
Smoke tests in Model serving are failing as the test screen is changed and previous dependant tests are not ran. Fixing screen 
Failures for 2.4: https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/rhods/job/rhods-smoke/3819/