### PR TITLE
Keep ReadWriteOnce as a default for storage class

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesKfpTekton.py
+++ b/ods_ci/libs/DataSciencePipelinesKfpTekton.py
@@ -29,6 +29,8 @@ class DataSciencePipelinesKfpTekton:
             os.environ["TEKTON_BASH_STEP_IMAGE"] = default_image
             os.environ["TEKTON_COPY_RESULTS_STEP_IMAGE"] = default_image
             os.environ["CONDITION_IMAGE_NAME"] = default_image
+            # https://kubernetes.io/docs/concepts/storage/persistent-volumes/#access-modes
+            os.environ["DEFAULT_ACCESSMODES"] = 'ReadWriteOnce'
             import kfp_tekton
 
             # the following fallback it is to simplify the test development

--- a/ods_ci/tests/Resources/Files/pipeline-samples/upload_download-compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/upload_download-compiled.yaml
@@ -371,7 +371,7 @@ spec:
       spec:
         storageClassName: standard-csi
         accessModes:
-        - ReadWriteMany
+        - ReadWriteOnce
         resources:
           requests:
             storage: 2Gi


### PR DESCRIPTION
```
erify Ods Users Can Create And Run A Data Science Pipeline Using ... | PASS |
------------------------------------------------------------------------------
Tests.Ods Dashboard.Data Science Pipelines.Data-Science-Pipelines-... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Data Science Pipelines                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================
```