### PR TITLE
fix: Dashboards UI Tests 1775 and 1814

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -107,7 +107,7 @@ Project's Owner Should Be
     [Documentation]    Checks if the owner of a DS project is displayed and corresponds to the expected one
     [Arguments]     ${project_title}    ${expected_username}
     Run Keyword And Continue On Failure
-    ...    Page Should Contain Element    xpath=//td[div/a[text()="${project_title}"]]/small[text()="${expected_username}"]
+    ...    Page Should Contain Element    xpath=//td[div/div/a[text()="${project_title}"]]/small[text()="${expected_username}"]
 
 Create Data Science Project
     [Documentation]    Creates a DS Project with the given ${title}, ${description} and ${resource_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -14,7 +14,7 @@ ${STORAGE_SIZE_PLUS_BTN_XP}=         xpath=//div/button[@aria-label="Plus"]
 ${STORAGE_MOUNT_DIR_INPUT_XP}=         xpath=//input[@aria-label="mount-path-folder-value"]
 ${STORAGE_WORKBENCH_SELECTOR_XP}=         xpath=//div[contains(@class,"modal")]//div[contains(@class,"pf-c-select")]/ul/li
 ${STORAGE_ADD_BTN_1_XP}=           ${STORAGE_SECTION_XP}//button[.="Add cluster storage"]
-${STORAGE_ADD_BTN_2_XP}=           xpath=//footer/button[.="Add storage"]
+${STORAGE_ADD_BTN_2_XP}=           xpath=//footer//button[.="Add storage"]
 
 
 *** Keywords ***


### PR DESCRIPTION
Fixes for Dashboard Tests 1775 and 1814. 

Results can be found on execution 3989 of the smoke pipeline.


```
2 tests, 2 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Ods Dashboard Projects                            | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
```