### PR TITLE
[Fix] test versions for the RHODS 2.4; add TrustyAI and HabanaAI

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -410,6 +410,16 @@ Check Versions In JupyterLab
             END
         ELSE IF  "${libDetail}[0]" == "Python"
             ${status} =  Python Version Check  ${libDetail}[1]
+        ELSE IF  "${libDetail}[0]" == "Sklearn-onnx"
+            ${status}  ${value} =  Verify Installed Library Version  skl2onnx  ${libDetail}[1]
+            IF  '${status}' == 'FAIL'
+              ${return_status} =    Set Variable    FAIL
+            END
+        ELSE IF  "${libDetail}[0]" == "MySQL Connector/Python"
+            ${status}  ${value} =  Verify Installed Library Version  mysql-connector-python  ${libDetail}[1]
+            IF  '${status}' == 'FAIL'
+              ${return_status} =    Set Variable    FAIL
+            END
         # CUDA version is checked in GPU-specific test cases, we can skip it here.
         ELSE IF  "${libDetail}[0]" == "CUDA"
             CONTINUE

--- a/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
@@ -17,9 +17,9 @@ Force Tags          JupyterHub
 *** Variables ***
 @{status_list}      # robocop: disable
 &{package_versions}      # robocop: disable
-${JupyterLab_Version}         v3.5
+${JupyterLab_Version}         v3.6
 ${Notebook_Version}           v6.5
-${JupyterLab-git_Version}     v0.41
+${JupyterLab-git_Version}     v0.42
 
 
 *** Test Cases ***
@@ -35,7 +35,7 @@ Verify Libraries in Minimal Image
     Verify List Of Libraries In Image    minimal-notebook    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Cuda Image
-    [Documentation]    Verifies libraries in Minimal Python image
+    [Documentation]    Verifies libraries in Cuda image
     [Tags]    Sanity
     Verify List Of Libraries In Image    minimal-gpu    JupyterLab-git ${JupyterLab-git_Version}
 


### PR DESCRIPTION
- notebook in versions 2023b have newer packages

Relates to: https://github.com/opendatahub-io/notebooks/issues/261

CI: rhods-ci-pr-test/2138