### PR TITLE
Uninstall RHODS: Delete all subscription instead of the first one only

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -97,7 +97,7 @@ Uninstall RHODS V2
     ${return_code}    ${output}    Run And Return Rc And Output
     ...    oc delete CatalogSource odh-catalog-dev -n openshift-marketplace --ignore-not-found  # robocop: disable
     ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete subscription $(oc get subscription -n ${OPERATOR_NAMESPACE} --no-headers | awk '{print $1}') -n ${OPERATOR_NAMESPACE} --ignore-not-found  # robocop: disable
+    ...    oc delete subscription --all -n ${OPERATOR_NAMESPACE}  # robocop: disable
     Should Be Equal As Integers  ${return_code}   0   msg=Error deleting RHODS subscription
 
     ${return_code}    ${output}    Run And Return Rc And Output


### PR DESCRIPTION
This should fix:

1) When there's no subscription at all, re-install will fail on: 
`error: resource(s) were provided, but no name was specified`

2) Currently Uninstall delete just the first subscription in redhat-ods-operator, which doesn't make scene