### PR TITLE
[Fix] Tests.Jupyterhub.test-pipChanges-not-permanent

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -475,7 +475,7 @@ Verify Package Is Not Installed In JupyterLab
     [Documentation]  Check Package is not Installed
     [Arguments]  ${package_name}
     Add And Run JupyterLab Code Cell In Active Notebook  import ${package_name}
-    Wait Until JupyterLab Code Cell Is Not Active
+    Wait Until JupyterLab Code Cell Is Not Active    timeout=10seconds
     ${output} =  Get Text  (//div[contains(@class,"jp-OutputArea-output")])[last()]
     ${output}   Split String     ${output}   \n\n
     Should Match  ${output[-1]}   ModuleNotFoundError: No module named '${package_name}'

--- a/ods_ci/tests/Tests/500__jupyterhub/test-pipChanges-not-permanent.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-pipChanges-not-permanent.robot
@@ -21,7 +21,7 @@ Verify pip Changes not permanent
     Stop JupyterLab Notebook Server
     Capture Page Screenshot
     Fix Spawner Status
-    Spawn Notebook With Arguments
+    Spawn Notebook With Arguments    image=minimal-notebook
     Verify Package Is Not Installed In JupyterLab  paramiko
     Capture Page Screenshot
 
@@ -32,4 +32,4 @@ Test Setup
     Begin Web Test
     Wait for RHODS Dashboard to Load
     Launch JupyterHub Spawner From Dashboard
-    Spawn Notebook With Arguments
+    Spawn Notebook With Arguments    image=minimal-notebook


### PR DESCRIPTION
- the `paramiko` is now part of the `science-notebook` so let's use the `minimal-notebook` instead - also, this notebook should be smaller so it could be spinned up a bit faster.
- the default maximum timeout for the check of `import paramiko` failure is too long, let's wait up to 10seconds max.

Relates to: https://github.com/opendatahub-io/notebooks/issues/261

CI: rhods-ci-pr-test/2112