### PR TITLE
After installation, verify the monitoring stack only for managed

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
@@ -18,7 +18,7 @@ Installing RHODS Operator ${image_url}
   IF  ${is_codeflare_managed}    Installing CodeFlare Operator
 
 RHODS Operator Should Be installed
-  Verify RHODS Installation
+  Verify RHODS Installation    ${cluster_type}
   ${version} =  Get RHODS Version
   Set Global Variable  ${RHODS_VERSION}  ${version}
   Log  RHODS has been installed  console=yes

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/install.robot
@@ -18,7 +18,7 @@ Installing RHODS Operator ${image_url}
   IF  ${is_codeflare_managed}    Installing CodeFlare Operator
 
 RHODS Operator Should Be installed
-  Verify RHODS Installation    ${cluster_type}
+  Verify RHODS Installation
   ${version} =  Get RHODS Version
   Set Global Variable  ${RHODS_VERSION}  ${version}
   Log  RHODS has been installed  console=yes

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -50,7 +50,6 @@ Install RHODS
   END
 
 Verify RHODS Installation
-  [Arguments]  ${cluster_type}
   # Needs to be removed ASAP
   IF  "${UPDATE_CHANNEL}" == "odh-nightlies"
     Set Global Variable    ${APPLICATIONS_NAMESPACE}    opendatahub

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -50,6 +50,7 @@ Install RHODS
   END
 
 Verify RHODS Installation
+  [Arguments]  ${cluster_type}
   # Needs to be removed ASAP
   IF  "${UPDATE_CHANNEL}" == "odh-nightlies"
     Set Global Variable    ${APPLICATIONS_NAMESPACE}    opendatahub
@@ -144,7 +145,14 @@ Verify RHODS Installation
     Wait For Pods Status  namespace=${APPLICATIONS_NAMESPACE}  timeout=60
     Log  Verified Applications NS: ${APPLICATIONS_NAMESPACE}  console=yes
   END
-  
+
+  # Monitoring stack only deployed for managed, as modelserving monitoring stack is no longer deployed
+  IF  "${cluster_type}" == "managed"
+     Log To Console    "Waiting for pod status in ${MONITORING_NAMESPACE}"
+     Wait For Pods Status  namespace=${MONITORING_NAMESPACE}  timeout=600
+     Log  Verified Monitoring NS: ${MONITORING_NAMESPACE}  console=yes
+  END
+
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${workbenches}" == "true"
     Oc Get  kind=Namespace  field_selector=metadata.name=${NOTEBOOKS_NAMESPACE}
     Log  Verified Notebooks NS: ${NOTEBOOKS_NAMESPACE}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -144,12 +144,7 @@ Verify RHODS Installation
     Wait For Pods Status  namespace=${APPLICATIONS_NAMESPACE}  timeout=60
     Log  Verified Applications NS: ${APPLICATIONS_NAMESPACE}  console=yes
   END
-  # Monitoring stack not deployed with operator V2, only model serving monitoring stack present
-  IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${modelmeshserving}" == "true"
-    Log To Console    "Waiting for pod status in ${MONITORING_NAMESPACE}"
-    Wait For Pods Status  namespace=${MONITORING_NAMESPACE}  timeout=1200
-    Log  Verified Monitoring NS: ${MONITORING_NAMESPACE}  console=yes
-  END
+  
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${workbenches}" == "true"
     Oc Get  kind=Namespace  field_selector=metadata.name=${NOTEBOOKS_NAMESPACE}
     Log  Verified Notebooks NS: ${NOTEBOOKS_NAMESPACE}


### PR DESCRIPTION
- Starting at RHOAI 2.5 the modelmesh monitoring stack is no longer deployed in redhat-ods-monitoring. 
- Disabling this check for Self-Managed will save 20 mins in RHOAI Self-Managed installation
- Note: clusters upgrading 2.4 > 2.5 still will have the modelserving monitoring stack until https://issues.redhat.com/browse/RHOAIENG-293 is solved