### PR TITLE
[Fix] custom image tests and one test removal

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -541,11 +541,12 @@ RHODS Notification Drawer Should Contain
     Close Notification Drawer
 
 Open Notebook Images Page
-    [Documentation]    Opens the RHODS dashboard and navigates to the Notebook Images page
+    [Documentation]    Opens the RHODS dashboard and navigates to the Notebook Image Settings page
     Wait Until Page Contains    Settings
     Page Should Contain    Settings
-    Menu.Navigate To Page    Settings    Notebook images
+    Menu.Navigate To Page    Settings    Notebook image settings
     Wait Until Page Contains    Notebook image settings
+    Wait Until Page Contains    Import new image    # This should assure us that the page content is ready
 
 Import New Custom Image
     [Documentation]    Opens the Custom Image import view and imports an image
@@ -553,7 +554,7 @@ Import New Custom Image
     [Arguments]    ${repo}    ${name}    ${description}    ${software}    ${packages}
     Sleep  1
     Open Custom Image Import Popup
-    Input Text    xpath://input[@id="byon-image-repository-input"]    ${repo}
+    Input Text    xpath://input[@id="byon-image-location-input"]    ${repo}
     Input Text    xpath://input[@id="byon-image-name-input"]    ${name}
     Input Text    xpath://input[@id="byon-image-description-input"]    ${description}
     # No button present anymore?
@@ -563,13 +564,8 @@ Import New Custom Image
 
 Open Custom Image Import Popup
     [Documentation]    Opens the Custom Image import view, using the appropriate button
-    ${first_image} =  Run Keyword And Return Status  Page Should Contain Element  xpath://button[.="Import image"]
-    IF  ${first_image}==True
-        Click Element  xpath://button[.="Import image"]
-    ELSE
-        Click Element  xpath://button[.="Import new image"]
-    END
-    Wait Until Page Contains    Import notebook images
+    Click Element  xpath://button[.="Import new image"]
+    Wait Until Page Contains    Import notebook image
 
 Add Softwares To Custom Image
     [Documentation]    Loops through a dictionary to add software to the custom img metadata
@@ -621,9 +617,9 @@ Delete Custom Image
     ...    Needs an additional check on removed ImageStream
     [Arguments]    ${image_name}
     Click Button  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[last()]//button
-    Click Element  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[last()]//button/..//li[@id="${image_name}-delete-button"]  # robocop: disable
-    Wait Until Page Contains  Do you wish to permanently delete ${image_name}?
-    Click Button  xpath://button[.="Delete"]
+    ${image_name_id} =  Replace String  ${image_name}  ${SPACE}  -
+    Click Element  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[last()]//button/..//li[@id="custom-${image_name_id}-delete-button"]  # robocop: disable
+    Handle Deletion Confirmation Modal  ${image_name}  notebook image
 
 Open Edit Menu For Custom Image
     [Documentation]    Opens the edit view for a specific custom image
@@ -674,14 +670,14 @@ Verify Custom Image Is Listed
     END
     RETURN    ${exists}
 
-Verify Custom Image Owner
+Verify Custom Image Provider
     [Documentation]    Verifies that the user listed for an image in the dahsboard
     ...    UI matches the given one
     [Arguments]    ${image_name}    ${expected_user}
     ${exists} =  Run Keyword And Return Status  Page Should Contain Element  
-    ...  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[@data-label="User" and .="${expected_user}"]  # robocop: disable
+    ...  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[@data-label="Provider" and .="${expected_user}"]  # robocop: disable
     IF  ${exists}==False
-        ${user} =  Get Text  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[@data-label="User"]  # robocop: disable
+        ${user} =  Get Text  xpath://td[@data-label="Name"]/div/div/div[.="${image_name} "]/../../../../td[@data-label="Provider"]  # robocop: disable
         Log  User for ${image_name} does not match ${expected_user} - Actual user is ${user}
         FAIL
     END

--- a/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
@@ -5,6 +5,7 @@ Resource         ../../Resources/Common.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource         ../../Resources/Page/ODH/JupyterHub/GPU.resource
+Resource         ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 Resource         ../../Resources/RHOSi.resource
 Library          JupyterLibrary
 Library          OpenShiftLibrary
@@ -38,12 +39,13 @@ Verify Custom Image Can Be Added
     ...                Then loads the spawner and tries using the custom img
     [Tags]    Sanity    Tier1    ExcludeOnDisconnected
     ...       ODS-1208    ODS-1365
+    ${CLEANUP}=  Set Variable  False
     Create Custom Image
     Sleep    5s    #wait a bit from IS to be created
     Get ImageStream Metadata And Check Name
     Verify Custom Image Is Listed  ${IMG_NAME}
     Verify Custom Image Description  ${IMG_NAME}  ${IMG_DESCRIPTION}
-    Verify Custom Image Owner  ${IMG_NAME}  ${TEST_USER.USERNAME}
+    Verify Custom Image Provider  ${IMG_NAME}  ${TEST_USER.USERNAME}
     Launch JupyterHub Spawner From Dashboard
 
     # These keywords need to be reworked to function here
@@ -55,26 +57,25 @@ Verify Custom Image Can Be Added
     #Should Match  ${spawner_packages}  ${IMG_PACKAGES}
 
     Spawn Notebook With Arguments  image=${IMAGESTREAM_NAME}  size=Small
-    [Teardown]  Custom Image Teardown
+    ${CLEANUP}=  Set Variable  True
+    [Teardown]  Custom Image Teardown  cleanup=${CLEANUP}
 
 Test Duplicate Image
     [Documentation]  Test adding two images with the same name (should fail)
+    ...       ProductBug - https://github.com/opendatahub-io/odh-dashboard/issues/2186
     [Tags]    Sanity    Tier1    ExcludeOnDisconnected
     ...       ODS-1368
+    ...       ProductBug
     Sleep  1
     Create Custom Image
     Sleep  1
     Import New Custom Image    ${IMG_URL}    ${IMG_NAME}    ${IMG_DESCRIPTION}
     ...    software=${IMG_SOFTWARE}
     ...    packages=${IMG_PACKAGES}
-    Run Keyword And Warn On Failure  RHODS Notification Drawer Should Contain
-    ...  Unable to add notebook image ${IMG_NAME}
-    Sleep  1
-    Delete Custom Image  ${IMG_NAME}
-    # If both imgs can be created they also have to be deleted twice
-    Sleep  2
-    Run Keyword And Continue On Failure    Delete Custom Image  ${IMG_NAME}
-    Reset Image Name
+    Wait Until Page Contains    Unable to add notebook image: ${IMG_NAME}
+    # Since the image cannot be created, we need to cancel the modal window now
+    Click Button    ${GENERIC_CANCEL_BTN_XP}
+    [Teardown]  Duplicate Image Teardown
 
 Test Bad Image URL
     [Documentation]  Test adding an image with a bad repo URL (should fail)
@@ -84,10 +85,10 @@ Test Bad Image URL
     ${IMG_URL}=  Set Variable  quay.io/RandomName/RandomImage:v1.2.3
     Set Global Variable  ${IMG_URL}  ${IMG_URL}
     Create Custom Image
-    RHODS Notification Drawer Should Contain  Unable to add notebook image ${IMG_NAME}
-    ${IMG_URL}=  Set Variable  ${OG_URL}
-    Set Global Variable  ${IMG_URL}  ${IMG_URL}
-    Reset Image Name
+    Wait Until Page Contains    Invalid repository URL: ${IMG_URL}
+    # Since the image cannot be created, we need to cancel the modal window now
+    Click Button    ${GENERIC_CANCEL_BTN_XP}
+    [Teardown]  Bad Image URL Teardown  orig_url=${OG_URL}
 
 Test Bad Image Import
     [Documentation]  Import a broken image and confirm it is disabled
@@ -103,8 +104,11 @@ Test Bad Image Import
 
 Test Image From Local registry
     [Documentation]  Try creating a custom image using a local registry URL (i.e. OOTB image)
+    ...       ProductBug - https://github.com/opendatahub-io/odh-dashboard/issues/2185
     [Tags]    Sanity    Tier1
     ...       ODS-2470
+    ...       ProductBug
+    ${CLEANUP}=  Set Variable  False
     Open Notebook Images Page
     ${local_url} =    Get Standard Data Science Local Registry URL
     ${IMG_URL}=    Set Variable    ${local_url}
@@ -112,10 +116,11 @@ Test Image From Local registry
     Create Custom Image
     Get ImageStream Metadata And Check Name
     Verify Custom Image Is Listed    ${IMG_NAME}
-    Verify Custom Image Owner  ${IMG_NAME}  ${TEST_USER.USERNAME}
+    Verify Custom Image Provider  ${IMG_NAME}  ${TEST_USER.USERNAME}
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments  image=${IMAGESTREAM_NAME}  size=Small
-    [Teardown]  Custom Image Teardown
+    ${CLEANUP}=  Set Variable  True
+    [Teardown]  Custom Image Teardown  cleanup=${CLEANUP}
 
 
 *** Keywords ***
@@ -139,8 +144,34 @@ Custom Image Teardown
     END
     Go To  ${ODH_DASHBOARD_URL}
     Open Notebook Images Page
-    Sleep  1
     Delete Custom Image  ${IMG_NAME}
+    Reset Image Name
+
+Duplicate Image Teardown
+    [Documentation]    Closes the Import image dialog (if present), deletes custom images
+    ...    and resets the global variables
+    ${is_modal}=  Is Generic Modal Displayed
+    IF  ${is_modal} == ${TRUE}
+      Click Button  ${GENERIC_CANCEL_BTN_XP}
+    END
+    Delete Custom Image  ${IMG_NAME}
+    # If both imgs can be created they also have to be deleted twice
+    Sleep  2
+    ${exists} =  Run Keyword And Return Status  Page Should Contain Element  xpath://td[@data-label="Name"]/div/div/div[.="${IMG_NAME} "]  # robocop: disable
+    IF  ${exists}==True
+      Delete Custom Image  ${IMG_NAME}
+    END
+    Reset Image Name
+
+Bad Image URL Teardown
+    [Documentation]    Closes the Import image dialog (if present) and resets the global variables
+    [Arguments]    ${orig_url}
+    ${is_modal}=  Is Generic Modal Displayed
+    IF  ${is_modal} == ${TRUE}
+      Click Button  ${GENERIC_CANCEL_BTN_XP}
+    END
+    ${IMG_URL}=  Set Variable  ${orig_url}
+    Set Global Variable  ${IMG_URL}  ${IMG_URL}
     Reset Image Name
 
 Server Cleanup

--- a/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
@@ -90,18 +90,6 @@ Test Bad Image URL
     Click Button    ${GENERIC_CANCEL_BTN_XP}
     [Teardown]  Bad Image URL Teardown  orig_url=${OG_URL}
 
-Test Bad Image Import
-    [Documentation]  Import a broken image and confirm it is disabled
-    ...    in the JH spawner page
-    [Tags]    Sanity    Tier1
-    ...       ODS-1364
-    ${OG_URL}=  Set Variable  ${IMG_URL}
-    ${IMG_URL}=  Set Variable  randomstring
-    Set Global Variable  ${IMG_URL}  ${IMG_URL}
-    Create Custom Image
-    RHODS Notification Drawer Should Contain
-    ...  Unable to add notebook image ${IMG_NAME}
-
 Test Image From Local registry
     [Documentation]  Try creating a custom image using a local registry URL (i.e. OOTB image)
     ...       ProductBug - https://github.com/opendatahub-io/odh-dashboard/issues/2185


### PR DESCRIPTION
This fixes custom image tests against 2.4 RC2 release and removes one test that I believe is redundant now.

There are two tests failing due to the product bug, issues tracked here:

* https://github.com/opendatahub-io/odh-dashboard/issues/2185
* https://github.com/opendatahub-io/odh-dashboard/issues/2186

---

CI: rhods-ci-pr-test/2148

![Screenshot from 2023-11-22 13-20-44](https://github.com/red-hat-data-services/ods-ci/assets/12250881/baf4cf61-bd7f-4d64-be38-bc7c25714563)
