### PR TITLE
Remove SMMR clean up from KServe test teardown

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -271,18 +271,20 @@ Add Namespace To ServiceMeshMemberRoll
     ...    oc patch smmr/default -n ${servicemesh_ns} --type='json' -p="[{'op': 'add', 'path': '/spec/members/-', 'value': \"${namespace}\"}]"
     Should Be Equal As Integers    ${rc}    ${0}
 
-Remove Namespace From ServiceMeshMemberRoll
+Namespace Should Be Removed From ServiceMeshMemberRoll
     [Arguments]    ${namespace}    ${servicemesh_ns}=istio-system
-    ${rc}    ${ns_idx}=    Run And Return Rc And Output
-    ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members | map(. == "${namespace}") | index(true)'
+    ${rc}    ${member_list}=    Run And Return Rc And Output
+    ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members'
     Should Be Equal As Integers    ${rc}    ${0}
-    IF    "${ns_idx}" == "null"
-        Log    message=${namespace} was not in the SMMR..
-        ...    level=WARN
+    IF    $member_list == "null"
+        Log    message=ServiceMeshMemberRoll already cleaned up
     ELSE
-        ${rc}    ${out}=    Run And Return Rc And Output    oc patch smmr/default -n ${servicemesh_ns} --type='json' -p="[{'op': 'remove', 'path': '/spec/members/${ns_idx}'}]"
+        ${rc}    ${ns_idx}=    Run And Return Rc And Output
+        ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members | map(. == "${namespace}") | index(true)'
         Should Be Equal As Integers    ${rc}    ${0}
+        Should Be Equal As Strings    ${ns_idx}    null    msg=${namespace} should have been automatically removed from SMMR
     END
+
 
 Deploy Model Via CLI
     [Documentation]    Deploys a model using Model Serving feature by applying the InfereceService

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -272,6 +272,8 @@ Add Namespace To ServiceMeshMemberRoll
     Should Be Equal As Integers    ${rc}    ${0}
 
 Namespace Should Be Removed From ServiceMeshMemberRoll
+    [Documentation]    Checks if the given namespace is present in the SMMR.
+    ...                If yes, it fails
     [Arguments]    ${namespace}    ${servicemesh_ns}=istio-system
     ${rc}    ${member_list}=    Run And Return Rc And Output
     ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members'
@@ -280,9 +282,10 @@ Namespace Should Be Removed From ServiceMeshMemberRoll
         Log    message=ServiceMeshMemberRoll already cleaned up
     ELSE
         ${rc}    ${ns_idx}=    Run And Return Rc And Output
-        ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members | map(. == "${namespace}") | index(true)'
+        ...    oc get smmr/default -n ${servicemesh_ns} -o json | jq '.spec.members | map(. == "${namespace}") | index(true)'    # robocop: disable
         Should Be Equal As Integers    ${rc}    ${0}
-        Should Be Equal As Strings    ${ns_idx}    null    msg=${namespace} should have been automatically removed from SMMR
+        Should Be Equal As Strings    ${ns_idx}    null
+        ...    msg=${namespace} should have been automatically removed from SMMR
     END
 
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -590,15 +590,8 @@ Clean Up Test Project
     ELSE
         Log To Console     InferenceService Delete option not provided by user
     END
-    ${rc}    ${member_list}=    Run And Return Rc And Output
-    ...    oc get smmr/default -n ${SERVICEMESH_CR_NS} -o json | jq '.spec.members'
-    Should Be Equal As Integers    ${rc}    ${0}
-    IF    $member_list == "null"
-        Log    message=ServiceMeshMemberRoll already cleaned up. Skipping manual deletion
-    ELSE
-        Remove Namespace From ServiceMeshMemberRoll    namespace=${test_ns}
-    ...    servicemesh_ns=${SERVICEMESH_CR_NS}
-    END
+    Wait Until Keyword Succeeds    10    1s    Namespace Should Be Removed From ServiceMeshMemberRoll
+    ...    namespace=${test_ns}
     ${rc}    ${out}=    Run And Return Rc And Output    oc delete project ${test_ns}
     Should Be Equal As Integers    ${rc}    ${0}
     ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=300s

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -593,7 +593,7 @@ Clean Up Test Project
     ${rc}    ${member_list}=    Run And Return Rc And Output
     ...    oc get smmr/default -n ${SERVICEMESH_CR_NS} -o json | jq '.spec.members'
     Should Be Equal As Integers    ${rc}    ${0}
-    IF    "${member_list}" == "null"
+    IF    $member_list == "null"
         Log    message=ServiceMeshMemberRoll already cleaned up. Skipping manual deletion
     ELSE
         Remove Namespace From ServiceMeshMemberRoll    namespace=${test_ns}


### PR DESCRIPTION
The kserve tests try to delete the test namespace from the ServiceMeshMemberRoll (SMMR) but most of the time it fails, because the model controller does it automatically (it wasn't like this in origin, but then it got fixed).

This PR is removing the SMMR clean up and replace it with a check to ensure that the model controller actually does it automatically.