### PR TITLE
[Fix] test to check various user group access

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -103,20 +103,15 @@ Set Custom Access Groups
 Check New Access Configuration Works As Expected
     [Documentation]    Checks if the new access configuration (using two custom groups)
     ...                works as expected in JH
-    Launch Dashboard   ocp_user_name=${TEST_USER.USERNAME}  ocp_user_pw=${TEST_USER.PASSWORD}
-    ...    ocp_user_auth_type=${TEST_USER.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
+    Launch Dashboard   ocp_user_name=${TEST_USER_4.USERNAME}  ocp_user_pw=${TEST_USER_4.PASSWORD}
+    ...    ocp_user_auth_type=${TEST_USER_4.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
     ...    browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
     ...    expected_page=${NONE}    wait_for_cards=${FALSE}
-    ${version_check}=    Is RHODS Version Greater Or Equal Than    1.20.0
-    IF    ${version_check} == True
-        ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link
-        Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${FALSE}
-        Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
-        Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
-    ELSE
-        Launch Jupyter From RHODS Dashboard Link
-        Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=none
-    END
+    ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link
+    Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${FALSE}
+    Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
+    Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
+
     Capture Page Screenshot    perm_denied_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_2.USERNAME}  ${TEST_USER_2.PASSWORD}  ${TEST_USER_2.AUTH_TYPE}


### PR DESCRIPTION
The existing test checks that users from different groups have different
access and that this access can be setup via RHOAI User settings.

What this test does:

* creates a `custom-admins-group` with `TEST_USER2` user
* creates a `custom-users-group` with `TEST_USER3` user
* configures first group as admins in RHOAI User settings
* configures second group as users in RHOAI User settings

Once this was applied it tried to perform operations with three
different users:

* TEST_USER - expected no privileges and simple `Access
  permissions needed` page presented
* TEST_USER2 - all privileges
* TEST_USER3 - no Administration page shown

Problem in this approach is that the `TEST_USER` is part of the
`dedicated-admins` group, which has a `cluster-admin` role in our
default cluster settings. Per this [1], such user is an admin by
default.

So my changes incorporates usage of the `TEST_USER4` instead of
`TEST_USER`.

Also, unnecessary check for the product version is removed with this
commit.

[1] https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html-single/managing_users_and_user_resources/index#defining-openshift-data-science-admin-and-user-groups_user-mgmt
```
By default, users with cluster admin permissions and users in the
dedicated-admins administrator group are OpenShift Data Science
administrators, but all users authenticated in OpenShift can access
OpenShift Data Science. A cluster admin is a superuser that can perform
any action in any project in the OpenShift cluster.
```

---

CI: rhods-ci-pr-test/2159