### PR TITLE
[Fix] the Tests.Jupyterhub.Test-Jupyterlab-Git-Notebook

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git.robot
@@ -130,7 +130,7 @@ Push Changes To Remote
     Open With JupyterLab Menu    Git    Push to Remote
     Wait Until Page Contains    Git credentials required    timeout=200s
     Input Text    xpath=//input[@placeholder="username"]    ${github_username}
-    Input Text    xpath=//input[@placeholder="password / personal access token"]    ${token}
+    Input Text    xpath=//input[@placeholder="personal access token"]    ${token}
     Click Element    xpath=//button[.="OK"]
     Sleep    4s
 


### PR DESCRIPTION
The pre-filled input text has been changed in JupyterHub 3.6 when compared to JupyterHub 3.5 used in previous notebook image.

Relates to: https://github.com/opendatahub-io/notebooks/issues/261

CI: rhods-ci-pr-test/2235 :white_check_mark: 