### PR TITLE
Fix various Python lint warnings using ruff auto-fixes

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesAPI.py
+++ b/ods_ci/libs/DataSciencePipelinesAPI.py
@@ -25,7 +25,7 @@ class DataSciencePipelinesAPI:
         while deployment_count != 1 and count < 30:
             deployments = []
             response, _ = self.run_oc(
-                f"oc get deployment -n openshift-operators openshift-pipelines-operator -o json"
+                "oc get deployment -n openshift-operators openshift-pipelines-operator -o json"
             )
             try:
                 response = json.loads(response)
@@ -45,12 +45,14 @@ class DataSciencePipelinesAPI:
         while pipeline_run_crd_count < 1 and count < 60:
             # https://github.com/opendatahub-io/odh-dashboard/issues/1673
             # It is possible to start the Pipeline Server without pipelineruns.tekton.dev CRD
-            pipeline_run_crd_count = self.count_pods("oc get crd pipelineruns.tekton.dev", 1)
+            pipeline_run_crd_count = self.count_pods(
+                "oc get crd pipelineruns.tekton.dev", 1
+            )
             time.sleep(1)
             count += 1
         assert pipeline_run_crd_count == 1
         return self.count_running_pods(
-            f"oc get pods -n openshift-operators -l name=openshift-pipelines-operator -o json",
+            "oc get pods -n openshift-operators -l name=openshift-pipelines-operator -o json",
             "openshift-pipelines-operator",
             "Running",
             1,
@@ -92,7 +94,9 @@ class DataSciencePipelinesAPI:
             count += 1
 
         assert self.route != "", "Route must not be empty"
-        print(f"Waiting for Data Science Pipeline route to be ready to avoid firing false alerts: {self.route}")
+        print(
+            f"Waiting for Data Science Pipeline route to be ready to avoid firing false alerts: {self.route}"
+        )
         time.sleep(45)
         status = -1
         count = 0
@@ -195,12 +199,11 @@ class DataSciencePipelinesAPI:
                     run_status = run_json["run"]["status"]
             except JSONDecodeError:
                 print(response, status)
-                pass
             print(f"Checking run status: {run_status}")
-            if run_status == 'Failed':
+            if run_status == "Failed":
                 break
             # https://github.com/tektoncd/pipeline/blob/main/docs/pipelineruns.md#monitoring-execution-status
-            if run_status == "Completed" or run_status == "Succeeded":
+            if run_status in ("Completed", "Succeeded"):
                 run_finished_ok = True
                 break
             time.sleep(1)
@@ -255,13 +258,13 @@ class DataSciencePipelinesAPI:
         return response.url
 
     def count_pods(self, oc_command, pod_criteria, timeout=30):
-        oc_command = f'{oc_command} --no-headers'
+        oc_command = f"{oc_command} --no-headers"
         pod_count = 0
         count = 0
         while pod_count != pod_criteria and count < timeout:
             bash_str, _ = self.run_oc(oc_command)
             # | wc -l is returning an empty string
-            pod_count = sum(1 for line in bash_str.split('\n') if line.strip())
+            pod_count = sum(1 for line in bash_str.split("\n") if line.strip())
             if pod_count >= pod_criteria:
                 break
             time.sleep(1)
@@ -304,17 +307,22 @@ class DataSciencePipelinesAPI:
     def get_default_storage(self):
         result, _ = self.run_oc("oc get storageclass -A -o json")
         result = json.loads(result)
-        for storage_class in result['items']:
-            if 'annotations' in storage_class['metadata']:
-                if storage_class['metadata']['annotations']['storageclass.kubernetes.io/is-default-class'] == 'true':
+        for storage_class in result["items"]:
+            if "annotations" in storage_class["metadata"]:
+                if (
+                    storage_class["metadata"]["annotations"][
+                        "storageclass.kubernetes.io/is-default-class"
+                    ]
+                    == "true"
+                ):
                     break
-        return storage_class['metadata']['name']
+        return storage_class["metadata"]["name"]
 
     def get_openshift_server(self):
-        return self.run_oc('oc whoami --show-server=true')[0].replace('\n', '')
+        return self.run_oc("oc whoami --show-server=true")[0].replace("\n", "")
 
     def get_openshift_token(self):
-        return self.run_oc('oc whoami --show-token=true')[0].replace('\n', '')
+        return self.run_oc("oc whoami --show-token=true")[0].replace("\n", "")
 
     def run_oc(self, command):
         process = subprocess.Popen(command.split(), stdout=subprocess.PIPE)

--- a/ods_ci/libs/Helpers.py
+++ b/ods_ci/libs/Helpers.py
@@ -1,9 +1,9 @@
 from robot.api import logger
 from robot.libraries.BuiltIn import BuiltIn
+from robotlibcore import keyword
 from semver import VersionInfo
 
 from ods_ci.utils.scripts.ocm.ocm import OpenshiftClusterManager
-from robotlibcore import keyword
 
 
 class Helpers:
@@ -136,7 +136,7 @@ class Helpers:
             elif line.startswith("Events:"):
                 break
             else:
-                if saving == True:
+                if saving is True:
                     tolerations.append(line.strip())
                     print(line)
                     print(tolerations)
@@ -213,7 +213,7 @@ class Helpers:
                     # if element is model name, don't care about ID
                     result_ex = model_name.match(expected)
                     result_rec = model_name.match(received)
-                    if result_ex != None and result_rec != None:
+                    if result_ex is not None and result_rec is not None:
                         if expected.split("__")[0] != received.split("__")[0]:
                             failures.append([expected, received])
                     # else compare values are equal
@@ -245,8 +245,9 @@ class Helpers:
     ):
         import os
         import random
-        import requests
         from pathlib import Path
+
+        import requests
 
         for _ in range(no_requests):
             data_img = [
@@ -304,11 +305,11 @@ class Helpers:
                 resource_name = line.split()[1]
                 resource_name = regex.sub(repl="", string=resource_name)
                 out.append(line.split()[0] + " " * spaces + resource_name + "\n")
-        if filename_out == None:
+        if filename_out is None:
             filename_out = filename_in.split(".")[0] + "_processed.txt"
         with open(filename_out, "w") as outfile:
             outfile.write("".join(str(l) for l in out))
 
     @keyword
     def escape_forward_slashes(self, string_to_escape):
-        return string_to_escape.replace('/','\/')
+        return string_to_escape.replace("/", "\/")

--- a/ods_ci/tests/Resources/Files/pipeline-samples/flip_coin.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/flip_coin.py
@@ -14,6 +14,7 @@
 
 # source https://github.com/kubeflow/kfp-tekton/blob/master/samples/flip-coin/condition.py
 from kfp import components, dsl
+
 from ods_ci.libs.DataSciencePipelinesKfpTekton import DataSciencePipelinesKfpTekton
 
 

--- a/ods_ci/tests/Resources/Files/pipeline-samples/ray_integration.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/ray_integration.py
@@ -1,44 +1,47 @@
 from kfp import components, dsl
+
 from ods_ci.libs.DataSciencePipelinesKfpTekton import DataSciencePipelinesKfpTekton
 
 
-def ray_fn(openshift_server:str, openshift_token:str) -> int:
-    from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
-    from codeflare_sdk.cluster.auth import TokenAuthentication
+def ray_fn(openshift_server: str, openshift_token: str) -> int:
     import ray
+    from codeflare_sdk.cluster.auth import TokenAuthentication
+    from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
 
-    print('before login')
+    print("before login")
     auth = TokenAuthentication(
-        token=openshift_token,
-        server=openshift_server,
-        skip_tls=True
+        token=openshift_token, server=openshift_server, skip_tls=True
     )
     auth_return = auth.login()
     print(f'auth_return: "{auth_return}"')
-    print('after login')
-    cluster = Cluster(ClusterConfiguration(
-        name='raytest',
-        # namespace must exist, and it is the same from 432__data-science-pipelines-tekton.robot
-        namespace='pipelineskfptekton1',
-        num_workers=1,
-        head_cpus='500m',
-        min_memory=1,
-        max_memory=1,
-        num_gpus=0,
-        image="quay.io/project-codeflare/ray:latest-py39-cu118",
-        instascale=False
-    ))
+    print("after login")
+    cluster = Cluster(
+        ClusterConfiguration(
+            name="raytest",
+            # namespace must exist, and it is the same from 432__data-science-pipelines-tekton.robot
+            namespace="pipelineskfptekton1",
+            num_workers=1,
+            head_cpus="500m",
+            min_memory=1,
+            max_memory=1,
+            num_gpus=0,
+            image="quay.io/project-codeflare/ray:latest-py39-cu118",
+            instascale=False,
+        )
+    )
     # workaround for https://github.com/project-codeflare/codeflare-sdk/pull/412
-    cluster_file_name = '/opt/app-root/src/.codeflare/appwrapper/raytest.yaml'
+    cluster_file_name = "/opt/app-root/src/.codeflare/appwrapper/raytest.yaml"
     # Read in the file
-    with open(cluster_file_name, 'r') as file:
+    with open(cluster_file_name, "r") as file:
         filedata = file.read()
 
     # Replace the target string
-    filedata = filedata.replace('busybox:1.28', 'quay.io/project-codeflare/busybox:latest')
+    filedata = filedata.replace(
+        "busybox:1.28", "quay.io/project-codeflare/busybox:latest"
+    )
 
     # Write the file out again
-    with open(cluster_file_name, 'w') as file:
+    with open(cluster_file_name, "w") as file:
         file.write(filedata)
     # end workaround
 
@@ -82,7 +85,8 @@ def ray_fn(openshift_server:str, openshift_token:str) -> int:
 )
 def ray_integration(openshift_server, openshift_token):
     ray_op = components.create_component_from_func(
-        ray_fn, base_image=DataSciencePipelinesKfpTekton.base_image,
-        packages_to_install=['codeflare-sdk']
+        ray_fn,
+        base_image=DataSciencePipelinesKfpTekton.base_image,
+        packages_to_install=["codeflare-sdk"],
     )
     ray_op(openshift_server, openshift_token)

--- a/ods_ci/utils/scripts/SplitSuite.py
+++ b/ods_ci/utils/scripts/SplitSuite.py
@@ -18,7 +18,7 @@ def chunked(lst, nchunk):
 
 
 def fetch_subsuites(parent):
-    children = [child for child in parent.suites]
+    children = list(parent.suites)
     return children
 
 
@@ -70,7 +70,7 @@ class SplitSuite(SuiteVisitor):
         print("Suites names in the suite: ", suite_names)
         num_suite = math.ceil(len(sub_suites_list) / self.parts)
         print("Number of suites per split:", num_suite)
-        chunked_suites = [i for i in chunked(sub_suites_list, num_suite)]
+        chunked_suites = list(chunked(sub_suites_list, num_suite))
         print("Number of chunked suites: ", len(chunked_suites))
         print("Chunked suites: ", chunked_suites)
         suite_to_execute = chunked_suites[self.which_part - 1]

--- a/ods_ci/utils/scripts/awsOps.py
+++ b/ods_ci/utils/scripts/awsOps.py
@@ -1,8 +1,7 @@
-from util import (
-    execute_command,
-)
 from logging import log
 from time import sleep
+
+from util import execute_command
 
 
 def aws_configure(aws_access_key_id, aws_secret_access_key, aws_region):

--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -18,9 +18,16 @@ import yaml
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")
 from logger import log
+
 # fmt: off
-from util import (clone_config_repo, compare_dicts, execute_command,
-                  read_data_from_json, read_yaml, write_data_in_json)
+from util import (
+    clone_config_repo,
+    compare_dicts,
+    execute_command,
+    read_data_from_json,
+    read_yaml,
+    write_data_in_json,
+)
 
 # fmt: on
 
@@ -54,7 +61,7 @@ class OpenshiftClusterManager:
         self.region = args.get("region")
         self.compute_machine_type = args.get("compute_machine_type")
         self.ocm_cli_binary_url = args.get("ocm_cli_binary_url")
-        self.ocm_verbose_level = args.get("ocm_verbose_level","0")
+        self.ocm_verbose_level = args.get("ocm_verbose_level", "0")
         self.num_users_to_create_per_group = args.get("num_users_to_create_per_group")
         self.htpasswd_cluster_admin = args.get("htpasswd_cluster_admin")
         self.htpasswd_cluster_password = args.get("htpasswd_cluster_password")
@@ -122,7 +129,7 @@ class OpenshiftClusterManager:
             cmd += " " + filter
         ret = execute_command(cmd)
         if ret is None or "Error: Can't retrieve cluster for key" in ret:
-            log.info("ocm describe for cluster " "{} failed".format(self.cluster_name))
+            log.info("ocm describe for cluster {} failed".format(self.cluster_name))
             return None
         return ret
 
@@ -130,9 +137,7 @@ class OpenshiftClusterManager:
         """Checks if cluster exists"""
         ret = self.ocm_describe()
         if ret is None:
-            log.info(
-                "ocm cluster with name " "{} not exists!".format(self.cluster_name)
-            )
+            log.info("ocm cluster with name {} not exists!".format(self.cluster_name))
             return False
         log.info("ocm cluster with name {} exists!".format(self.cluster_name))
         return True
@@ -173,7 +178,7 @@ class OpenshiftClusterManager:
 
         channel_grp = ""
         if self.channel_group != "":
-            if (self.channel_group == "stable") or (self.channel_group == "candidate"):
+            if self.channel_group in ("stable", "candidate"):
                 if version == "":
                     log.error(
                         (
@@ -236,7 +241,9 @@ class OpenshiftClusterManager:
     def get_osd_cluster_id(self):
         """Gets osd cluster ID"""
 
-        cmd = "ocm list clusters -p search=\"name = '{}' or id = '{}'\" --columns id --no-headers".format(self.cluster_name, self.cluster_name)
+        cmd = "ocm list clusters -p search=\"name = '{}' or id = '{}'\" --columns id --no-headers".format(
+            self.cluster_name, self.cluster_name
+        )
         ret = execute_command(cmd)
         if ret is None:
             log.info(
@@ -343,7 +350,7 @@ class OpenshiftClusterManager:
                 break
             elif cluster_state == "error":
                 log.info(
-                    "{} is in error state. Hence " "exiting!!".format(self.cluster_name)
+                    "{} is in error state. Hence exiting!!".format(self.cluster_name)
                 )
                 sys.exit(1)
 
@@ -416,7 +423,7 @@ class OpenshiftClusterManager:
         """Checks if given machine pool name already
         exists in cluster"""
 
-        cmd = "/bin/ocm list machinepools --cluster {} " "| grep -w {}".format(
+        cmd = "/bin/ocm list machinepools --cluster {} | grep -w {}".format(
             self.cluster_name, self.pool_name
         )
         ret = execute_command(cmd)
@@ -526,8 +533,10 @@ class OpenshiftClusterManager:
         addon_state = self.get_addon_state(addon_name)
         if addon_state != "not installed":
             cluster_id = self.get_osd_cluster_id()
-            cmd = "ocm --v={} delete /api/clusters_mgmt/v1/clusters/{}/addons/" "{}".format(
-                self.ocm_verbose_level, cluster_id, addon_name
+            cmd = (
+                "ocm --v={} delete /api/clusters_mgmt/v1/clusters/{}/addons/{}".format(
+                    self.ocm_verbose_level, cluster_id, addon_name
+                )
             )
             log.info("CMD: {}".format(cmd))
             ret = execute_command(cmd)
@@ -604,8 +613,10 @@ class OpenshiftClusterManager:
         output_file = output_filename
         self._render_template(template_file, output_file, replace_vars)
         cluster_id = self.get_osd_cluster_id()
-        cmd = "ocm --v={} post /api/clusters_mgmt/v1/clusters/{}/addons " "--body={}".format(
-            self.ocm_verbose_level, cluster_id, output_file
+        cmd = (
+            "ocm --v={} post /api/clusters_mgmt/v1/clusters/{}/addons --body={}".format(
+                self.ocm_verbose_level, cluster_id, output_file
+            )
         )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
@@ -724,9 +735,7 @@ class OpenshiftClusterManager:
                 log.info("redhat-rhoam-smpt secret found!")
             else:
                 failure_flags.append(True)
-                log.info(
-                    "redhat-rhoam-smpt secret " "was not created during installation"
-                )
+                log.info("redhat-rhoam-smpt secret was not created during installation")
                 if exit_on_failure:
                     sys.exit(1)
 
@@ -901,12 +910,14 @@ class OpenshiftClusterManager:
     def delete_idp(self):
         """Deletes Identity Provider"""
 
-        cmd = "ocm --v={} delete idp -c {} {}".format(self.ocm_verbose_level, self.cluster_name, self.idp_name)
+        cmd = "ocm --v={} delete idp -c {} {}".format(
+            self.ocm_verbose_level, self.cluster_name, self.idp_name
+        )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
             log.info(
-                "Failed to delete identity provider of " "type {}".format(self.idp_name)
+                "Failed to delete identity provider of type {}".format(self.idp_name)
             )
 
     def add_user_to_group(self, user="", group="cluster-admins"):
@@ -915,33 +926,29 @@ class OpenshiftClusterManager:
         if user == "":
             user = self.htpasswd_cluster_admin
 
-        if (
-            (group == "rhods-admins")
-            or (group == "rhods-users")
-            or (group == "rhods-noaccess")
-        ):
+        if group in ("rhods-admins", "rhods-users", "rhods-noaccess"):
             cmd = "oc adm groups add-users {} {}".format(group, user)
         else:
-            cmd = "ocm --v={} create user {} --cluster {} " "--group={}".format(
+            cmd = "ocm --v={} create user {} --cluster {} --group={}".format(
                 self.ocm_verbose_level, user, self.cluster_name, group
             )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to add user {} to group " "{}".format(user, group))
+            log.info("Failed to add user {} to group {}".format(user, group))
 
     def delete_user(self, user="", group="cluster-admins"):
         """Deletes user"""
 
         if user == "":
             user = self.htpasswd_cluster_admin
-        cmd = "ocm --v={} delete user {} --cluster {} " "--group={}".format(
+        cmd = "ocm --v={} delete user {} --cluster {} --group={}".format(
             self.ocm_verbose_level, user, self.cluster_name, group
         )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to delete user {} of group " "{}".format(user, group))
+            log.info("Failed to delete user {} of group {}".format(user, group))
 
     def create_group(self, group_name):
         """Creates new group"""
@@ -950,7 +957,7 @@ class OpenshiftClusterManager:
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
-            log.info("Failed to add group " "{}".format(group_name))
+            log.info("Failed to add group {}".format(group_name))
 
     def add_users_to_rhods_group(self):
         """Add users to rhods group"""
@@ -1024,8 +1031,12 @@ class OpenshiftClusterManager:
             # Install dependency operators for rhoai deployment
             dependency_operators = ["servicemesh", "serverless"]
             for dependency_operator in dependency_operators:
-                self.install_openshift_isv(dependency_operator, "stable", "redhat-operators")
-                self.wait_for_isv_installation_to_complete(dependency_operator, namespace="openshift-operators")
+                self.install_openshift_isv(
+                    dependency_operator, "stable", "redhat-operators"
+                )
+                self.wait_for_isv_installation_to_complete(
+                    dependency_operator, namespace="openshift-operators"
+                )
 
             # Deploy rhoai
             self.install_rhods()
@@ -1102,7 +1113,9 @@ class OpenshiftClusterManager:
         """Hibernate OSD Cluster"""
 
         cluster_id = self.get_osd_cluster_id()
-        cmd = "ocm --v={} hibernate cluster {}".format(self.ocm_verbose_level, cluster_id)
+        cmd = "ocm --v={} hibernate cluster {}".format(
+            self.ocm_verbose_level, cluster_id
+        )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
         if ret is None:
@@ -1179,7 +1192,9 @@ class OpenshiftClusterManager:
         cluster_id = self.get_osd_cluster_id()
         cmd = (
             "ocm --v={} patch /api/clusters_mgmt/v1/clusters/{}/addons/{} "
-            "--body={}".format(self.ocm_verbose_level, cluster_id, addon_name, output_file)
+            "--body={}".format(
+                self.ocm_verbose_level, cluster_id, addon_name, output_file
+            )
         )
         log.info("CMD: {}".format(cmd))
         ret = execute_command(cmd)
@@ -1194,7 +1209,6 @@ class OpenshiftClusterManager:
                 return False
         else:
             return ret
-
 
     def install_openshift_isv(
         self, operator_name, channel, source, exit_on_failure=True
@@ -1216,26 +1230,31 @@ class OpenshiftClusterManager:
                 yaml.dump(newdct, f)
 
         if operator_name == "serverless":
-
             replace_vars = {
                 "ISV_NAME": "serverless-operators",
-                "NAMESPACE": "openshift-serverless"
+                "NAMESPACE": "openshift-serverless",
             }
             template_file = "resource.jinja"
             file_path1 = "resource.yaml"
             self._render_template(template_file, file_path1, replace_vars)
 
             def yaml_loader(filepath):
-                with open(filepath,'rb')as file_descriptor:
+                with open(filepath, "rb") as file_descriptor:
                     data = yaml.load(file_descriptor, Loader=yaml.SafeLoader)
                 return data
 
             data1 = yaml_loader(file_path1)
             data2 = yaml_loader(output_file)
             data1.update(data2)
-   
-            with open(output_file, 'w') as yaml_output:
-                yaml.dump(data1, yaml_output, default_flow_style=False, explicit_start=True, allow_unicode=True)
+
+            with open(output_file, "w") as yaml_output:
+                yaml.dump(
+                    data1,
+                    yaml_output,
+                    default_flow_style=False,
+                    explicit_start=True,
+                    allow_unicode=True,
+                )
 
         cmd = "oc apply -f {} ".format(os.path.abspath(output_file))
         ret = execute_command(cmd)
@@ -1373,7 +1392,9 @@ class OpenshiftClusterManager:
         cluster_id = self.get_osd_cluster_id()
         run_change_channel_cmd = (
             "ocm --v={} patch /api/clusters_mgmt/v1/clusters/{}"
-            " --body {}".format(self.ocm_verbose_level, cluster_id, self.update_ocm_channel_json)
+            " --body {}".format(
+                self.ocm_verbose_level, cluster_id, self.update_ocm_channel_json
+            )
         )
         log.info(run_change_channel_cmd)
         ret = execute_command(run_change_channel_cmd)

--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -18,8 +18,6 @@ import yaml
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")
 from logger import log
-
-# fmt: off
 from util import (
     clone_config_repo,
     compare_dicts,
@@ -28,8 +26,6 @@ from util import (
     read_yaml,
     write_data_in_json,
 )
-
-# fmt: on
 
 """
 Class for Openshift Cluster Manager
@@ -1423,10 +1419,12 @@ class OpenshiftClusterManager:
             latest_upgrade_version = ast.literal_eval(latest_upgrade_version)[-1]
             data["version"] = latest_upgrade_version
         write_data_in_json(self.update_policies_json, data)
-        # fmt: off
+
         schedule_cluster_upgrade = (
             "ocm --v={} post /api/clusters_mgmt/v1/clusters/{}/upgrade_policies"
-            " --body {}".format(self.ocm_verbose_level, cluster_id, self.update_policies_json)
+            " --body {}".format(
+                self.ocm_verbose_level, cluster_id, self.update_policies_json
+            )
         )
         ret = execute_command(schedule_cluster_upgrade)
         if ret is None:

--- a/ods_ci/utils/scripts/polarion/xunit_add_properties.py
+++ b/ods_ci/utils/scripts/polarion/xunit_add_properties.py
@@ -1,12 +1,13 @@
 """Inserts properties from a config file into a xunit format XML file"""
 import argparse
 import codecs
+import os
 import xml.etree.ElementTree as et
 from copy import deepcopy
 from xml.dom import minidom
-import os
-from junitparser import JUnitXml, TestCase, TestSuite, Failure, Error, Skipped
+
 import yaml
+from junitparser import Error, Failure, JUnitXml, Skipped, TestCase, TestSuite
 
 
 def parse_args():

--- a/ods_ci/utils/scripts/reportportal/rp_uploader.py
+++ b/ods_ci/utils/scripts/reportportal/rp_uploader.py
@@ -43,7 +43,7 @@ class ReportPortalOperations:
     def upload_result(self):
         """Uploads test results to report portal"""
 
-        cmd = "rp_preproc -c {} -d {} " "--service {} -l {}".format(
+        cmd = "rp_preproc -c {} -d {} --service {} -l {}".format(
             self.config_file, self.payload_dir, self.service_url, self.log_path
         )
         log.info("CMD: {}".format(cmd))

--- a/ods_ci/utils/scripts/rosa/rosa.py
+++ b/ods_ci/utils/scripts/rosa/rosa.py
@@ -1,12 +1,14 @@
-import argparse, sys, os
+import argparse
+import os
+import sys
 
 dir_path = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(dir_path + "/../")
-from logger import log
 from awsOps import aws_configure
+from logger import log
 from rosaOps import (
-    rosa_create_cluster,
     create_account_roles,
+    rosa_create_cluster,
     wait_for_osd_cluster_to_be_ready,
 )
 

--- a/ods_ci/utils/scripts/rosa/rosaOps.py
+++ b/ods_ci/utils/scripts/rosa/rosaOps.py
@@ -1,7 +1,8 @@
-from util import execute_command
+import sys
 from logging import log
 from time import sleep
-import sys
+
+from util import execute_command
 
 
 def create_account_roles():
@@ -29,7 +30,7 @@ def rosa_create_cluster(
     rosa_version,
     sts=True,
 ):
-    if sts == True:
+    if sts is True:
         cmd_rosa_create_cluster = [
             "rosa",
             "create",
@@ -126,7 +127,7 @@ def rosa_describe(cluster_name, filter=""):
         cmd += " " + filter
     ret = execute_command(cmd)
     if ret is None:
-        print("rosa describe for cluster " "{} failed".format(cluster_name))
+        print("rosa describe for cluster {} failed".format(cluster_name))
         return None
     return ret
 
@@ -159,13 +160,11 @@ def wait_for_osd_cluster_to_be_ready(cluster_name, timeout=7200):
             check_flag = True
             break
         elif cluster_state == "error":
-            print("{} is in error state. Hence " "exiting!!".format(cluster_name))
+            print("{} is in error state. Hence exiting!!".format(cluster_name))
             sys.exit(1)
 
         sleep(60)
         count += 60
     if not check_flag:
-        print(
-            "{} not in ready state even after 2 hours." " EXITING".format(cluster_name)
-        )
+        print("{} not in ready state even after 2 hours. EXITING".format(cluster_name))
         sys.exit(1)

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -107,6 +107,7 @@ def parse_args():
 
     return parser.parse_args()
 
+
 def change_component_state(components):
     # Parse and convert the component states argument into a dictionary
     component_states = {}
@@ -150,12 +151,16 @@ def get_dashboard_url():
     cmd = "oc get route -A -o json  | jq '.items[].spec.host' | grep 'dashboard'"
 
     dashboard_url = execute_command(cmd)
-    return "https://" + dashboard_url.strip('\"').strip("\n")
+    return "https://" + dashboard_url.strip('"').strip("\n")
 
 
 def generate_test_config_file(
-    config_template, config_data, test_cluster, set_prometheus_config,
-    set_dashboard_url, components=None
+    config_template,
+    config_data,
+    test_cluster,
+    set_prometheus_config,
+    set_dashboard_url,
+    components=None,
 ):
     """
     Generates test config file dynamically by
@@ -271,7 +276,7 @@ def generate_test_config_file(
     if bool(set_dashboard_url):
         # Get Dashboard url for open data science
         dashboard_url = get_dashboard_url()
-        data["ODH_DASHBOARD_URL"] = dashboard_url.replace('"', '')
+        data["ODH_DASHBOARD_URL"] = dashboard_url.replace('"', "")
 
     with open(config_file, "w") as yaml_file:
         yaml_file.write(yaml.dump(data, default_flow_style=False, sort_keys=False))
@@ -300,9 +305,12 @@ def main():
 
     # Generate test config file
     generate_test_config_file(
-        args.config_template, config_data, args.test_cluster, args.set_prometheus_config,
-        args.set_dashboard_url, components=args.components,
-
+        args.config_template,
+        config_data,
+        args.test_cluster,
+        args.set_prometheus_config,
+        args.set_dashboard_url,
+        components=args.components,
     )
     print("Done generating config file")
 

--- a/ods_ci/utils/scripts/util.py
+++ b/ods_ci/utils/scripts/util.py
@@ -54,32 +54,32 @@ def read_yaml(filename):
             return yaml.safe_load(fh)
     except OSError as error:
         return None
-          
+
 
 def execute_command(cmd):
     """
     Executes command in the local node, and print real-time output
     """
-    output = ''
+    output = ""
     try:
         with subprocess.Popen(
-                cmd,
-                shell=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                universal_newlines=True,
-                encoding='utf-8',
-                errors='replace'
-            ) as p:
-                while True:
-                    line = p.stdout.readline()
-                    if line != '':
-                        output += (line + "\n")
-                        print(line)
-                    elif p.poll() != None:
-                        break
-                sys.stdout.flush()
-                return output
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            encoding="utf-8",
+            errors="replace",
+        ) as p:
+            while True:
+                line = p.stdout.readline()
+                if line != "":
+                    output += line + "\n"
+                    print(line)
+                elif p.poll() is not None:
+                    break
+            sys.stdout.flush()
+            return output
     except:
         return None
 
@@ -119,9 +119,7 @@ def render_template(search_path, template_file, output_file, replace_vars):
         with open(output_file, "w") as fh:
             fh.write(outputText)
     except:
-        print(
-            "Failed to render template and create json " "file {}".format(output_file)
-        )
+        print("Failed to render template and create json file {}".format(output_file))
         sys.exit(1)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,14 @@ ruff = "0.1.11"
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
+[tool.isort]
+# https://pycqa.github.io/isort/docs/configuration/black_compatibility.html
+profile = "black"
+line_length = 88 # align with black's default
+
 [tool.ruff]
 target-version = "py38"
+line-length = 88 # align with black's default
 
 # https://docs.astral.sh/ruff/rules
 [tool.ruff.lint]
@@ -100,9 +106,7 @@ ignore = [
   "COM812", # Trailing comma missing
   "F841", # Local variable `response` is assigned to but never used
   "FA100", # Missing `from __future__ import annotations`, but uses `typing.Optional`
-  "I001", # Import block is un-sorted or un-formatted
   "INP001", # File `ods_ci/tests/Resources/Page/ODH/JupyterHub/jupyter-helper.py` is part of an implicit namespace package. Add an `__init__.py`.
-  "ISC001", # Implicitly concatenated string literals on one line
   "N806", # Variable `outputText` in function should be lowercase
   "N813", # Camelcase `ElementTree` imported as lowercase `et`
   "N816", # Variable `rotatingHandler` in global scope should not be mixedCase
@@ -115,7 +119,6 @@ ignore = [
   "PLR6301", # Method `_render_template` could be a function, class method, or static method
   "PLW1514", # `codecs.open` in text mode without explicit `encoding` argument
   "PLW2901", # `for` loop variable `tag_it` overwritten by assignment target
-  "Q000", # Single quotes found but double quotes preferred
   "RET501", # Do not explicitly `return None` in function if it is the only possible return value
   "RET503", # Missing explicit `return` at the end of function able to return non-`None` value
   "RET504", # Unnecessary assignment to `names` before `return` statement
@@ -126,28 +129,16 @@ ignore = [
   "UP034", # Avoid extraneous parentheses
   "W605", # Invalid escape sequence: `\d`
  # TODO(jdanek)
-  "C416", # Unnecessary `list` comprehension (rewrite using `list()`)
-  "E117", # Over-indented
-  "E231", # Missing whitespace after ','
-  "E401", # Multiple imports on one line
   "E402", # Module level import not at top of file
-  "E711", # Comparison to `None` should be `cond is not None`
-  "E712", # Comparison to `True` should be `cond is True` or `if cond:`
   "E721", # Use `is` and `is not` for type comparisons, or `isinstance()` for isinstance checks
   "E722", # Do not use bare `except`
   "F401", # `re` imported but unused
   "F403", # `from python_terraform import *` used; unable to detect undefined names
   "F405", # `IsNotFlagged` may be undefined, or defined from star imports
-  "F541", # f-string without any placeholders
   "F811", # Redefinition of unused `hide_values_in_op_json` from line 565
   "F821", # Undefined name `os`
-  "PIE790", # Unnecessary `pass` statement
-  "PLR1714", # Consider merging multiple comparisons. Use a `set` if the elements are hashable.
-  "Q004", # Unnecessary escape on inner quote character
   "RET507", # Unnecessary `else` after `continue` statement
   "RET508", # Unnecessary `elif` after `break` statement
-  "W292", # No newline at end of file
-  "W293", # Blank line contains whitespace
 ]
 
 # Allow unused variables when underscore-prefixed.


### PR DESCRIPTION
This deliberately only fixes problems for which there is an auto-fix in ruff. I don't want to mix manual and automated edits in one PR. Also, the number of changed lines is around 200, which I think is about the limit for anyone to be willing to browse through the changes line by line and doublecheck there is nothing obviously wrong.

```
poetry run ruff ods_ci/ --unsafe-fixes --fix
poetry run black $(git diff --name-only | grep '.py$')
poetry run isort $(git diff --name-only | grep '.py$')
```

Besides running ruff, it is necessary to placate black and isort in the affected files using the commands above.

Config for isort had to be added, so it converges with the black's ideas about formatting import blocks.