### PR TITLE
Fix 'Operator Subscription Last Condition Should Be'

### DIFF
--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -57,7 +57,7 @@ Operator Subscription Last Condition Should Be
     [Arguments]    ${type}    ${status}    ${reason}
     ...    ${subcription_name}    ${namespace}=openshift-operators
     ${rc}    ${out}=    Run And Return Rc And Output
-    ...    oc get subscription ${subcription_name} -n ${namespace} -ojson | jq '.status.conditions | last | select(.type=="${type}" and .status=="${status}" and .reason=="${reason}")'    # robocop: disable
+    ...    oc get subscription ${subcription_name} -n ${namespace} -ojson | jq '.status.conditions[] | select(.type=="${type}" and .status=="${status}" and .reason=="${reason}")'    # robocop: disable
     Should Be Equal As Integers    ${rc}     ${0}
     Should Not Be Empty    ${out}
 


### PR DESCRIPTION
'Operator Subscription Last Condition Should Be' can fail if the last condition is not the requested one:
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/b75516d2-d2a0-44f9-922f-54879cda108d)


For example:
```
oc get subscription servicemeshoperator -n openshift-operators -ojson | jq '.status.conditions'
[
  {
    "lastTransitionTime": "2023-12-13T19:20:40Z",
    "message": "all available catalogsources are healthy",
    "reason": "AllCatalogSourcesHealthy",
    "status": "False",
    "type": "CatalogSourcesUnhealthy"
  },
  {
    "status": "False",
    "type": "BundleUnpacking"
  }
]
```

The current query will return no output:
`oc get subscription servicemeshoperator -n openshift-operators -ojson | jq '.status.conditions | last | select(.type=="CatalogSourcesUnhealthy" and .status=="False" and .reason=="AllCatalogSourcesHealthy")'`

Explanation:
`last` is not required, since k8s condition types do not show twice, but always the latest.

After the fix - the step succeeds:
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/145d3fd5-d061-4a66-bd1d-3010fed82432)

