### PR TITLE
[Fix] we should click on elements that have some size

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -204,9 +204,9 @@ Select Workbench Image Version
     Click Element    xpath=${WORKBENCH_IMAGE_VER_BUTTON}
     Wait Until Page Contains Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}
     IF    "${version}"=="default"
-        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]/..
+        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${DEFAULT_NOTEBOOK_VER}")]/../../..
     ELSE IF    "${version}"=="previous"
-        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]/..
+        Click Element    xpath=${WORKBENCH_IMAGE_VER_DROPDOWN}//span//div[contains(text(), "${PREVIOUS_NOTEBOOK_VER}")]/../../..
     ELSE
         Fail    ${version} does not exist, use default/previous
     END


### PR DESCRIPTION
After recent fix in #1016 [1] we updated the xpath we check for the notebook version. However to click on an element this element has to have some size, which doesn't apply for the targeted `div` element. Let's point to the parent `button` element then.

[1] 53ff0d41485485153e95d0433778fee889ff358f

CI: rhods-ci-pr-test/2147