### PR TITLE
Temporally disable verifications of CodeFlare alerting and recording rules for 2.4

### DIFF
--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/200__metrics.robot
@@ -12,14 +12,12 @@ Test Tags           ExcludeOnODH
 
 
 *** Variables ***
-@{RECORD_GROUPS}    SLOs - MCAD Controller     SLOs - CodeFlare Operator
-...    SLOs - Data Science Pipelines Operator    SLOs - Data Science Pipelines Application
+@{RECORD_GROUPS}    SLOs - Data Science Pipelines Operator    SLOs - Data Science Pipelines Application
 ...    SLOs - Modelmesh Controller
 ...    SLOs - ODH Model Controller
 ...    SLOs - RHODS Operator v2
 
-@{ALERT_GROUPS}     SLOs-probe_success_codeflare    Distributed Workloads CodeFlare
-...    SLOs-haproxy_backend_http_responses_dsp    RHODS Data Science Pipelines    SLOs-probe_success_dsp
+@{ALERT_GROUPS}    SLOs-haproxy_backend_http_responses_dsp    RHODS Data Science Pipelines    SLOs-probe_success_dsp
 ...    SLOs-probe_success_modelmesh     SLOs-probe_success_dashboard    SLOs-probe_success_workbench
 ...    DeadManSnitch
 


### PR DESCRIPTION
The tests `Test Existence of Prometheus Alerting Rules` and `Test Existence of Prometheus Recording Rules` are failing in OpenShift AI 2.4  because CodeFlare is not enabled by default and their rules are not found when running the tests.

This PR is removing CodeFlare's rules so they are not checked for ods-ci 2.4.

For 2.5, the tests will be enhanced to check only the rules for enabled components. This is still a WIP in PR  #1040

Tested successfully in rhods-smoke/3986