### PR TITLE
[Fix] for the window title to accomodate with RHOAI 2.5

### DIFF
--- a/ods_ci/tests/Tests/700__sandbox/700__sandbox.robot
+++ b/ods_ci/tests/Tests/700__sandbox/700__sandbox.robot
@@ -52,7 +52,7 @@ Verify That Idle JupyterLab Servers Are Culled In Sandbox Environment After 24h
     ...        Execution-Time-Over-1d
     Spawn Notebook With Arguments
     ${jl_title}     Get Title
-    Switch Window    title=Red Hat OpenShift Data Science
+    Switch Window    title=Red Hat OpenShift AI
     Sleep    24h
     Switch Window     title=${jl_title}
     Wait Until Keyword Succeeds    120    2


### PR DESCRIPTION
This is the very same update for the Window name as was done as a part
of the fixes in #1049 [1].

[1] ef44c42000d1f717b74b3d2a760ea5a980a9bb0d

---

CI: didn't test it, please let me know if you insist