### PR TITLE
[Fix] of the xpath for the jupyterlab workbench image version check

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -63,7 +63,7 @@ Select Notebook Image
         Verify Version Dropdown Is Present    ${notebook_image}
         Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
         Click Element
-        ...    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]/../input
+        ...    xpath=${KFNBC_IMAGE_DROPDOWN}//label//div[contains(string(), "${PREVIOUS_NOTEBOOK_VER}")]/../../input
     ELSE
         Verify Version Dropdown Is Present    ${notebook_image}
         Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
@@ -86,8 +86,8 @@ Verify Version Dropdown Is Present
     Page Should Contain Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
     Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
     Wait Until Page Contains Element    xpath=${KFNBC_IMAGE_DROPDOWN}
-    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]
-    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]
+    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//label//div[contains(string(), "${DEFAULT_NOTEBOOK_VER}")]
+    Page Should Contain Element    xpath=${KFNBC_IMAGE_DROPDOWN}//label//div[contains(string(), "${PREVIOUS_NOTEBOOK_VER}")]
     Click Element    xpath=${KFNBC_IMAGE_ROW}/../..//button[.="Versions"]
 
 Select Container Size


### PR DESCRIPTION
This is a followup for the previous fix #1016 [1] where I missed that I'm updating two different xpaths actually, which led us into the failing another test.

Relates to: opendatahub-io/notebooks#261

[1] 53ff0d41485485153e95d0433778fee889ff358f

CI check: rhods-ci-pr-test/2131