### PR TITLE
Pass Execution at the end of 'Provision Self-Managed Cluster'

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -147,17 +147,17 @@ Wait For Cluster To Be Ready
     Log    Watching Hive Pool namespace: ${pool_namespace}    console=True
     ${install_log_file} =    Set Variable    ${artifacts_dir}/${cluster_name}_install.log
     Create File    ${install_log_file}
-    Run Keyword And Continue On Failure    Watch Hive Install Log    ${pool_namespace}    ${install_log_file}
+    Run Keyword And Ignore Error    Watch Hive Install Log    ${pool_namespace}    ${install_log_file}
     Log    Verifying that Cluster '${cluster_name}' has been created in Hive namespace '${hive_namespace}'      console=True
     ${result} =    Run Process 	oc -n ${pool_namespace} get cd ${pool_namespace} -o json | jq -r '.status.webConsoleURL' --exit-status    shell=yes
     IF    ${result.rc} != 0
         ${result} =    Run Process 	oc -n ${pool_namespace} get cd ${pool_namespace} -o json    shell=yes
-        Log    Cluster '${cluster_name}' install completed, but it is not accesible - Cleaning Hive resources    console=True
+        Log    Cluster '${cluster_name}' install completed, but it is not accessible - Cleaning Hive resources    console=True
         Deprovision Cluster
         Log    Cluster '${cluster_name}' deployment had errors: ${result.stdout}    console=True    level=ERROR
         FAIL    Cluster '${cluster_name}' provisioning failed. Please look into the logs for more details.
     END
-    Log    Cluster ${cluster_name} created successfully. Web Console: ${result.stdout}     console=True
+    Log    Cluster '${cluster_name}' install completed and accessible at: ${result.stdout}     console=True
     
 Save Cluster Credentials
     Set Task Variable    ${cluster_details}    ${artifacts_dir}/${cluster_name}_details.txt

--- a/ods_ci/tasks/Tasks/provision_self_managed_cluster.robot
+++ b/ods_ci/tasks/Tasks/provision_self_managed_cluster.robot
@@ -31,6 +31,7 @@ Provision Self-Managed Cluster
     Save Cluster Credentials
     Login To Cluster
     Set Cluster Storage
+    Pass Execution    Self-Managed Cluster ${cluster_name} provisionend successfully
 
 Deprovision Self-Managed Cluster
     [Documentation]    Deprovision a self-managed cluster


### PR DESCRIPTION
This is a workaround for a known issue in RF: https://github.com/robotframework/robotframework/issues/3881
It should have been part of #1078.

The inner Task Keyword uses `TRY/CATCH`while waiting for Hive pod to be ready, and there's an expected error until the Pod is ready.  However, due to the known issue, the task is still counted as failed task, even after login to cluster:

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/2af9a2f8-e72b-4212-a0ce-708c7589016a)
...
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/27741e5a-d773-441e-8181-8320fcc25bde)

To workaround, we need to mark the `Provision Self-Managed Cluster` task as passed, by calling `Pass Execution` after a successful login to the cluster.