### PR TITLE
[Fix] Verify Elyra Pipelines In SDS-Based Images

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
@@ -58,7 +58,9 @@ Close Properties Panel
 Save Pipeline Changes
     [Documentation]    Saves changes to the pipeline
     Click Element    xpath=//div[contains(@class, 'save-action')]/button
-    Wait Until Page Contains    Saving started
+    # We can also check that `Saving started` text appears but it usually shows up for a very
+    # short amount of time so let's just check the `Saving completed` only.
+    # Wait Until Page Contains    Saving started
     Wait Until Page Contains    Saving completed
 
 Run Pipeline

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -31,7 +31,9 @@ ${KFNBC_MODAL_X_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[@aria-label="Clo
 ${KFNBC_CONTROL_PANEL_HEADER_XPATH} =    //h1[.="Notebook server control panel"]
 ${KFNBC_ENV_VAR_NAME_PRE} =    //span[.="Variable name"]/../../../div[@class="pf-c-form__group-control"]
 ${DEFAULT_PYTHON_VER} =    3.9
-${PREVIOUS_PYTHON_VER} =    3.8
+${PREVIOUS_PYTHON_VER} =    3.9
+${DEFAULT_NOTEBOOK_VER} =    2023.2
+${PREVIOUS_NOTEBOOK_VER} =    2023.1
 
 
 *** Keywords ***
@@ -61,7 +63,7 @@ Select Notebook Image
         Verify Version Dropdown Is Present    ${notebook_image}
         Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
         Click Element
-        ...    xpath=${KFNBC_IMAGE_DROPDOWN}//span[contains(text(), "Python v${PREVIOUS_PYTHON_VER}")]/../input
+        ...    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]/../input
     ELSE
         Verify Version Dropdown Is Present    ${notebook_image}
         Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
@@ -84,8 +86,8 @@ Verify Version Dropdown Is Present
     Page Should Contain Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
     Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
     Wait Until Page Contains Element    xpath=${KFNBC_IMAGE_DROPDOWN}
-    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span[contains(text(), "Python v${DEFAULT_PYTHON_VER}")]
-    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span[contains(text(), "Python v${PREVIOUS_PYTHON_VER}")]
+    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]
+    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]
     Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
 
 Select Container Size

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -193,8 +193,8 @@ Verify Version Selection Dropdown
     Page Should Contain Element    xpath=${WORKBENCH_IMAGE_VER_BUTTON}//div[contains(text(),"Recommended")]
     Click Element    xpath=${WORKBENCH_IMAGE_VER_BUTTON}
     Wait Until Page Contains Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}
-    Page Should Contain Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span[contains(text(), "Python v${DEFAULT_PYTHON_VER}")]
-    Page Should Contain Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span[contains(text(), "Python v${PREVIOUS_PYTHON_VER}")]
+    Page Should Contain Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]
+    Page Should Contain Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]
     Click Element    xpath=${WORKBENCH_IMAGE_VER_BUTTON}
 
 Select Workbench Image Version
@@ -204,9 +204,9 @@ Select Workbench Image Version
     Click Element    xpath=${WORKBENCH_IMAGE_VER_BUTTON}
     Wait Until Page Contains Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}
     IF    "${version}"=="default"
-        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span[contains(text(), "Python v${DEFAULT_PYTHON_VER}")]/..
+        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]/..
     ELSE IF    "${version}"=="previous"
-        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span[contains(text(), "Python v${PREVIOUS_PYTHON_VER}")]/..
+        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]/..
     ELSE
         Fail    ${version} does not exist, use default/previous
     END


### PR DESCRIPTION
Two recent images both use Python 3.9 so we need to distinguish notebook image version by other means - let's do it via actual notebook version instead. This also means we need to adjust the xPath there.

I kept the original properties since they are used on some other place to check an actual Python version which we can want in the future.

Another change - since during the saving of the changes in Elyra
pipelines the text `Saving started` is usually showed for a very short
amount of time, let's skip this check and just wait for the text `Saving
completed` only. Otherwise it is very fragile and error-prone in our CI.

Relates to: https://github.com/opendatahub-io/notebooks/issues/261

CI: rhods-ci-pr-test/2123