### PR TITLE
New Test ODS-2223

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -91,7 +91,6 @@ Set Standard RHODS Groups Variables
     Set Suite Variable    ${STANDARD_SYSTEM_GROUP}    system:authenticated
     Set Suite Variable    ${STANDARD_USERS_GROUP}    rhods-users
 
-
 Apply Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
     ...                and rolls out JH to make the changes effecting in Jupyter

--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -84,12 +84,12 @@ Set Standard RHODS Groups Variables
     [Documentation]     Sets the RHODS groups name based on RHODS version
     ${is_self_managed}=    Is RHODS Self-Managed
     IF    ${is_self_managed} == False
-        Set Suite Variable    ${STANDARD_ADMINS_GROUP}      dedicated-admins
+        Set Suite Variable    ${STANDARD_ADMINS_GROUP}    dedicated-admins
     ELSE
-        Set Suite Variable    ${STANDARD_ADMINS_GROUP}      rhods-admins
+        Set Suite Variable    ${STANDARD_ADMINS_GROUP}    rhods-admins
     END
-    Set Suite Variable    ${STANDARD_USERS_GROUP}       system:authenticated
-    Set Suite Variable    ${STANDARD_USERS_GROUP}       rhods-users
+    Set Suite Variable    ${STANDARD_SYSTEM_GROUP}    system:authenticated
+    Set Suite Variable    ${STANDARD_USERS_GROUP}    rhods-users
 
 
 Apply Access Groups Settings
@@ -108,7 +108,7 @@ Set Access Groups Settings
 Set Default Access Groups Settings
     [Documentation]    Restores the default rhods-groups config map
     Apply Access Groups Settings     admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...     users_group=${STANDARD_SYSTEM_GROUP}
 
 Uninstall RHODS From OSD Cluster
     [Documentation]    Selects the cluster type and triggers the RHODS uninstallation
@@ -242,7 +242,7 @@ Verify RHODS Dashboard CR Contains Expected Values
 Verify Default Access Groups Settings
     [Documentation]     Verifies that ODS contains the expected default groups settings
     &{exp_values}=  Create Dictionary  spec.groupsConfig.adminGroups=${STANDARD_ADMINS_GROUP}
-    ...    spec.groupsConfig.allowedGroups=${STANDARD_USERS_GROUP}
+    ...    spec.groupsConfig.allowedGroups=${STANDARD_SYSTEM_GROUP}
     Verify RHODS Dashboard CR Contains Expected Values   &{exp_values}
 
 Enable Access To Grafana Using OpenShift Port Forwarding

--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -89,6 +89,7 @@ Set Standard RHODS Groups Variables
         Set Suite Variable    ${STANDARD_ADMINS_GROUP}      rhods-admins
     END
     Set Suite Variable    ${STANDARD_USERS_GROUP}       system:authenticated
+    Set Suite Variable    ${STANDARD_USERS_GROUP}       rhods-users
 
 
 Apply Access Groups Settings

--- a/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -24,7 +24,10 @@ Create Group
 Delete Group
     [Documentation]     Deletes a user group in OCP
     [Arguments]   ${group_name}
-    Oc Delete  kind=Group   name=${group_name}
+    ${res}  ${output}=    Run And Return Rc And Output    
+    ...    oc adm groups delete ${group_name} --dry-run=client -o yaml | kubectl apply --validate=false -f -
+    # Oc Delete  kind=Group   name=${group_name}
+    Should Be Equal As Integers    ${res}    0
 
 Add User To Group
     [Documentation]     Add a user to a given OCP user group

--- a/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -14,9 +14,10 @@ Go To ${group_name} Group Page
     Wait Until Page Contains Element    xpath://h2/span[text()='Users']
 
 Create Group
-    [Documentation]     Creates a user group in OCP
+    [Documentation]     Creates a user group in OCP if it doesn't exist
     [Arguments]   ${group_name}
-    ${res}  ${output}=    Run And Return Rc And Output    oc adm groups new ${group_name}
+    ${res}  ${output}=    Run And Return Rc And Output    
+    ...    oc adm groups new ${group_name} --dry-run=client -o yaml | kubectl apply --validate=false -f -
     # Oc Create  kind=Group   src={"metadata": {"name": "${group_name}"}, "users": null}
     Should Be Equal As Integers    ${res}    0
 

--- a/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -32,7 +32,7 @@ Add User To Group
     Run    oc adm groups add-users ${group_name} ${username}
 
 Remove User From Group
-    [Documentation]     Add a user to a given OCP user group
+    [Documentation]     Remove a user from a given OCP user group
     [Arguments]  ${username}  ${group_name}
     Run    oc adm groups remove-users ${group_name} ${username}
 

--- a/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/UserManagement/Groups.robot
@@ -14,20 +14,18 @@ Go To ${group_name} Group Page
     Wait Until Page Contains Element    xpath://h2/span[text()='Users']
 
 Create Group
-    [Documentation]     Creates a user group in OCP if it doesn't exist
+    [Documentation]     Creates a user group in OCP (if it doesn't exist)
     [Arguments]   ${group_name}
     ${res}  ${output}=    Run And Return Rc And Output    
     ...    oc adm groups new ${group_name} --dry-run=client -o yaml | kubectl apply --validate=false -f -
-    # Oc Create  kind=Group   src={"metadata": {"name": "${group_name}"}, "users": null}
-    Should Be Equal As Integers    ${res}    0
+    Should Be Equal As Integers    ${res}    0    ${output}
 
 Delete Group
-    [Documentation]     Deletes a user group in OCP
+    [Documentation]     Deletes a user group in OCP (if it exists)
     [Arguments]   ${group_name}
     ${res}  ${output}=    Run And Return Rc And Output    
-    ...    oc adm groups delete ${group_name} --dry-run=client -o yaml | kubectl apply --validate=false -f -
-    # Oc Delete  kind=Group   name=${group_name}
-    Should Be Equal As Integers    ${res}    0
+    ...    oc delete group ${group_name} --ignore-not-found
+    Should Be Equal As Integers    ${res}    0    ${output}
 
 Add User To Group
     [Documentation]     Add a user to a given OCP user group

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -2,6 +2,7 @@
 Library         OpenShiftLibrary
 Resource        ../../LoginPage.robot
 Resource        ../../ODH/JupyterHub/LoginJupyterHub.robot
+Resource        ../../../ODS.robot
 
 
 *** Variables ***
@@ -9,7 +10,7 @@ ${TOLERATION_CHECKBOX}=    //input[@id="tolerations-enabled-checkbox"]
 ${GROUP_BTN_XP}=    (//*[@class="pf-c-chip-group"])//*[@class="pf-c-chip__text" ]//following-sibling::button[1]
 ${SINGLE_MODE_SERVING_CHECK_BOX}=   //input[@id="single-model-serving-platform-enabled-checkbox"]
 ${MULTI_MODE_SERVING_CHECK_BOX}=   //input[@id="multi-model-serving-platform-enabled-checkbox"]
-
+${CUSTOM_EMPTY_GROUP}=    empty-group
 
 *** Keywords ***
 Add OpenShift Groups To Data Science Administrators
@@ -306,3 +307,39 @@ Check IF Multi Model Serving IS Enabled From DSC And Cluster Setting
     ${status}=   Get Checkbox State Of Multi Model Serving Platforms
     Should Be Equal    ${status}  True
     Element Should Be Enabled     ${MULTI_MODEL_SERVING_CHECK_BOX}
+
+Set RHODS Admins Group Empty Group
+    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
+
+Set RHODS Admins Group To system:authenticated    # robocop:disable
+    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the system:authenticated group
+    Set Access Groups Settings    admins_group=system:authenticated
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
+
+Set RHODS Admins Group To Inexistent Group
+    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given inexistent group
+    Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
+
+Set RHODS Users Group Empty Group
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...    users_group=${CUSTOM_EMPTY_GROUP}
+
+Set RHODS Users Group To rhods-users    # robocop:disable
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the rhods-users group
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...    users_group=${STANDARD_USERS_GROUP}
+
+Set RHODS Users Group To Inexistent Group
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given inexistent group
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...    users_group=${CUSTOM_INEXISTENT_GROUP}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -1,14 +1,12 @@
 *** Settings ***
 Documentation    Collection of keywords to interact with Storages
 Resource       ./Projects.resource
-Resource       ../../../../../Resources/ODS.robot
 
 
 *** Variables ***
 ${SAVE_BUTTON}=    xpath://button[@data-id="save-rolebinding-button"]
 ${PERMISSIONS_DROPDOWN}=    xpath://td[@data-label="Permission"]//button[@aria-label="Options menu"]
 ${IS_CLUSTER_ADMIN}=    ${FALSE}
-${CUSTOM_EMPTY_GROUP}=    empty-group
 
 
 *** Keywords ***
@@ -22,6 +20,13 @@ Assign ${permission_type} Permissions To User ${username}
     Select Permission Type    permission_type=${permission_type}
     Save Permission
 
+Assign ${permission_type} Permissions To User ${username} in Project ${project_title}
+    Open Data Science Projects Home Page
+    Wait Until Project Is Listed    project_title=${project_title}
+    Open Data Science Project Details Page    ${project_title}
+    Move To Tab             Permissions
+    Assign ${permission_type} Permissions To User ${username}
+    
 Change ${username} Permissions To ${permission_type}
     [Documentation]    Change the level of permission ${permission_type} for the given user ${username}
     ...    in the currently open DS Project in UI
@@ -104,51 +109,3 @@ Is ${username} In The Permissions Table
     ${present}=    Run Keyword And Return Status
     ...    Page Should Contain Element       xpath=//tr[td[@data-label="Username"]//*[text()="${username}"]]
     RETURN    ${present}
-
-Set RHODS Admins Group Empty Group
-    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
-    ...    users_group=${STANDARD_SYSTEM_GROUP}
-
-Set RHODS Admins Group To system:authenticated    # robocop:disable
-    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
-    ...    to the system:authenticated group
-    Set Access Groups Settings    admins_group=system:authenticated
-    ...    users_group=${STANDARD_SYSTEM_GROUP}
-
-Set RHODS Admins Group To Inexistent Group
-    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
-    ...    to the given inexistent group
-    Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
-    ...    users_group=${STANDARD_SYSTEM_GROUP}
-
-Set RHODS Users Group Empty Group
-    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...    to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...    users_group=${CUSTOM_EMPTY_GROUP}
-
-Set RHODS Users Group To rhods-users    # robocop:disable
-    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...    to the rhods-users group
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...    users_group=${STANDARD_USERS_GROUP}
-
-Set RHODS Users Group To Inexistent Group
-    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...    to the given inexistent group
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...    users_group=${CUSTOM_INEXISTENT_GROUP}
-
-Set Default Groups And Check Logs Do Not Change
-    [Documentation]    Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "odh-dashboard-config"
-    ...    ConfigMap and checks if no new lines are generated in the logs after that.
-    [Arguments]    ${delete_group}=${FALSE}
-    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...    users_group=${STANDARD_SYSTEM_GROUP}
-    Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
-    IF  "${delete_group}" == "${TRUE}"
-        Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
-    END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -31,7 +31,7 @@ Change ${username} Permissions To ${permission_type}
     Save Permission
 
 Remove ${username} Permissions
-    [Documentation]    Remove the the access to the given user ${username}
+    [Documentation]    Remove the access to the given user ${username}
     ...    from the currently open DS Project in UI
     Permissions.Click Action From Actions Menu    username=${username}
     ...    action=Delete

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -1,12 +1,14 @@
 *** Settings ***
 Documentation    Collection of keywords to interact with Storages
 Resource       ./Projects.resource
+Resource       ../../../../../Resources/ODS.robot
 
 
 *** Variables ***
 ${SAVE_BUTTON}=    xpath://button[@data-id="save-rolebinding-button"]
 ${PERMISSIONS_DROPDOWN}=    xpath://td[@data-label="Permission"]//button[@aria-label="Options menu"]
 ${IS_CLUSTER_ADMIN}=    ${FALSE}
+${CUSTOM_EMPTY_GROUP}=    empty-group
 
 
 *** Keywords ***

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -106,37 +106,43 @@ Is ${username} In The Permissions Table
     RETURN    ${present}
 
 Set RHODS Admins Group Empty Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}
 
 Set RHODS Admins Group To system:authenticated    # robocop:disable
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
+    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...                 to the system:authenticated group
     Set Access Groups Settings    admins_group=system:authenticated
     ...     users_group=${STANDARD_USERS_GROUP}
 
-Set RHODS Users Group Empty Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_EMPTY_GROUP}
-
 Set RHODS Admins Group To Inexistent Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
     ...                 to the given inexistent group
     Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
     ...     users_group=${STANDARD_USERS_GROUP}
 
+Set RHODS Users Group Empty Group
+    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...     users_group=${CUSTOM_EMPTY_GROUP}
+
+Set RHODS Users Group To rhods-users    # robocop:disable
+    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...                 to the rhods-users group
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...     users_group=${STANDARD_USERS_GROUP}
+
 Set RHODS Users Group To Inexistent Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
     ...                 to the given inexistent group
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...     users_group=${CUSTOM_INEXISTENT_GROUP}
 
 Set Default Groups And Check Logs Do Not Change
-    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
+    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "odh-dashboard-config"
     ...                 ConfigMap and checks if no new lines are generated in the logs after that.
     [Arguments]     ${delete_group}=${FALSE}
     ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -109,45 +109,45 @@ Set RHODS Admins Group Empty Group
     [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
     ...                 to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
 
 Set RHODS Admins Group To system:authenticated    # robocop:disable
-    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the system:authenticated group
+    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the system:authenticated group
     Set Access Groups Settings    admins_group=system:authenticated
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
 
 Set RHODS Admins Group To Inexistent Group
-    [Documentation]     Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the given inexistent group
+    [Documentation]    Sets the "adminGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given inexistent group
     Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
 
 Set RHODS Users Group Empty Group
-    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given empty group (i.e., with no users)
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_EMPTY_GROUP}
+    ...    users_group=${CUSTOM_EMPTY_GROUP}
 
 Set RHODS Users Group To rhods-users    # robocop:disable
-    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the rhods-users group
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the rhods-users group
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...    users_group=${STANDARD_USERS_GROUP}
 
 Set RHODS Users Group To Inexistent Group
-    [Documentation]     Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
-    ...                 to the given inexistent group
+    [Documentation]    Sets the "allowedGroups" field in "odh-dashboard-config" ConfigMap
+    ...    to the given inexistent group
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_INEXISTENT_GROUP}
+    ...    users_group=${CUSTOM_INEXISTENT_GROUP}
 
 Set Default Groups And Check Logs Do Not Change
-    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "odh-dashboard-config"
-    ...                 ConfigMap and checks if no new lines are generated in the logs after that.
-    [Arguments]     ${delete_group}=${FALSE}
+    [Documentation]    Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "odh-dashboard-config"
+    ...    ConfigMap and checks if no new lines are generated in the logs after that.
+    [Arguments]    ${delete_group}=${FALSE}
     ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
     Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
     Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
     IF  "${delete_group}" == "${TRUE}"
         Delete Group    group_name=${CUSTOM_EMPTY_GROUP}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -102,3 +102,45 @@ Is ${username} In The Permissions Table
     ${present}=    Run Keyword And Return Status
     ...    Page Should Contain Element       xpath=//tr[td[@data-label="Username"]//*[text()="${username}"]]
     RETURN    ${present}
+
+Set RHODS Admins Group Empty Group
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
+    ...     users_group=${STANDARD_USERS_GROUP}
+
+Set RHODS Admins Group To system:authenticated    # robocop:disable
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=system:authenticated
+    ...     users_group=${STANDARD_USERS_GROUP}
+
+Set RHODS Users Group Empty Group
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given empty group (i.e., with no users)
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...     users_group=${CUSTOM_EMPTY_GROUP}
+
+Set RHODS Admins Group To Inexistent Group
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given inexistent group
+    Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
+    ...     users_group=${STANDARD_USERS_GROUP}
+
+Set RHODS Users Group To Inexistent Group
+    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
+    ...                 to the given inexistent group
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...     users_group=${CUSTOM_INEXISTENT_GROUP}
+
+Set Default Groups And Check Logs Do Not Change
+    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
+    ...                 ConfigMap and checks if no new lines are generated in the logs after that.
+    [Arguments]     ${delete_group}=${FALSE}
+    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...     users_group=${STANDARD_USERS_GROUP}
+    Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
+    IF  "${delete_group}" == "${TRUE}"
+        Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
+    END

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -5,7 +5,6 @@ Resource          ../../Resources/RHOSi.resource
 Resource          ../../Resources/ODS.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
-Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
 Resource          ../../Resources/Page/ODH/AiApps/Anaconda.resource
 Resource          ../../Resources/Page/LoginPage.robot
 Resource          ../../Resources/Page/OCPLogin/OCPLogin.robot
@@ -397,6 +396,18 @@ Logs Of Dashboard Pods Should Not Contain New Lines
         ...                 Wait Until New Log Lines Are Generated In A Dashboard Pod
         ...                 prev_length=${lengths_dict}[${pod_name}]  pod_name=${pod_name}
         Run Keyword And Continue On Failure     Should Be Equal     ${new_lines_flag}   ${FALSE}
+    END
+
+Set Default Groups And Check Logs Do Not Change
+    [Documentation]    Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "odh-dashboard-config"
+    ...    ConfigMap and checks if no new lines are generated in the logs after that.
+    [Arguments]    ${delete_group}=${FALSE}
+    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
+    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
+    ...    users_group=${STANDARD_SYSTEM_GROUP}
+    Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
+    IF  "${delete_group}" == "${TRUE}"
+        Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
     END
 
 Favorite Items Should Be Listed First

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -5,6 +5,7 @@ Resource          ../../Resources/RHOSi.resource
 Resource          ../../Resources/ODS.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
 Resource          ../../Resources/Page/ODH/AiApps/Anaconda.resource
 Resource          ../../Resources/Page/LoginPage.robot
 Resource          ../../Resources/Page/OCPLogin/OCPLogin.robot
@@ -387,48 +388,6 @@ Wait Until New Log Lines Are Generated In A Dashboard Pod
         Fail    Something got wrong. Check the logs
     END
     RETURN    ${pod_logs_lines}[${prev_length}:]     ${n_lines}
-
-Set RHODS Admins Group Empty Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=${CUSTOM_EMPTY_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
-
-Set RHODS Admins Group To system:authenticated    # robocop:disable
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=system:authenticated
-    ...     users_group=${STANDARD_USERS_GROUP}
-
-Set RHODS Users Group Empty Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given empty group (i.e., with no users)
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_EMPTY_GROUP}
-
-Set RHODS Admins Group To Inexistent Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given inexistent group
-    Set Access Groups Settings    admins_group=${CUSTOM_INEXISTENT_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
-
-Set RHODS Users Group To Inexistent Group
-    [Documentation]     Sets the "admins_groups" field in "rhods-groups-config" ConfigMap
-    ...                 to the given inexistent group
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${CUSTOM_INEXISTENT_GROUP}
-
-Set Default Groups And Check Logs Do Not Change
-    [Documentation]     Teardown for ODS-1408 and ODS-1494. It sets the default configuration of "rhods-groups-config"
-    ...                 ConfigMap and checks if no new lines are generated in the logs after that.
-    [Arguments]     ${delete_group}=${FALSE}
-    ${lengths_dict}=    Get Lengths Of Dashboard Pods Logs
-    Set Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
-    ...     users_group=${STANDARD_USERS_GROUP}
-    Logs Of Dashboard Pods Should Not Contain New Lines  lengths_dict=${lengths_dict}
-    IF  "${delete_group}" == "${TRUE}"
-        Delete Group    group_name=${CUSTOM_EMPTY_GROUP}
-    END
 
 Logs Of Dashboard Pods Should Not Contain New Lines
     [Documentation]     Checks if no new lines are generated in the logs after that.

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -85,21 +85,15 @@ Verify Project Sharing Does Not Override Dashboard Permissions
     # [Setup]                 Run Keywords            Restore Permissions Of The Project
     # ...                     AND                     Set RHODS Users Group To rhods-users
     [Setup]                 Set RHODS Users Group To rhods-users
-    # Launch Data Science Project Main Page           username=${TEST_USER.USERNAME}
     Launch Data Science Project Main Page    username=${OCP_ADMIN_USER.USERNAME}    password=${OCP_ADMIN_USER.PASSWORD}
     ...    ocp_user_auth_type=${OCP_ADMIN_USER.AUTH_TYPE}
-    # Switch To User    ${USER_A}
-    # Open Data Science Projects Home Page
     Assign Admin Permissions To User ${USER_B} in Project ${PRJ_USER_B_TITLE}
     Assign Edit Permissions To User ${USER_C} in Project ${PRJ_USER_C_TITLE}
     Remove User From Group    username=${USER_B}    group_name=rhods-users
     Remove User From Group    username=${USER_C}    group_name=rhods-users
+    Verify No Permissions For User ${USER_B}
+    Verify No Permissions For User ${USER_C}
     Switch To User    ${USER_B}
-    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
-    Page Should Contain    Access permissions needed
-    Switch To User    ${USER_C}
-    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
-    Page Should Contain    Access permissions needed
     [Teardown]              Run Keywords            Set RHODS Admins Group To system:authenticated
     ...                     AND                     Set User Groups For Testing
 
@@ -296,3 +290,8 @@ Assign ${permission_type} Permissions To User ${username} in Project ${project_t
     Open Data Science Project Details Page    ${project_title}
     Move To Tab             Permissions
     Assign ${permission_type} Permissions To User ${username}
+
+Verify No Permissions For User ${username}
+    Switch To User    ${username}
+    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Page Should Contain    Access permissions needed

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -80,7 +80,7 @@ Verify Project Sharing Does Not Override Dashboard Permissions
     [Tags]    Tier1    Sanity
     ...       ODS-2223
     # [Setup]    Run Keywords  Restore Permissions Of The Project
-    # ...         AND           Set RHODS Admins Group Empty Group     
+    # ...         AND           Set RHODS Admins Group Empty Group
     [Setup]    Set RHODS Admins Group Empty Group     
     Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
     Move To Tab    Permissions
@@ -101,6 +101,8 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
+    Set Standard RHODS Groups Variables
+    Set Default Access Groups Settings
     ${to_delete}=    Create List
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch RHODS Dashboard Session With User A

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -101,7 +101,7 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
-    # Set Standard RHODS Groups Variables
+    Set Standard RHODS Groups Variables
     # Set Default Access Groups Settings
     ${to_delete}=    Create List
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -84,8 +84,6 @@ Verify User Can Assign Access Permissions To User Groups
 
 Verify Project Sharing Does Not Override Dashboard Permissions
     [Tags]                  Tier1                   Sanity                  ODS-2223
-    # [Setup]                 Run Keywords            Restore Permissions Of The Project
-    # ...                     AND                     Set RHODS Users Group To rhods-users
     [Setup]                 Set RHODS Users Group To rhods-users
     Launch Data Science Project Main Page    username=${OCP_ADMIN_USER.USERNAME}    password=${OCP_ADMIN_USER.PASSWORD}
     ...    ocp_user_auth_type=${OCP_ADMIN_USER.AUTH_TYPE}
@@ -95,9 +93,9 @@ Verify Project Sharing Does Not Override Dashboard Permissions
     Remove User From Group    username=${USER_B}    group_name=rhods-admins
     Remove User From Group    username=${USER_C}    group_name=rhods-users
     Remove User From Group    username=${USER_C}    group_name=rhods-admins
-    Verify No Permissions For User ${USER_B}
-    Verify No Permissions For User ${USER_C}
-    [Teardown]              Run Keywords            Set RHODS Admins Group To system:authenticated
+    User ${USER_B} Should Not Be Allowed To Dashboard
+    User ${USER_C} Should Not Be Allowed To Dashboard
+    [Teardown]              Run Keywords            Set Default Access Groups Settings
     ...                     AND                     Set User Groups For Testing
 
 
@@ -229,6 +227,7 @@ Reload Page If Project ${project_title} Is Not Listed
             Sleep   5s
         END
     END
+    [Teardown]    Capture Page Screenshot
 
 Reload Page If Project ${project_title} Is Listed
     ${is_listed} =    Set Variable    ${TRUE}
@@ -242,6 +241,7 @@ Reload Page If Project ${project_title} Is Listed
             Sleep   5s
         END
     END
+    [Teardown]    Capture Page Screenshot
 
 ${username} Should Have Edit Access To ${project_title}
     Switch To User    ${username}
@@ -269,17 +269,11 @@ ${username} Should Not Have Access To ${project_title}
     RoleBinding Should Not Exist    project_title=${project_title}
     ...    subject_name=${username}
 
-Assign ${permission_type} Permissions To User ${username} in Project ${project_title}
-    Open Data Science Projects Home Page
-    Wait Until Project Is Listed    project_title=${project_title}
-    Open Data Science Project Details Page    ${project_title}
-    Move To Tab             Permissions
-    Assign ${permission_type} Permissions To User ${username}
-
-Verify No Permissions For User ${username}
+User ${username} Should Not Be Allowed To Dashboard
     Switch To User    ${username}
     ${permissions_set} =    Set Variable    ${FALSE}
     WHILE   not ${permissions_set}    limit=3m    on_limit_message=Timeout exceeded waiting for user ${username} permissions to be updated    # robotcode: ignore
         ${permissions_set}=    Run Keyword And Return Status    Wait Until Page Contains     Access permissions needed    timeout=15
         IF    ${permissions_set} == ${FALSE}    Reload Page
     END
+    [Teardown]    Capture Page Screenshot

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -79,9 +79,9 @@ Verify User Can Assign Access Permissions To User Groups
 Verify Project Sharing Does Not Override Dashboard Permissions
     [Tags]    Tier1    Sanity
     ...       ODS-2223
-    # [Setup]    Run Keywords  Restore Permissions Of The Project
-    # ...         AND           Set RHODS Admins Group Empty Group
-    [Setup]    Set RHODS Admins Group Empty Group     
+    [Setup]    Run Keywords  Restore Permissions Of The Project
+    ...         AND           Set RHODS Users Group To rhods-users
+    # [Setup]    Set RHODS Users Group To rhods-users     
     Launch Data Science Project Main Page    username=${TEST_USER.USERNAME}
     Move To Tab    Permissions
     Remove User From Group    username=${USER_B}
@@ -101,8 +101,8 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
-    Set Standard RHODS Groups Variables
-    Set Default Access Groups Settings
+    # Set Standard RHODS Groups Variables
+    # Set Default Access Groups Settings
     ${to_delete}=    Create List
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch RHODS Dashboard Session With User A

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -82,7 +82,7 @@ Verify Project Sharing Does Not Override Dashboard Permissions
     # [Setup]    Run Keywords  Restore Permissions Of The Project
     # ...         AND           Set RHODS Admins Group Empty Group
     [Setup]    Set RHODS Admins Group Empty Group     
-    Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
+    Launch Data Science Project Main Page    username=${TEST_USER.USERNAME}
     Move To Tab    Permissions
     Remove User From Group    username=${USER_B}
     ...    group_name=rhods-users

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -76,6 +76,24 @@ Verify User Can Assign Access Permissions To User Groups
     Sleep   5s
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
+Verify Project Sharing Does Not Override Dashboard Permissions
+    [Tags]    Tier1    Sanity
+    ...       ODS-2223
+    # [Setup]    Run Keywords  Restore Permissions Of The Project
+    # ...         AND           Set RHODS Admins Group Empty Group     
+    [Setup]    Set RHODS Admins Group Empty Group     
+    Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
+    Move To Tab    Permissions
+    Remove User From Group    username=${USER_B}
+    ...    group_name=rhods-users
+    Remove User From Group    username=${USER_C}
+    ...    group_name=rhods-users
+    Assign Admin Permissions To User ${USER_B}
+    Assign Edit Permissions To User ${USER_C}
+    ${USER_B} Should Not Have Access To ${PRJ_USER_B_TITLE}
+    ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
+    [Teardown]    Run Keywords  Set RHODS Admins Group To system:authenticated
+    ...         AND           Set User Groups For Testing
 
 *** Keywords ***
 Project Permissions Mgmt Suite Setup    # robocop: disable

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -1,34 +1,40 @@
 *** Settings ***
-Documentation      Suite to test additional scenarios for Data Science Projects (a.k.a DSG) feature
-Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
-Suite Setup        Project Permissions Mgmt Suite Setup
-Suite Teardown     Project Permissions Mgmt Suite Teardown
+Documentation       Suite to test additional scenarios for Data Science Projects (a.k.a DSG) feature
+
+Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+
+Suite Setup         Project Permissions Mgmt Suite Setup
+Suite Teardown      Project Permissions Mgmt Suite Teardown
 
 
 *** Variables ***
-${PRJ_BASE_TITLE}=   ODS-CI DS Project
-${PRJ_DESCRIPTION}=   ${PRJ_BASE_TITLE} is a test project for validating DS Project Sharing feature
-${WORKBENCH_DESCRIPTION}=   a test workbench to check project sharing
-${NB_IMAGE}=        Minimal Python
-${PV_NAME}=         ods-ci-project-sharing
-${PV_DESCRIPTION}=         it is a PV created to test DS Projects Sharing feature
-${PV_SIZE}=         1
-${USER_GROUP_1}=    ds-group-1
-${USER_GROUP_2}=    ds-group-2
+${PRJ_BASE_TITLE}=              ODS-CI DS Project
+${PRJ_DESCRIPTION}=             ${PRJ_BASE_TITLE} is a test project for validating DS Project Sharing feature
+${WORKBENCH_DESCRIPTION}=       a test workbench to check project sharing
+${NB_IMAGE}=                    Minimal Python
+${PV_NAME}=                     ods-ci-project-sharing
+${PV_DESCRIPTION}=              it is a PV created to test DS Projects Sharing feature
+${PV_SIZE}=                     1
+${USER_GROUP_1}=                ds-group-1
+${USER_GROUP_2}=                ds-group-2
+${USER_A}=                      ${TEST_USER_2.USERNAME}
+${USER_B}=                      ${TEST_USER_3.USERNAME}
+${PRJ_USER_B_TITLE}=            ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
+${USER_C}=                      ${TEST_USER_4.USERNAME}
+${PRJ_USER_C_TITLE}=            ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
+
 
 *** Test Cases ***
 Verify User Can Access Permission Tab In Their Owned DS Project
     [Documentation]    Verify user has access to "Permissions" tab in their DS Projects
-    [Tags]    Tier1    Smoke    OpenDataHub
-    ...       ODS-2194
-    Pass Execution    The Test is executed as part of Suite Setup
+    [Tags]                  Tier1                   Smoke                   OpenDataHub             ODS-2194
+    Pass Execution          The Test is executed as part of Suite Setup
 
 Verify User Can Make Their Owned DS Project Accessible To Other Users    # robocop: disable
     [Documentation]    Verify user can give access permissions for their DS Projects to other users
-    [Tags]    Tier1    Sanity
-    ...       ODS-2201
-    Switch To User    ${USER_B}
-    Move To Tab    Permissions
+    [Tags]                  Tier1                   Sanity                  ODS-2201
+    Switch To User          ${USER_B}
+    Move To Tab             Permissions
     Assign Edit Permissions To User ${USER_C}
     Assign Admin Permissions To User ${USER_A}
     ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
@@ -36,69 +42,67 @@ Verify User Can Make Their Owned DS Project Accessible To Other Users    # roboc
 
 Verify User Can Modify And Revoke Access To DS Projects From Other Users    # robocop: disable
     [Documentation]    Verify user can modify/remove access permissions for their DS Projects to other users
-    [Tags]    Tier1    Sanity
-    ...       ODS-2202
-    Switch To User    ${USER_B}
-    Move To Tab    Permissions
+    [Tags]                  Tier1                   Sanity                  ODS-2202
+    Switch To User          ${USER_B}
+    Move To Tab             Permissions
     Change ${USER_C} Permissions To Admin
     Change ${USER_A} Permissions To Edit
     Refresh Pages
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
-    Switch To User    ${USER_B}
-    Move To Tab    Permissions
+    Switch To User          ${USER_B}
+    Move To Tab             Permissions
     Remove ${USER_C} Permissions
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify User Can Assign Access Permissions To User Groups
-    [Tags]    Tier1    Sanity
-    ...       ODS-2208
-    [Setup]    Restore Permissions Of The Project
-    Switch To User    ${USER_B}
+    [Tags]                  Tier1                   Sanity                  ODS-2208
+    [Setup]                 Restore Permissions Of The Project
+    Switch To User          ${USER_B}
     Assign Edit Permissions To Group ${USER_GROUP_1}
     Assign Admin Permissions To Group ${USER_GROUP_2}
-    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_GROUP_1}
+    RoleBinding Should Exist                        project_title=${PRJ_USER_B_TITLE}
+    ...                     subject_name=${USER_GROUP_1}
 
-    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
-    ...    subject_name=${USER_GROUP_2}
-    Sleep   5s
+    RoleBinding Should Exist                        project_title=${PRJ_USER_B_TITLE}
+    ...                     subject_name=${USER_GROUP_2}
+    Sleep                   5s
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
-    Switch To User    ${USER_B}
+    Switch To User          ${USER_B}
     Change ${USER_GROUP_1} Permissions To Admin
     Change ${USER_GROUP_2} Permissions To Edit
-    Sleep   5s
+    Sleep                   5s
     ${USER_A} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
-    Switch To User    ${USER_B}
+    Switch To User          ${USER_B}
     Remove ${USER_GROUP_2} Permissions
-    Sleep   5s
+    Sleep                   5s
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify Project Sharing Does Not Override Dashboard Permissions
-    [Tags]    Tier1    Sanity
-    ...       ODS-2223
-    [Setup]    Run Keywords  Restore Permissions Of The Project
-    ...         AND           Set RHODS Users Group To rhods-users
-    # [Setup]    Set RHODS Users Group To rhods-users     
-    Launch Data Science Project Main Page    username=${TEST_USER.USERNAME}
-    Move To Tab    Permissions
-    Remove User From Group    username=${USER_B}
-    ...    group_name=rhods-users
-    Remove User From Group    username=${USER_C}
-    ...    group_name=rhods-users
+    [Tags]                  Tier1                   Sanity                  ODS-2223
+    [Setup]                 Run Keywords            Restore Permissions Of The Project
+    ...                     AND                     Set RHODS Users Group To rhods-users
+    # [Setup]    Set RHODS Users Group To rhods-users
+    Launch Data Science Project Main Page           username=${TEST_USER.USERNAME}
+    Move To Tab             Permissions
+    Remove User From Group                          username=${USER_B}
+    ...                     group_name=rhods-users
+    Remove User From Group                          username=${USER_C}
+    ...                     group_name=rhods-users
     Assign Admin Permissions To User ${USER_B}
     Assign Edit Permissions To User ${USER_C}
     ${USER_B} Should Not Have Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
-    [Teardown]    Run Keywords  Set RHODS Admins Group To system:authenticated
-    ...         AND           Set User Groups For Testing
+    [Teardown]              Run Keywords            Set RHODS Admins Group To system:authenticated
+    ...                     AND                     Set User Groups For Testing
+
 
 *** Keywords ***
 Project Permissions Mgmt Suite Setup    # robocop: disable
     [Documentation]    Suite setup steps for testing DS Projects.
-    ...                It creates some test variables and runs RHOSi setup
+    ...    It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Set Standard RHODS Groups Variables
@@ -113,9 +117,9 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
 
 Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
-    ...                all the DS projects created by the tests and run RHOSi teardown
+    ...    all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete Data Science Projects From CLI    ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
     Remove User From Group    username=${USER_A}
     ...    group_name=rhods-users
@@ -140,14 +144,12 @@ Switch To User
     Set Suite Variable    ${IS_CLUSTER_ADMIN}    ${is_cluster_admin}
 
 Launch RHODS Dashboard Session With User A
-    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}  ocp_user_pw=${TEST_USER_2.PASSWORD}
+    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}    ocp_user_pw=${TEST_USER_2.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_2.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
-    ...    browser=${BROWSER.NAME}   browser_options=${BROWSER.OPTIONS}
+    ...    browser=${BROWSER.NAME}    browser_options=${BROWSER.OPTIONS}
     ...    browser_alias=${TEST_USER_2.USERNAME}-session
-    Set Suite Variable    ${USER_A}    ${TEST_USER_2.USERNAME}
 
 Launch RHODS Dashboard Session And Create A DS Project With User B
-    ${PRJ_USER_B_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_3.USERNAME}
     Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_USER_B_TITLE}
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}
@@ -157,11 +159,8 @@ Launch RHODS Dashboard Session And Create A DS Project With User B
     ...    description=${PRJ_DESCRIPTION}
     Permissions Tab Should Be Accessible
     Components Tab Should Be Accessible
-    Set Suite Variable    ${USER_B}    ${TEST_USER_3.USERNAME}
-    Set Suite Variable    ${PRJ_USER_B_TITLE}    ${PRJ_USER_B_TITLE}
 
 Launch RHODS Dashboard Session With User C
-    ${PRJ_USER_C_TITLE}=    Set Variable   ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
     Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_USER_C_TITLE}
     Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
     ...    password=${TEST_USER_4.PASSWORD}
@@ -171,8 +170,6 @@ Launch RHODS Dashboard Session With User C
     ...    description=${PRJ_DESCRIPTION}
     Permissions Tab Should Be Accessible
     Components Tab Should Be Accessible
-    Set Suite Variable    ${USER_C}    ${TEST_USER_4.USERNAME}
-    Set Suite Variable    ${PRJ_USER_C_TITLE}    ${PRJ_USER_C_TITLE}
 
 Set User Groups For Testing
     Create Group    ${USER_GROUP_1}
@@ -196,13 +193,9 @@ Restore Permissions Of The Project
     Switch To User    ${USER_B}
     Move To Tab    Permissions
     ${present_a}=    Is ${USER_A} In The Permissions Table
-    IF    ${present_a} == ${TRUE}
-        Remove ${USER_A} Permissions
-    END
+    IF    ${present_a} == ${TRUE}    Remove ${USER_A} Permissions
     ${present_c}=    Is ${USER_C} In The Permissions Table
-    IF    ${present_c} == ${TRUE}
-        Remove ${USER_C} Permissions
-    END
+    IF    ${present_c} == ${TRUE}    Remove ${USER_C} Permissions
     ${USER_A} Should Not Have Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
@@ -226,14 +219,18 @@ Reload Page If Project ${project_title} Is Not Listed
     ${is_listed}=    Run Keyword And Return Status
     ...    Project Should Be Listed    project_title=${project_title}
     IF    ${is_listed} == ${FALSE}
-        Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!    # robocop:disable
+        # robocop:disable
+        Log
+        ...    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data Science Projects
         ...    wait_for_cards=${FALSE}
         ${is_listed}=    Run Keyword And Return Status
         ...    Project Should Be Listed    project_title=${project_title}
         IF    ${is_listed} == ${FALSE}
-            Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
+            # robocop:disable
+            Log
+            ...    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list! (2)
             ...    level=WARN
             Reload RHODS Dashboard Page    expected_page=Data Science Projects
             ...    wait_for_cards=${FALSE}
@@ -244,14 +241,18 @@ Reload Page If Project ${project_title} Is Listed
     ${is_listed}=    Run Keyword And Return Status
     ...    Project Should Be Listed    project_title=${project_title}
     IF    ${is_listed} == ${TRUE}
-        Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!    # robocop:disable
+        # robocop:disable
+        Log
+        ...    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data Science Projects
         ...    wait_for_cards=${FALSE}
         ${is_listed}=    Run Keyword And Return Status
         ...    Project Should Be Listed    project_title=${project_title}
         IF    ${is_listed} == ${TRUE}
-            Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
+            # robocop:disable
+            Log
+            ...    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list! (2)
             ...    level=WARN
             Reload RHODS Dashboard Page    expected_page=Data Science Projects
             ...    wait_for_cards=${FALSE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -82,19 +82,24 @@ Verify User Can Assign Access Permissions To User Groups
 
 Verify Project Sharing Does Not Override Dashboard Permissions
     [Tags]                  Tier1                   Sanity                  ODS-2223
-    [Setup]                 Run Keywords            Restore Permissions Of The Project
-    ...                     AND                     Set RHODS Users Group To rhods-users
-    # [Setup]    Set RHODS Users Group To rhods-users
-    Launch Data Science Project Main Page           username=${TEST_USER.USERNAME}
-    Move To Tab             Permissions
-    Remove User From Group                          username=${USER_B}
-    ...                     group_name=rhods-users
-    Remove User From Group                          username=${USER_C}
-    ...                     group_name=rhods-users
-    Assign Admin Permissions To User ${USER_B}
-    Assign Edit Permissions To User ${USER_C}
-    ${USER_B} Should Not Have Access To ${PRJ_USER_B_TITLE}
-    ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
+    # [Setup]                 Run Keywords            Restore Permissions Of The Project
+    # ...                     AND                     Set RHODS Users Group To rhods-users
+    [Setup]                 Set RHODS Users Group To rhods-users
+    # Launch Data Science Project Main Page           username=${TEST_USER.USERNAME}
+    Launch Data Science Project Main Page    username=${OCP_ADMIN_USER.USERNAME}    password=${OCP_ADMIN_USER.PASSWORD}
+    ...    ocp_user_auth_type=${OCP_ADMIN_USER.AUTH_TYPE}
+    # Switch To User    ${USER_A}
+    # Open Data Science Projects Home Page
+    Assign Admin Permissions To User ${USER_B} in Project ${PRJ_USER_B_TITLE}
+    Assign Edit Permissions To User ${USER_C} in Project ${PRJ_USER_C_TITLE}
+    Remove User From Group    username=${USER_B}    group_name=rhods-users
+    Remove User From Group    username=${USER_C}    group_name=rhods-users
+    Switch To User    ${USER_B}
+    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Page Should Contain    Access permissions needed
+    Switch To User    ${USER_C}
+    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Page Should Contain    Access permissions needed
     [Teardown]              Run Keywords            Set RHODS Admins Group To system:authenticated
     ...                     AND                     Set User Groups For Testing
 
@@ -106,7 +111,7 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Set Standard RHODS Groups Variables
-    # Set Default Access Groups Settings
+    Set Default Access Groups Settings
     ${to_delete}=    Create List
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Launch RHODS Dashboard Session With User A
@@ -284,3 +289,10 @@ ${username} Should Not Have Access To ${project_title}
     Project Should Not Be Listed    project_title=${project_title}
     RoleBinding Should Not Exist    project_title=${project_title}
     ...    subject_name=${username}
+
+Assign ${permission_type} Permissions To User ${username} in Project ${project_title}
+    Open Data Science Projects Home Page
+    Wait Until Project Is Listed    project_title=${project_title}
+    Open Data Science Project Details Page    ${project_title}
+    Move To Tab             Permissions
+    Assign ${permission_type} Permissions To User ${username}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -1,10 +1,8 @@
 *** Settings ***
-Documentation       Suite to test additional scenarios for Data Science Projects (a.k.a DSG) feature
-
-Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
-
-Suite Setup         Project Permissions Mgmt Suite Setup
-Suite Teardown      Project Permissions Mgmt Suite Teardown
+Documentation      Suite to test additional scenarios for Data Science Projects (a.k.a DSG) feature
+Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+Suite Setup        Project Permissions Mgmt Suite Setup
+Suite Teardown     Project Permissions Mgmt Suite Teardown
 
 
 *** Variables ***
@@ -27,14 +25,16 @@ ${PRJ_USER_C_TITLE}=            ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
 *** Test Cases ***
 Verify User Can Access Permission Tab In Their Owned DS Project
     [Documentation]    Verify user has access to "Permissions" tab in their DS Projects
-    [Tags]                  Tier1                   Smoke                   OpenDataHub             ODS-2194
-    Pass Execution          The Test is executed as part of Suite Setup
+    [Tags]    Tier1    Smoke    OpenDataHub
+    ...       ODS-2194
+    Pass Execution    The Test is executed as part of Suite Setup
 
 Verify User Can Make Their Owned DS Project Accessible To Other Users    # robocop: disable
     [Documentation]    Verify user can give access permissions for their DS Projects to other users
-    [Tags]                  Tier1                   Sanity                  ODS-2201
-    Switch To User          ${USER_B}
-    Move To Tab             Permissions
+    [Tags]    Tier1    Sanity
+    ...       ODS-2201
+    Switch To User    ${USER_B}
+    Move To Tab    Permissions
     Assign Edit Permissions To User ${USER_C}
     Assign Admin Permissions To User ${USER_A}
     ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
@@ -42,42 +42,44 @@ Verify User Can Make Their Owned DS Project Accessible To Other Users    # roboc
 
 Verify User Can Modify And Revoke Access To DS Projects From Other Users    # robocop: disable
     [Documentation]    Verify user can modify/remove access permissions for their DS Projects to other users
-    [Tags]                  Tier1                   Sanity                  ODS-2202
-    Switch To User          ${USER_B}
-    Move To Tab             Permissions
+    [Tags]    Tier1    Sanity
+    ...       ODS-2202
+    Switch To User    ${USER_B}
+    Move To Tab    Permissions
     Change ${USER_C} Permissions To Admin
     Change ${USER_A} Permissions To Edit
     Refresh Pages
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
-    Switch To User          ${USER_B}
-    Move To Tab             Permissions
+    Switch To User    ${USER_B}
+    Move To Tab    Permissions
     Remove ${USER_C} Permissions
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify User Can Assign Access Permissions To User Groups
-    [Tags]                  Tier1                   Sanity                  ODS-2208
-    [Setup]                 Restore Permissions Of The Project
-    Switch To User          ${USER_B}
+    [Tags]    Tier1    Sanity
+    ...       ODS-2208
+    [Setup]    Restore Permissions Of The Project
+    Switch To User    ${USER_B}
     Assign Edit Permissions To Group ${USER_GROUP_1}
     Assign Admin Permissions To Group ${USER_GROUP_2}
-    RoleBinding Should Exist                        project_title=${PRJ_USER_B_TITLE}
-    ...                     subject_name=${USER_GROUP_1}
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_GROUP_1}
 
-    RoleBinding Should Exist                        project_title=${PRJ_USER_B_TITLE}
-    ...                     subject_name=${USER_GROUP_2}
-    Sleep                   5s
+    RoleBinding Should Exist    project_title=${PRJ_USER_B_TITLE}
+    ...    subject_name=${USER_GROUP_2}
+    Sleep   5s
     ${USER_A} Should Have Edit Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Have Admin Access To ${PRJ_USER_B_TITLE}
-    Switch To User          ${USER_B}
+    Switch To User    ${USER_B}
     Change ${USER_GROUP_1} Permissions To Admin
     Change ${USER_GROUP_2} Permissions To Edit
-    Sleep                   5s
+    Sleep   5s
     ${USER_A} Should Have Admin Access To ${PRJ_USER_B_TITLE}
     ${USER_C} Should Have Edit Access To ${PRJ_USER_B_TITLE}
-    Switch To User          ${USER_B}
+    Switch To User    ${USER_B}
     Remove ${USER_GROUP_2} Permissions
-    Sleep                   5s
+    Sleep   5s
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify Project Sharing Does Not Override Dashboard Permissions
@@ -101,7 +103,7 @@ Verify Project Sharing Does Not Override Dashboard Permissions
 *** Keywords ***
 Project Permissions Mgmt Suite Setup    # robocop: disable
     [Documentation]    Suite setup steps for testing DS Projects.
-    ...    It creates some test variables and runs RHOSi setup
+    ...                It creates some test variables and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Set Standard RHODS Groups Variables
@@ -116,9 +118,9 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
 
 Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
-    ...    all the DS projects created by the tests and run RHOSi teardown
+    ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    Delete Data Science Projects From CLI    ocp_projects=${PROJECTS_TO_DELETE}
+    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
     Remove User From Group    username=${USER_A}
     ...    group_name=rhods-users
@@ -143,9 +145,9 @@ Switch To User
     Set Suite Variable    ${IS_CLUSTER_ADMIN}    ${is_cluster_admin}
 
 Launch RHODS Dashboard Session With User A
-    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}    ocp_user_pw=${TEST_USER_2.PASSWORD}
+    Launch Dashboard    ocp_user_name=${TEST_USER_2.USERNAME}  ocp_user_pw=${TEST_USER_2.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_2.AUTH_TYPE}    dashboard_url=${ODH_DASHBOARD_URL}
-    ...    browser=${BROWSER.NAME}    browser_options=${BROWSER.OPTIONS}
+    ...    browser=${BROWSER.NAME}   browser_options=${BROWSER.OPTIONS}
     ...    browser_alias=${TEST_USER_2.USERNAME}-session
 
 Launch RHODS Dashboard Session And Create A DS Project With User B
@@ -218,18 +220,14 @@ Reload Page If Project ${project_title} Is Not Listed
     ${is_listed}=    Run Keyword And Return Status
     ...    Project Should Be Listed    project_title=${project_title}
     IF    ${is_listed} == ${FALSE}
-        # robocop:disable
-        Log
-        ...    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!
+        Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list!    # robocop:disable
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data Science Projects
         ...    wait_for_cards=${FALSE}
         ${is_listed}=    Run Keyword And Return Status
         ...    Project Should Be Listed    project_title=${project_title}
         IF    ${is_listed} == ${FALSE}
-            # robocop:disable
-            Log
-            ...    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list! (2)
+            Log    message=Project ${project_title} is not listed as expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
             ...    level=WARN
             Reload RHODS Dashboard Page    expected_page=Data Science Projects
             ...    wait_for_cards=${FALSE}
@@ -240,18 +238,14 @@ Reload Page If Project ${project_title} Is Listed
     ${is_listed}=    Run Keyword And Return Status
     ...    Project Should Be Listed    project_title=${project_title}
     IF    ${is_listed} == ${TRUE}
-        # robocop:disable
-        Log
-        ...    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!
+        Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list!    # robocop:disable
         ...    level=WARN
         Reload RHODS Dashboard Page    expected_page=Data Science Projects
         ...    wait_for_cards=${FALSE}
         ${is_listed}=    Run Keyword And Return Status
         ...    Project Should Be Listed    project_title=${project_title}
         IF    ${is_listed} == ${TRUE}
-            # robocop:disable
-            Log
-            ...    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list! (2)
+            Log    message=Project ${project_title} is still listed as NOT expected: reloading DS Project page to refresh project list! (2)    # robocop:disable
             ...    level=WARN
             Reload RHODS Dashboard Page    expected_page=Data Science Projects
             ...    wait_for_cards=${FALSE}


### PR DESCRIPTION
Add New Test ODS-2223:
Verify permissions set as part of Project Sharing do not override Dashboard permission.

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/b98b7560-ece5-42b8-9324-d7cd60927f6d)

Including:
- New Keyword: Set RHODS Users Group To rhods-users
- New Keyword: Assign Permissions To User in Project
- New Keyword: Verify No Permissions For User
- 'Reload Page If Project Is/Not Listed' Keyword with WHILE and Timeout
- Fix 'Create Group' KW to apply new group only if it doesn't exist
- Fix 'Delete Group' KW to delete the group only if it already exists
- Add Resource ODS.robot to Permissions.resource and set Groups Variables
- Add Users names to Suite Variables