### PR TITLE
Fix monitoring tests in Smoke for RHODS 2.4.0

### DIFF
--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -8,17 +8,19 @@ Suite Setup         RHOSi Setup
 Suite Teardown      RHOSi Teardown
 Test Setup          Begin Metrics Web Test
 Test Teardown       End Metrics Web Test
+Test Tags           ExcludeOnODH
 
 
 *** Variables ***
-@{RECORD_GROUPS}    Availability Metrics    SLOs - ODH Dashboard
-...    SLOs - RHODS Operator    Usage Metrics
+@{RECORD_GROUPS}    SLOs - MCAD Controller     SLOs - CodeFlare Operator
+...    SLOs - Data Science Pipelines Operator    SLOs - Data Science Pipelines Application
+...    SLOs - Modelmesh Controller
+...    SLOs - ODH Model Controller
+...    SLOs - RHODS Operator v2
 
-@{ALERT_GROUPS}     Builds    DeadManSnitch    RHODS Notebook controllers
-...    RHODS-PVC-Usage    SLOs-haproxy_backend_http_responses_total    SLOs-probe_success
-
-@{ALERT_GROUPS_120}    DeadManSnitch    RHODS Notebook controllers
-...    RHODS-PVC-Usage    SLOs-haproxy_backend_http_responses_total    SLOs-probe_success
+@{ALERT_GROUPS}     SLOs-probe_success    Distributed Workloads CodeFlare
+...    SLOs-haproxy_backend_http_responses_dsp    RHODS Data Science Pipelines
+...    DeadManSnitch    RHODS operator
 
 
 *** Test Cases ***
@@ -123,12 +125,7 @@ Check Prometheus Recording Rules
 
 Check Prometheus Alerting Rules
     [Documentation]    Verifies alerting rules in prometheus
-    ${version_check} =  Is RHODS Version Greater Or Equal Than  1.20.0
-    IF    ${version_check}==False
-        Prometheus.Verify Rules    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{ALERT_GROUPS}
-    ELSE
-        Prometheus.Verify Rules    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{ALERT_GROUPS_120}
-    END
+    Prometheus.Verify Rules    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{ALERT_GROUPS}
 
 Read Current CPU Usage
     [Documentation]    Returns list of current cpu usage

--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -51,15 +51,26 @@ Test Metric "Rhods_Total_Users" On Cluster Monitoring Prometheus
     [Teardown]    Close All Browsers
 
 Test Metric "Rhods_Aggregate_Availability" On Cluster Monitoring Prometheus
-    [Documentation]     Verifies the openshift metrics and rhods prometheus showing same rhods_aggregate_availability values
-    [Tags]    Sanity
+    [Documentation]     Verifies metric rhods_aggregate_availability exist in OpenShift > Observe > Metrics and
+    ...   in RHODS Prometheus. Verify their value matches
+    [Tags]    Smoke
     ...       ODS-637
     ...       Tier1
+
     Skip If RHODS Is Self-Managed
-    ${value} =    Run OpenShift Metrics Query    query=rhods_aggregate_availability
-    ${value_from_promothues} =    Fire Query On RHODS Prometheus And Return Value    query=rhods_aggregate_availability
-    Should Be Equal    ${value_from_promothues}    ${value}
-    [Teardown]    Close All Browsers
+
+    ${value_openshift_observe} =    Run OpenShift Metrics Query
+    ...    query=rhods_aggregate_availability
+    ...    retry_attempts=1    return_zero_if_result_empty=False
+
+    SeleniumLibrary.Capture Page Screenshot
+
+    Should Not Be Empty    ${value_openshift_observe}
+    ...    msg=Metric rhods_aggregate_availability is empty in OpenShift>Observe>Metrics
+
+    ${value_prometheus} =    Fire Query On RHODS Prometheus And Return Value    query=rhods_aggregate_availability
+    Should Be Equal    ${value_prometheus}    ${value_openshift_observe}
+    [Teardown]    SeleniumLibrary.Close All Browsers
 
 Test Metric "Active_Users" On OpenShift Monitoring On Cluster Monitoring Prometheus
     [Documentation]    Test launchs notebook for N user and and checks Openshift Matrics showing N active users


### PR DESCRIPTION
Fixes automation errors in Monitoring tests due to the changes in RHODS 2.4.0

Tested successfully in rhods-ci-pr-test/2118:
- _Test Metric "Rhods_Aggregate_Availability" On Cluster Monitoring Prometheus_ failed because of product bug (RHODS-12867)

I'll send a follow-up PR fixing monitoring tests in other quality gates