### PR TITLE
Fix alerting recording tests components enabled

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -186,7 +186,7 @@ Wait For Pods Numbers
 
 Apply DataScienceCluster CustomResource
     [Documentation]
-    [Arguments]        ${dsc_name}=default
+    [Arguments]        ${dsc_name}=${DSC_NAME}
     ${file_path} =    Set Variable    tasks/Resources/Files/
     Log to Console    Requested Configuration:
     FOR    ${cmp}    IN    @{COMPONENT_LIST}
@@ -216,7 +216,7 @@ Apply DataScienceCluster CustomResource
 
 Create DataScienceCluster CustomResource Using Test Variables
     [Documentation]
-    [Arguments]    ${dsc_name}=default
+    [Arguments]    ${dsc_name}=${DSC_NAME}
     ${file_path} =    Set Variable    tasks/Resources/Files/
     Copy File    source=${file_path}dsc_template.yml    destination=${file_path}dsc_apply.yml
     Run    sed -i 's/<dsc_name>/${dsc_name}/' ${file_path}dsc_apply.yml
@@ -231,30 +231,31 @@ Create DataScienceCluster CustomResource Using Test Variables
     END
 
 Component Should Be Enabled
-    [Arguments]    ${component}    ${dsc_name}=default
+    [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
     ${status} =    Is Component Enabled    ${component}    ${dsc_name}
     IF    '${status}' != 'true'    Fail
 
 Component Should Not Be Enabled
-    [Arguments]    ${component}    ${dsc_name}=default
+    [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
     ${status} =    Is Component Enabled    ${component}    ${dsc_name}
     IF    '${status}' != 'false'    Fail
 
 Is Component Enabled
     [Documentation]    Returns the enabled status of a single component (true/false)
-    [Arguments]    ${component}    ${dsc_name}=default
+    [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
     ${return_code}    ${output} =    Run And Return Rc And Output    oc get datasciencecluster ${dsc_name} -o json | jq '.spec.components.${component}.managementState'  #robocop:disable
-    Log    ${output}
-    Should Be Equal As Integers  ${return_code}  0  msg=Error detected while getting component status
+    Log    ${component}:${output}
+    Should Be Equal As Integers  ${return_code}  0  msg=Error detected while getting component ${component} status
     ${n_output} =    Evaluate    '${output}' == ''
     IF  ${n_output}
-          RETURN    false
+        Log       message=Error detected while getting component ${component} status    level=ERROR
+        RETURN    false
     ELSE
-         IF    ${output} == "Removed"
-               RETURN    false
-         ELSE IF    ${output} == "Managed"
-              RETURN    true
-         END
+        IF    ${output} == "Removed"
+            RETURN    false
+        ELSE IF    ${output} == "Managed"
+            RETURN    true
+        END
     END
 
 Create Catalog Source For Operator

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -232,6 +232,12 @@ Skip If RHODS Is Managed
        Skip If    condition=${is_self_managed}==False    msg=This test is skipped for Managed RHODS
     END
 
+Skip If Component Is Not Enabled
+    [Documentation]    Skips test if ${component_name} is not enabled in DataScienceCluster
+    [Arguments]    ${component_name}
+    ${enabled}=    Is Component Enabled    ${component_name}
+    Skip If    "${enabled}" == "false"    msg=This test is skipped because component ${component_name} is not enabled
+
 Run Keyword If RHODS Is Managed
     [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Managed (Cloud Version)
     [Arguments]    ${name}    @{arguments}
@@ -244,6 +250,12 @@ Run Keyword If RHODS Is Self-Managed
     [Arguments]    ${name}    @{arguments}
     ${is_self_managed}=    Is RHODS Self-Managed
     IF    ${is_self_managed} == True    Run Keyword    ${name}    @{arguments}
+
+Run Keyword If Component Is Enabled
+    [Documentation]    Runs keyword ${name} using  @{arguments} if ${component_name} is enabled
+    [Arguments]    ${component_nane}    ${name}    @{arguments}
+    ${enabled}=    Is Component Enabled    ${component_nane}
+    IF    "${enabled}" == "true"    Run Keyword    ${name}    @{arguments}
 
 Get Domain From Current URL
     [Documentation]    Gets the lowest level domain from the current URL (i.e. everything before the first dot in the URL)
@@ -363,7 +375,7 @@ Run And Watch Command
   ${is_test}=    Run keyword And Return Status    Variable Should Exist     ${TEST NAME}
   IF    ${is_test} == ${FALSE}
     ${incremental}=    Generate Random String    5    [NUMBERS]
-    ${TEST NAME}=    Set Variable    testlogs-${incremental}    
+    ${TEST NAME}=    Set Variable    testlogs-${incremental}
   END
   ${process_log} =    Set Variable    ${OUTPUT DIR}/${TEST NAME}.log
   ${temp_log} =    Set Variable    ${TEMPDIR}/${TEST NAME}.log
@@ -408,8 +420,3 @@ Escape String Chars
     END
     RETURN    ${str}
 
-Skip If Component Is Not Enabled
-    [Documentation]    Skips test if ${component_name} is not enabled in DataScienceCluster
-    [Arguments]    ${component_name}
-    ${enabled}=    Is Component Enabled    ${component_name}
-    Skip If    "${enabled}" == "false"

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -65,11 +65,8 @@ Is RHODS Self-Managed
     ...                 in the cluster (e.g., usually on OSD, ROSA).
     ...                 Returns ${TRUE} if RHODS Self-Managed is installed or if PRODUCT=ODH
     IF  "${PRODUCT}" == "ODH"  RETURN     ${TRUE}
-    ${is_managed} =    Run Keyword And Return Status    OpenshiftLibrary.Oc Get
-    ...                                                      kind=CatalogSource
-    ...                                                      name=addon-managed-odh-catalog
-    ...                                                      namespace=${OPERATOR_NAMESPACE}
-    Run Keyword And Return    Evaluate    not ${is_managed}
+    ${rc} =    Run And Return Rc    oc get catalogsource addon-managed-odh-catalog -n ${OPERATOR_NAMESPACE}
+    Run Keyword And Return    Run Keyword And Return Status      Should Not Be Equal As Numbers    ${rc}    ${0}
 
 Get MachineSets
     [Documentation]    Returns a list of machinesets names

--- a/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
+++ b/ods_ci/tests/Resources/Page/ODH/Monitoring/Monitoring.resource
@@ -2,6 +2,7 @@
 Documentation       Contains ODS Monitoring Keywords
 
 Resource            ../Prometheus/Prometheus.resource
+Resource            ../../../Common.robot
 
 
 *** Variables ***
@@ -10,6 +11,33 @@ ${SUITE_AVAILABILITY_2M}        0
 ${SUITE_AVAILABILITY_15M}       0
 ${SUITE_AVAILABILITY_1H}        0
 ${SUITE_AVAILABILITY_3H}        0
+
+@{RECORD_GROUPS}    SLOs - MCAD Controller     SLOs - CodeFlare Operator
+...    SLOs - Data Science Pipelines Operator    SLOs - Data Science Pipelines Application
+...    SLOs - Modelmesh Controller
+...    SLOs - ODH Model Controller
+...    SLOs - RHODS Operator v2
+
+@{CODEFLARE_ALERTING_GROUPS}                SLOs-probe_success_codeflare    Distributed Workloads CodeFlare
+@{CODEFLARE_RECORDING_GROUPS}               SLOs - MCAD Controller    SLOs - CodeFlare Operator
+@{DASHBOARD_ALERTING_GROUPS}                SLOs-haproxy_backend_http_responses_dashboard   SLOs-probe_success_dashboard
+@{DASHBOARD_RECORDING_GROUPS}               SLOs - ODH Dashboard
+@{DATASCIENCEPIPELINES_ALERTING_GROUPS}     SLOs-haproxy_backend_http_responses_dsp
+...                                         SLOs-probe_success_dsp    RHODS Data Science Pipelines
+@{DATASCIENCEPIPELINES_RECORDING_GROPUS}    SLOs - Data Science Pipelines Operator
+...                                         SLOs - Data Science Pipelines Application
+@{DEADMANSNITCH_ALERTING_GROUPS}            DeadManSnitch
+@{KSERVE_ALERTING_GROUPS}
+@{KSERVE_RECORDING_GROUPS}
+@{MODELMESHSERVING_ALERTING_GROUPS}         SLOs-probe_success_modelmesh    SLOs-probe_success_model_controller
+@{MODELMESHSERVING_RECORDING_GROUPS}        SLOs - Modelmesh Controller    SLOs - ODH Model Controller
+@{RAY_ALERTING_GROUPS}                      Distributed Workloads Kuberay
+@{RAY_RECORDING_GROUPS}
+@{TRUSTYAI_ALERTING_GROUPS}
+@{TRUSTYAI_RECORDING_GROUPS}
+@{WORKBENCHES_ALERTING_GROUPS}              RHODS-PVC-Usage    RHODS Notebook controllers
+...                                         SLOs-probe_success_workbench
+@{WORKBENCHES_RECORDING_GROUPS}             SLOs - Notebook Controller    Usage Metrics    Availability Metrics
 
 
 *** Keywords ***
@@ -160,3 +188,17 @@ Get Thanos Metrics List
     END
     ${rc}    ${out}=    Run And Return Rc And Output    ${cmd} | tr -d '"'
     RETURN    ${out}
+
+Verify DeadManSnitch Alerting Rules
+    [Documentation]    Verifies DeadManSnitch alerting rules in prometheus
+    Prometheus.Verify Rules
+    ...    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{DEADMANSNITCH_ALERTING_GROUPS}
+
+Verify Component Alerting Rules
+    [Documentation]    Verifies alerting rules for a component in prometheus
+    [Arguments]    ${component_name}    ${component_alerting_groups}
+    Run Keyword If Component Is Enabled
+    ...    ${component_name}
+    ...    Prometheus.Verify Rules
+    ...    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{component_alerting_groups}
+

--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -3,6 +3,7 @@ Documentation       Test suite testing ODS Metrics
 Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Common.robot
+Resource            ../../../Resources/Page/ODH/Monitoring/Monitoring.resource
 Library             DateTime
 Suite Setup         RHOSi Setup
 Suite Teardown      RHOSi Teardown
@@ -18,20 +19,25 @@ Test Tags           ExcludeOnODH
 ...    SLOs - ODH Model Controller
 ...    SLOs - RHODS Operator v2
 
-@{ALERT_GROUPS}     SLOs-probe_success_codeflare    Distributed Workloads CodeFlare
-...    SLOs-haproxy_backend_http_responses_dsp    RHODS Data Science Pipelines    SLOs-probe_success_dsp
-...    SLOs-probe_success_modelmesh     SLOs-probe_success_dashboard    SLOs-probe_success_workbench
-...    DeadManSnitch
-
 
 *** Test Cases ***
 Test Existence of Prometheus Alerting Rules
-    [Documentation]    Verifies the prometheus alerting rules
+    [Documentation]    Verifies the prometheus alerting rules for all components
+    ...    Note: kserve and trustyai are disabled because they don't have any alerting rule
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-509
+    ...       robot:recursive-continue-on-failure
     Skip If RHODS Is Self-Managed
-    Check Prometheus Alerting Rules
+    Verify DeadManSnitch Alerting Rules
+    Verify Component Alerting Rules    codeflare               ${CODEFLARE_ALERTING_GROUPS}
+    Verify Component Alerting Rules    dashboard               ${DASHBOARD_ALERTING_GROUPS}
+    Verify Component Alerting Rules    datasciencepipelines    ${DATASCIENCEPIPELINES_ALERTING_GROUPS}
+    #Verify Component Alerting Rules    kserve                  ${KSERVE_ALERTING_GROUPS}
+    Verify Component Alerting Rules    modelmeshserving        ${MODELMESHSERVING_ALERTING_GROUPS}
+    Verify Component Alerting Rules    ray                     ${RAY_ALERTING_GROUPS}
+    #Verify Component Alerting Rules    trustyai                ${TRUSTYAI_ALERTING_GROUPS}
+    Verify Component Alerting Rules    workbenches             ${WORKBENCHES_ALERTING_GROUPS}
 
 Test Existence of Prometheus Recording Rules
     [Documentation]    Verifies the prometheus recording rules
@@ -51,6 +57,7 @@ Test Metric "Notebook CPU Usage" On ODS Prometheus
     Run Jupyter Notebook For 5 Minutes
     Wait Until Keyword Succeeds    10 times   30s
     ...    CPU Usage Should Have Increased    ${cpu_usage_before}
+
 
 Test Metric "Rhods_Total_Users" On ODS Prometheus
     [Documentation]    Verifies that metric value for rhods_total_users
@@ -118,15 +125,11 @@ Begin Metrics Web Test
 
 End Metrics Web Test
     [Documentation]    Test Teardown
-    Close All Browsers
+    SeleniumLibrary.Close All Browsers
 
 Check Prometheus Recording Rules
     [Documentation]    Verifies recording rules in prometheus
     Prometheus.Verify Rules    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    record    @{RECORD_GROUPS}
-
-Check Prometheus Alerting Rules
-    [Documentation]    Verifies alerting rules in prometheus
-    Prometheus.Verify Rules    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    alert    @{ALERT_GROUPS}
 
 Read Current CPU Usage
     [Documentation]    Returns list of current cpu usage


### PR DESCRIPTION
* Speed up keyword `Is RHODS Self-Managed`
* Add keyword `Skip If Component Is Not Enabled`
* Fix test checking monitoring alerting rules to verify only rules for enabled components