### PR TITLE
[Fix] the test that checks the User/Group privileges permissions

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -102,7 +102,7 @@ Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
     [Arguments]     ${admins_group}   ${users_group}
     ${return_code}    ${output}    Run And Return Rc And Output    oc patch OdhDashboardConfig odh-dashboard-config -n ${APPLICATIONS_NAMESPACE} --type=merge -p '{"spec": {"groupsConfig": {"adminGroups": "${admins_group}","allowedGroups": "${users_group}"}}}'   #robocop:disable
-    Should Be Equal As Integers	${return_code}	 0    msg=Pathc failed
+    Should Be Equal As Integers	${return_code}	 0    msg=Patch to group settings failed
 
 Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -69,7 +69,7 @@ Save Changes In User Management Setting
     [Documentation]  Save User Management Settings In Dashboard
     Press Keys    None    ESC
     Click Button    Save changes
-    Sleep  60s
+    Sleep    120s    reason=Wait for Dashboard to apply the updated configuration...
 
 AdminGroups In OdhDashboardConfig CRD Should Be
     [Documentation]  Verify Expect Changes Are Present In CRD

--- a/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
@@ -49,28 +49,30 @@ Verify If Unauthorized User Can Not Change The Permission
 Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook
     [Documentation]    Verify unauthorized User Is Not Able To Spawn Jupyter
     ...     Notebook , user should not see a spawner if the user is not in allowed Groups
+    ...     Note: this test configures user access via ODH Dashboard UI in setting appropriate
+    ...     groups in `Settings -> User management` section. There is an another test that changes
+    ...     users/groups via `oc adm groups` command,see: `Verify User Can Set Custom RHODS Groups`
+    ...     in ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
     [Tags]  ODS-1680
     ...     Tier1
     ...     Sanity
     Launch Dashboard And Check User Management Option Is Available For The User   ${TEST_USER.USERNAME}   ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Clear User Management Settings
-    Add OpenShift Groups To Data Science Administrators    rhods-users
-    Add OpenShift Groups To Data Science User Groups       rhods-users
+    Add OpenShift Groups To Data Science Administrators    rhods-admins
+    Add OpenShift Groups To Data Science User Groups       rhods-admins
     Save Changes In User Management Setting
-    AdminGroups In OdhDashboardConfig CRD Should Be        rhods-users
-    AllowedGroups In OdhDashboardConfig CRD Should Be      rhods-users
-    Reload Page
-    ${version_check}=    Is RHODS Version Greater Or Equal Than    1.20.0
-    IF    ${version_check} == True
-        ${status}=    Run Keyword And Return Status     Launch Jupyter From RHODS Dashboard Link
-        Run Keyword And Continue On Failure    Should Be Equal    ${status}    ${FALSE}
-        Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
-        Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
-    ELSE
-        Menu.Navigate To Page    Applications    Enabled
-        Launch Jupyter From RHODS Dashboard Link
-        Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=none
-    END
+    AdminGroups In OdhDashboardConfig CRD Should Be        rhods-admins
+    AllowedGroups In OdhDashboardConfig CRD Should Be      rhods-admins
+    Logout From RHODS Dashboard
+    Login To RHODS Dashboard    ${TEST_USER_4.USERNAME}    ${TEST_USER_4.PASSWORD}    ${TEST_USER_4.AUTH_TYPE}
+    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
+    Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
+    # Let's check that we're not allowed to also access the spawner page directly navigating the browser there
+    Go To    ${ODH_DASHBOARD_URL}/notebookController/spawner
+    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
+    Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
     [Teardown]  Revert Changes To Access Configuration
 
 Verify Automatically Detects a Group Selected Is Removed and Notify the User

--- a/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -26,6 +26,11 @@ ${STANDARD_USERS_GROUP}=   system:authenticated
 Verify User Can Set Custom RHODS Groups
     [Documentation]    Tests the JH access level when using custom rhods groups
     ...                different from rhods-admins and rhods-users
+    ...                Note: this test creates users/groups via `oc adm groups`
+    ...                command. There is an another test that changes users/groups
+    ...                via ODH Dashboard UI in `Settings -> User management` section, see:
+    ...                `Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook` in
+    ...                ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
     [Tags]  Sanity
     ...     ODS-293    ODS-503
     [Setup]      Set Standard RHODS Groups Variables


### PR DESCRIPTION
This fixes the `Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook`
test. It is basically similar change as done in [1,2].

Note: looks like the behavior of the RHOAI is a bit different now - the
user without permissions is shown directly the `Access permissions
needed` page. Nothing else is shown. Based on the test structure, in
previous versions we could see the application but weren't able to start
a JupyterHub tile in the `Applications -> Enabled` menu.

Also, unnecessary check for the product version is removed with this
commit and a small typo fix.

* [1] https://github.com/red-hat-data-services/ods-ci/pull/1034
* [2] https://github.com/jstourac/ods-ci/commit/c719b70d93c88734288ae064fefc71991ccb236a

---

CI: rhods-ci-pr-test/2244 :construction: 