### PR TITLE
Check DS listed project by link instead of xpath

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -90,7 +90,7 @@ Wait Until Project Is Open
 Project Should Be Listed
     [Documentation]    Checks a Project is available in DS Project home page
     [Arguments]     ${project_title}
-    Run Keyword And Continue On Failure     Page Should Contain Element    xpath=//td/div/a[text()="${project_title}"]
+    Run Keyword And Continue On Failure     Page Should Contain Link    ${project_title}
 
 Wait Until Project Is Listed
     [Documentation]    Waits until the DS projects appears in the list in DS project Home Page
@@ -101,7 +101,7 @@ Wait Until Project Is Listed
 Project Should Not Be Listed
     [Documentation]    Checks a Project is not available in DS Project home page
     [Arguments]     ${project_title}
-    Run Keyword And Continue On Failure     Page Should Not Contain Element    xpath=//td/div/a[text()="${project_title}"]
+    Run Keyword And Continue On Failure     Page Should Not Contain Link    ${project_title}
 
 Project's Owner Should Be
     [Documentation]    Checks if the owner of a DS project is displayed and corresponds to the expected one


### PR DESCRIPTION
This minor fix replaces the hardcoded xpath in Dashboard keywords:
- Project Should Be Listed: Page Should Contain Element {xpath}
- Project Should Not Be Listed: Page Should Not Contain Element {xpath}

With the builtin RF keywords that locate the project link without an xpath:
- Page Should Contain Link
- Page Should Not Contain Link

Verified:
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/ad8624d8-48fd-4291-b85c-6335de55cc07)
