### PR TITLE
[Fix] attempt to stabilize the `Logged Into OpenShift` test

### DIFF
--- a/ods_ci/tests/Resources/Page/LoginPage.robot
+++ b/ods_ci/tests/Resources/Page/LoginPage.robot
@@ -47,6 +47,8 @@ Login To Openshift
     Input Text  id=inputUsername  ${ocp_user_name}
     Input Text  id=inputPassword  ${ocp_user_pw}
     Click Element  xpath=/html/body/div/div/main/div/form/div[4]/button
+    # Wait until the page is loaded completely otherwise it doesn't make sense to skip the tour
+    Wait For Condition    return document.readyState == "complete"    timeout=60s
     Maybe Skip Tour
 
 Log In Should Be Requested


### PR DESCRIPTION
`Tests.Jupyterhub.Test.Logged Into OpenShift` test sometimes fails with the following error:

```
TimeoutException: Message: script timeout
  (Session info: headless chrome=118.0.5993.70)
Stacktrace:
 # 0 0x55c8c7a8e463 <unknown>
 # 1 0x55c8c7693166 <unknown>
 # 2 0x55c8c770f477 <unknown>
 # 3 0x55c8c76f7d82 <unknown>
 # 4 0x55c8c770ea60 <unknown>
 # 5 0x55c8c76f7b43 <unknown>
 # 6 0x55c8c76cad71 <unknown>
 # 7 0x55c8c76cc262 <unknown>
 # 8 0x55c8c7a6550b <unknown>
 # 9 0x55c8c7a6843e <unknown>
 # 10 0x55c8c7a67f49 <unknown>
 # 11 0x55c8c7a688d5 <unknown>
 # 12 0x55c8c7a6e817 <unknown>
 # 13 0x55c8c7a68c25 <unknown>
 # 14 0x55c8c7a4373b <unknown>
 # 15 0x55c8c7a80428 <unknown>
 # 16 0x55c8c7a80608 <unknown>
 # 17 0x55c8c7a8da1f <unknown>
 # 18 0x7efc3cca4802 start_thread
```

When waiting on `//*[@aria-label='Application launcher']/button` to be enabled.

This commit is a desperade attempt to stabilize such failure since I wasn't able to reproduce this issue locally.

---

CI: TODO