### PR TITLE
Update Model Serving tests for 2.5

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -50,15 +50,19 @@ Serving Runtime Template Should Be Listed
     ...    timeout=10s
     Run Keyword And Continue On Failure
     ...    SeleniumLibrary.Wait Until Page Contains Element
-    ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]
-    ${actual_platform_labels_str}=    SeleniumLibrary.Get Text    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]
+    ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]    # robocop: disable
+    ${actual_platform_labels_str}=    SeleniumLibrary.Get Text
+    ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]    # robocop: disable
     ${actual_platform_labels}=    Split To Lines    ${actual_platform_labels_str}
     IF    "${serving_platform}" == "both"
         Run Keyword And Continue On Failure    Length Should Be    ${actual_platform_labels}    ${2}
-        ${exp_platform_labels}=    Create List    ${PLATFORM_LABELS_MAPPING}[single]    ${PLATFORM_LABELS_MAPPING}[multi]
-        Run Keyword And Continue On Failure    Lists Should Be Equal    ${actual_platform_labels}    ${exp_platform_labels}
+        ${exp_platform_labels}=    Create List    ${PLATFORM_LABELS_MAPPING}[single]
+        ...    ${PLATFORM_LABELS_MAPPING}[multi]
+        Run Keyword And Continue On Failure    Lists Should Be Equal    ${actual_platform_labels}
+        ...    ${exp_platform_labels}
     ELSE
-        Run Keyword And Continue On Failure    Should Be Equal    ${actual_platform_labels_str}    ${PLATFORM_LABELS_MAPPING}[${serving_platform}]
+        Run Keyword And Continue On Failure    Should Be Equal    ${actual_platform_labels_str}
+        ...    ${PLATFORM_LABELS_MAPPING}[${serving_platform}]
     END
 
 Delete Serving Runtime Template
@@ -87,7 +91,6 @@ Get OpenShift Template Resource Name By Displayed Name
 Select Model Serving Platform
     [Documentation]    Selects which model serving platform the serving runtime could be executed on
     [Arguments]    ${platform}="both"
-    
     ${platform_link_name}=    Set Variable    Single model serving platform
     ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
     SeleniumLibrary.Click Element    css:div#custom-serving-runtime-selection > button

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -84,7 +84,7 @@ Delete Serving Runtime Template From CLI
 Get OpenShift Template Resource Name By Displayed Name
     [Arguments]    ${displayed_name}
     ${rc}    ${resource_name}=    Run And Return Rc And Output
-    ...    oc get templates -ojson -n ${APPLICATIONS_NAMESPACE} | jq '.items[] | select(.objects[].metadata.annotations."openshift.io/display-name"=="${displayed_name}") | .metadata.name' | tr -d '"'
+    ...    oc get templates -ojson -n ${APPLICATIONS_NAMESPACE} | jq '.items[] | select(.objects[].metadata.annotations."openshift.io/display-name"=="${displayed_name}") | .metadata.name' | tr -d '"'    # robocop: disable
     Should Be Equal As Integers    ${rc}    ${0}
     RETURN    ${resource_name}
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -9,6 +9,9 @@ ${SUBMIT_RUNTIME_BTN_XP}=    //button[text()="Add"]
 ${UPLOAD_RUNTIME_BTN_XP}=    //button[text()="Upload files"]
 ${SCRATCH_RUNTIME_BTN_XP}=    //button[text()="Start from scratch"]
 ${EDITOR_RUNTIME_BTN_XP}=    //div[contains(@class, "odh-dashboard__code-editor")]
+&{PLATFORM_NAMES_MAPPING}=    single=Single model serving platform    multi=Multi-model serving platform
+...    both=Both single and multi-model serving platforms
+&{PLATFORM_LABELS_MAPPING}=    single=Single model    multi=Multi-model
 
 
 *** Keywords ***
@@ -23,7 +26,7 @@ Click Add Serving Runtime Template Button
     
 Upload Serving Runtime Template
     [Documentation]    Uploads via UI a YAML file containing a custom Serving Runtime definition
-    [Arguments]    ${runtime_filepath}
+    [Arguments]    ${runtime_filepath}    ${serving_platform}
     Click Add Serving Runtime Template Button
     SeleniumLibrary.Click Element   ${UPLOAD_RUNTIME_BTN_XP}
     ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
@@ -31,6 +34,7 @@ Upload Serving Runtime Template
     SeleniumLibrary.Choose File    ${EDITOR_RUNTIME_BTN_XP}//input[@type="file"]    ${pwd}/${runtime_filepath}
     Run Keyword And Continue On Failure    SeleniumLibrary.Wait Until Page Contains Element    //span[text()="kind"]
     Run Keyword And Continue On Failure    SeleniumLibrary.Wait Until Page Contains Element    //span[text()="ServingRuntime"]
+    Select Model Serving Platform    platform=${serving_platform}
     Submit Serving Runtime Template
 
 Submit Serving Runtime Template
@@ -39,11 +43,23 @@ Submit Serving Runtime Template
     ...    wait_for_cards=${FALSE}
 
 Serving Runtime Template Should Be Listed
-    [Arguments]    ${displayed_name}
+    [Arguments]    ${displayed_name}    ${serving_platform}
     Run Keyword And Continue On Failure
     ...    SeleniumLibrary.Wait Until Page Contains Element
     ...    //table//tr/td[@data-label="Name"]//div[text()="${displayed_name}"]
     ...    timeout=10s
+    Run Keyword And Continue On Failure
+    ...    SeleniumLibrary.Wait Until Page Contains Element
+    ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]
+    ${actual_platform_labels_str}=    SeleniumLibrary.Get Text    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]
+    ${actual_platform_labels}=    Split To Lines    ${actual_platform_labels_str}
+    IF    "${serving_platform}" == "both"
+        Run Keyword And Continue On Failure    Length Should Be    ${actual_platform_labels}    ${2}
+        ${exp_platform_labels}=    Create List    ${PLATFORM_LABELS_MAPPING}[single]    ${PLATFORM_LABELS_MAPPING}[multi]
+        Run Keyword And Continue On Failure    Lists Should Be Equal    ${actual_platform_labels}    ${exp_platform_labels}
+    ELSE
+        Run Keyword And Continue On Failure    Should Be Equal    ${actual_platform_labels_str}    ${PLATFORM_LABELS_MAPPING}[${serving_platform}]
+    END
 
 Delete Serving Runtime Template
     [Arguments]    ${displayed_name}    ${press_cancel}=${FALSE}
@@ -68,3 +84,12 @@ Get OpenShift Template Resource Name By Displayed Name
     Should Be Equal As Integers    ${rc}    ${0}
     RETURN    ${resource_name}
 
+Select Model Serving Platform
+    [Documentation]    Selects which model serving platform the serving runtime could be executed on
+    [Arguments]    ${platform}="both"
+    
+    ${platform_link_name}=    Set Variable    Single model serving platform
+    ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
+    SeleniumLibrary.Click Element    css:div#custom-serving-runtime-selection > button
+    SeleniumLibrary.Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]
+    SeleniumLibrary.Click Link    ${platform_link_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -80,7 +80,7 @@ Delete Serving Runtime Template From CLI
 Get OpenShift Template Resource Name By Displayed Name
     [Arguments]    ${displayed_name}
     ${rc}    ${resource_name}=    Run And Return Rc And Output
-    ...    oc get templates -ojson -n redhat-ods-applications | jq '.items[] | select(.objects[].metadata.annotations."openshift.io/display-name"=="${displayed_name}") | .metadata.name' | tr -d '"'
+    ...    oc get templates -ojson -n ${APPLICATIONS_NAMESPACE} | jq '.items[] | select(.objects[].metadata.annotations."openshift.io/display-name"=="${displayed_name}") | .metadata.name' | tr -d '"'
     Should Be Equal As Integers    ${rc}    ${0}
     RETURN    ${resource_name}
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -91,7 +91,6 @@ Get OpenShift Template Resource Name By Displayed Name
 Select Model Serving Platform
     [Documentation]    Selects which model serving platform the serving runtime could be executed on
     [Arguments]    ${platform}="both"
-    ${platform_link_name}=    Set Variable    Single model serving platform
     ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
     SeleniumLibrary.Click Element    css:div#custom-serving-runtime-selection > button
     SeleniumLibrary.Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -23,6 +23,7 @@ ${SERVING_ACCELERATOR_INPUT_XPATH}=    xpath=//input[@aria-label='Number of acce
 ${SERVING_ACCELERATOR_MINUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/preceding-sibling::button
 ${SERVING_ACCELERATOR_PLUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/following-sibling::button
 ${SERVING_MODEL_SERVERS_SIDE_MENU}=    xpath=//span[text()='Models and model servers']
+${TOKEN_AUTH_CHECKBOX_XP}=    xpath://input[@id="alt-form-checkbox-auth"]
 
 *** Keywords ***
 Create Model Server
@@ -47,11 +48,14 @@ Create Model Server
     END
     IF    ${ext_route}==${TRUE}
         Enable External Serving Route
-    END
-    IF    ${token}==${TRUE}
-        Enable Token Authentication
-        # Set Service Account name
-        # Add Service Account
+        IF    ${token}==${FALSE}
+            Disable Token Authentication
+        ELSE
+            Log    message=Token Auth should be enabled by default..(from v2.5)
+            SeleniumLibrary.Checkbox Should Be Selected    ${TOKEN_AUTH_CHECKBOX_XP}
+        END
+    ELSE IF    ${token}==${TRUE}
+        Enable Token Authentication            
     END
     Click Button    Add
     Sleep    1s    reason=Sometimes the modal will intercept later clicks even after being closed, wait for a second
@@ -157,7 +161,12 @@ Enable External Serving Route
 
 Enable Token Authentication
     [Documentation]    Enables Token authentication to serving route
-    Select Checkbox    xpath://input[@id="alt-form-checkbox-auth"]
+    SeleniumLibrary.Select Checkbox    ${TOKEN_AUTH_CHECKBOX_XP}
+    # TODO: change service account name
+
+Disable Token Authentication
+    [Documentation]    Enables Token authentication to serving route
+    SeleniumLibrary.Unselect Checkbox    ${TOKEN_AUTH_CHECKBOX_XP}
     # TODO: change service account name
 
 Get Model Serving Access Token via UI

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -30,7 +30,7 @@ Create Model Server
     [Arguments]    ${no_replicas}=1    ${server_size}=Small    ${ext_route}=${TRUE}
     ...    ${token}=${TRUE}    ${runtime}=OpenVINO Model Server    ${server_name}=Model Serving Test
     ...    ${no_gpus}=0
-    Click Button    Add server
+    SeleniumLibrary.Click Button    Add model server
     Wait Until Page Contains Element    //span[.="Add model server"]
     Set Model Server Name    ${server_name}
     Set Replicas Number With Buttons    ${no_replicas}
@@ -143,7 +143,7 @@ Set Model Server Runtime
     [Documentation]    Selects a given Runtime for the model server
     [Arguments]    ${runtime}
     Open Serving runtime Options Menu  # robocop: disable
-    Click Element    xpath://div[@id="serving-runtime-template-selection"]//li//div[text()="${runtime}"]
+    Click Element    xpath://div[@id="serving-runtime-template-selection"]//li//*[text()="${runtime}"]
     # TODO: Implement Custom
 
 Set Model Server Name

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -70,7 +70,6 @@ Serve Model
         Set Up New Data Connection    dc_name=${data_connection_name}
         Set Folder Path    ${model_path}
     END
-    Sleep    5s
     SeleniumLibrary.Click Button    Deploy
     SeleniumLibrary.Wait Until Page Does Not Contain    xpath://h1[.="Deploy model"]
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -48,13 +48,14 @@ Serve Model
     [Arguments]    ${project_name}    ${model_name}    ${framework}    ${data_connection_name}    ${model_path}
     ...    ${existing_data_connection}=${TRUE}    ${model_server}=Model Serving Test
     # TODO: Does not work if there's already a model deployed
-    Wait Until Page Contains    Deploy model
-    Click Button    Deploy model
-    Wait Until Page Contains Element    xpath://h1[.="Deploy model"]
+    SeleniumLibrary.Wait Until Page Contains Element    //div[@id="model-server"]//table
+    SeleniumLibrary.Wait Until Page Contains    Deploy model
+    SeleniumLibrary.Click Button    Deploy model
+    SeleniumLibrary.Wait Until Page Contains Element    xpath://h1[.="Deploy model"]
     Select Project    ${project_name}
     Set Model Name    ${model_name}
     Select Model Server    ${model_server}
-    Wait Until Page Contains Element    xpath://span[.="Model framework (name - version)"]
+    SeleniumLibrary.Wait Until Page Contains Element    xpath://span[.="Model framework (name - version)"]
     Select Framework    ${framework}
     IF    ${existing_data_connection}==${TRUE}
         # Select Radio Button    group_name=radiogroup    value=existing-data-connection-radio
@@ -63,13 +64,14 @@ Serve Model
         Set Folder Path    ${model_path}
     ELSE
         # Existing connection radio is selected by default; for now blindly click on new connection radio
-        Click Element    //input[@id="new-data-connection-radio"]
+        SeleniumLibrary.Click Element    //input[@id="new-data-connection-radio"]
         # Select Radio Button    group_name=radiogroup    value=new-data-connection-radio
         Set Up New Data Connection    dc_name=${data_connection_name}
         Set Folder Path    ${model_path}
     END
-    Click Button    Deploy
-    Wait Until Page Does Not Contain    xpath://h1[.="Deploy model"]
+    Sleep    5s
+    SeleniumLibrary.Click Button    Deploy
+    SeleniumLibrary.Wait Until Page Does Not Contain    xpath://h1[.="Deploy model"]
 
 Select Project
     [Documentation]    Selects a project in the "deploy model" modal.
@@ -359,13 +361,13 @@ Disable Model Serving Runtime Using CLI
     Should Be Equal As Integers    ${rc}         ${0}
 
 Wait Until Runtime Pod Is Running
-    [Arguments]    ${server_name}    ${project_title}
+    [Arguments]    ${server_name}    ${project_title}    ${timeout}=10s
     ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${project_title}
     ${runtime_pod_name} =    Replace String Using Regexp    string=${server_name}    pattern=\\s    replace_with=-
     ${runtime_pod_name} =    Convert To Lower Case    ${runtime_pod_name}
     Log    name=modelmeshserving${runtime_pod_name}
     Wait For Pods To Be Ready    label_selector=name=modelmesh-serving-${runtime_pod_name}
-    ...    namespace=${ns_name}    timeout=10s
+    ...    namespace=${ns_name}    timeout=${timeout}
 
 Create Custom Serving Runtime Using Template By CLI
     [Documentation]  Use Openshift API to create a custome runtime using template CR

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -208,6 +208,8 @@ Get Model Project
     [Arguments]    ${model_name}
     Page Should Contain Element    //div[.="${model_name} "]
     ${project_name}=    Get Text    xpath://div[.="${model_name} "]${MS_TABLE_PROJECT}
+    ${tmp_list}=    Text To List    ${project_name}
+    ${project_name}=    Set Variable    ${tmp_list}[0]
     RETURN    ${project_name}
 
 Get Model Inference

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -48,7 +48,8 @@ Serve Model
     [Arguments]    ${project_name}    ${model_name}    ${framework}    ${data_connection_name}    ${model_path}
     ...    ${existing_data_connection}=${TRUE}    ${model_server}=Model Serving Test
     # TODO: Does not work if there's already a model deployed
-    SeleniumLibrary.Wait Until Page Contains Element    //div[@id="model-server"]//table
+    SeleniumLibrary.Wait Until Page Does Not Contain Element    //article[@id="multi-serving-platform-card"]
+    SeleniumLibrary.Wait Until Page Does Not Contain Element    //article[@id="single-serving-platform-card"]
     SeleniumLibrary.Wait Until Page Contains    Deploy model
     SeleniumLibrary.Click Button    Deploy model
     SeleniumLibrary.Wait Until Page Contains Element    xpath://h1[.="Deploy model"]

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -178,11 +178,11 @@ Model Serving Suite Teardown
     # Failure will be shown in the logs of the run nonetheless
     IF    ${MODEL_CREATED}
         Run Keyword And Continue On Failure    Delete Model Via UI    test-model
-        ${projects}=    Create List    ${PRJ_TITLE}
-        Delete Data Science Projects From CLI   ocp_projects=${projects}
     ELSE
         Log    Model not deployed, skipping deletion step during teardown    console=true
     END
+    ${projects}=    Create List    ${PRJ_TITLE}
+    Delete Data Science Projects From CLI   ocp_projects=${projects}
     # Will only be present on SM cluster runs, but keyword passes
     # if file does not exist
     Remove File    openshift_ca.crt

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -354,7 +354,7 @@ Verify User Can Set Requests And Limits For A Model
 Verify Model Can Be Served And Query On A GPU Node
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model on GPU node
     ...                using Kserve and Caikit+TGIS runtime
-    [Tags]    Sanity    Tier1    ODS-2381    Resource-GPU
+    [Tags]    Sanity    Tier1    ODS-2381    Resources-GPU
     [Setup]    Set Project And Runtime    namespace=singlemodel-gpu
     ${test_namespace}=    Set Variable    singlemodel-gpu
     ${model_name}=    Set Variable    flan-t5-small-caikit

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -590,8 +590,14 @@ Clean Up Test Project
     ELSE
         Log To Console     InferenceService Delete option not provided by user
     END
-    Remove Namespace From ServiceMeshMemberRoll    namespace=${test_ns}
+    ${rc}    ${member_list}=    Run And Return Rc And Output
+    ...    oc get smmr/default -n ${SERVICEMESH_CR_NS} -o json | jq '.spec.members'
+    IF    "${member_list}" == "null"
+        Log    message=ServiceMeshMemberRoll already cleaned up. Skipping manual deletion
+    ELSE
+        Remove Namespace From ServiceMeshMemberRoll    namespace=${test_ns}
     ...    servicemesh_ns=${SERVICEMESH_CR_NS}
+    END
     ${rc}    ${out}=    Run And Return Rc And Output    oc delete project ${test_ns}
     Should Be Equal As Integers    ${rc}    ${0}
     ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=300s

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -820,8 +820,8 @@ Set Project And Runtime
     # temporary step - caikit will be shipped OOTB
     Deploy Caikit Serving Runtime    namespace=${namespace}    protocol=${protocol}
     IF   ${enable_metrics} == ${TRUE}
-        Oc Apply    kind=ConfigMap    src=${UWM_ENABLE_FILEPATH}
         Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
+        Oc Apply    kind=ConfigMap    src=${UWM_ENABLE_FILEPATH}
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.
     END

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -592,6 +592,7 @@ Clean Up Test Project
     END
     ${rc}    ${member_list}=    Run And Return Rc And Output
     ...    oc get smmr/default -n ${SERVICEMESH_CR_NS} -o json | jq '.spec.members'
+    Should Be Equal As Integers    ${rc}    ${0}
     IF    "${member_list}" == "null"
         Log    message=ServiceMeshMemberRoll already cleaned up. Skipping manual deletion
     ELSE

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -17,12 +17,12 @@ ${PRJ_DESCRIPTION}=    ODS-CI DS Project for testing of Custom Serving Runtimes
 ${MODEL_SERVER_NAME}=    ODS-CI CustomServingRuntime Server
 
 
-*** Test Cases *** 
+*** Test Cases ***
 Verify RHODS Admins Can Import A Custom Serving Runtime Template By Uploading A YAML file
     [Tags]    Smoke    ODS-2276
     Open Dashboard Settings    settings_page=Serving runtimes
     Upload Serving Runtime Template    runtime_filepath=${OVMS_RUNTIME_FILEPATH}
-    ...    serving_platform=single
+    ...    serving_platform=multi
     Serving Runtime Template Should Be Listed    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}
     ...    serving_platform=multi
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -56,7 +56,7 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     Serve Model    project_name=${PRJ_TITLE}    model_name=${model_name}    framework=onnx    existing_data_connection=${TRUE}
     ...    data_connection_name=model-serving-connection    model_path=mnist-8.onnx
     Wait Until Runtime Pod Is Running    server_name=${MODEL_SERVER_NAME}
-    ...    project_title=${PRJ_TITLE}
+    ...    project_title=${PRJ_TITLE}    timeout=15s
     Verify Model Status    ${model_name}    success
     Verify Model Inference    ${model_name}    ${inference_input}    ${exp_inference_output}    token_auth=${TRUE}
     ...    project_title=${PRJ_TITLE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -17,12 +17,14 @@ ${PRJ_DESCRIPTION}=    ODS-CI DS Project for testing of Custom Serving Runtimes
 ${MODEL_SERVER_NAME}=    ODS-CI CustomServingRuntime Server
 
 
-*** Test Cases ***
+*** Test Cases *** 
 Verify RHODS Admins Can Import A Custom Serving Runtime Template By Uploading A YAML file
     [Tags]    Smoke    ODS-2276
     Open Dashboard Settings    settings_page=Serving runtimes
     Upload Serving Runtime Template    runtime_filepath=${OVMS_RUNTIME_FILEPATH}
+    ...    serving_platform=single
     Serving Runtime Template Should Be Listed    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}
+    ...    serving_platform=multi
 
 Verify RHODS Admins Can Delete A Custom Serving Runtime Template
     [Tags]    Smoke    ODS-2279
@@ -81,5 +83,7 @@ Create Test Serving Runtime Template If Not Exists
         Log    message=Creating the necessary Serving Runtime as part of Test Setup.
         Open Dashboard Settings    settings_page=Serving runtimes
         Upload Serving Runtime Template    runtime_filepath=${OVMS_RUNTIME_FILEPATH}
-        Serving Runtime Template Should Be Listed    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}        
+        ...    serving_platform=multi
+        Serving Runtime Template Should Be Listed    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}
+        ...    serving_platform=multi
     END


### PR DESCRIPTION
Tests for CustomServingRuntime feature must be updated to account for serving platform selection, introduced with 2.5.

This PR includes:
1. fix broken CustomServingRuntime tests
2. add one new CustomServingRuntime test (ODS-2542)
3. fix keywords for model mesh serving UI
4. fix test teardown for KServe tests
5. fix Resource-GPU tag for KServe test (it should be Resource**s**-GPU)
6. (tentative) try to mitigate timing issue in KServe metrics test