### PR TITLE
Verify GPU AcceleratorProfile is created after restarting Dashboard

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/gpu_deploy.sh
@@ -70,6 +70,12 @@ function rerun_accelerator_migration() {
       return 1
   fi
 
+  echo "Waiting for up to 3 minutes until rhods-dashboard deployment is rolled out"
+  oc rollout status deployment.apps/rhods-dashboard -n redhat-ods-applications --watch --timeout 3m
+
+  echo "Verifying that an AcceleratorProfiles resource was created in redhat-ods-applications"
+  oc describe AcceleratorProfiles -n redhat-ods-applications
+
 }
 
 wait_until_pod_ready_status  "gpu-operator"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/gpu_deploy.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+set -e
+
 # Make changes to gpu install file
 
 GPU_INSTALL_DIR="$(dirname "$0")"
@@ -12,61 +14,32 @@ sed -i -e "0,/v1.11/s//$CHANNEL/g" -e "s/gpu-operator-certified.v1.11.0/$CSVNAME
 oc apply -f ${GPU_INSTALL_DIR}/gpu_install.yaml
 
 function wait_until_pod_ready_status() {
-
   local timeout_seconds=1200
-  local sleep_time=90
   local pod_label=$1
   local namespace=nvidia-gpu-operator
 
-  echo "Waiting until gpu pods are in running state..."
-
-  SECONDS=0
-  while [ "$SECONDS" -le "$timeout_seconds" ]; do
-    pod_status=$(oc get pods -lapp=$pod_label -n $namespace -ojsonpath='{range .items[*]}{.status.conditions[?(@.type=="Ready")].status}{"\n"}{end}' 2>/dev/null || echo "terminated")
-    if [ "$pod_status" == "True" ]; then
-			pod_terminating_status=$(oc get pods -lapp=$pod_label -n $namespace -o jsonpath='{.items[0].metadata.deletionGracePeriodSeconds}' 2>/dev/null || echo "terminated")
-			if [ "${pod_terminating_status}" != "" ]; then
-				echo "pod $pod_label is in terminating state..."
-			else
-				echo "Pod $pod_label is ready"
-				break;
-			fi
-    else
-      ((remaining_seconds = timeout_seconds - SECONDS))
-      echo "GPU installation seems to be still running (timeout in $remaining_seconds seconds)..."
-      oc get pods -n $namespace
-      sleep $sleep_time
-    fi
-  done
-
-  if [ "$pod_status" == "True" ] ; then
-    printf "GPU operator is up and running\n"
-    return 0
-  else
-    printf "ERROR: Timeout reached while waiting for gpu operator to be in running state\n"
-    return 1
-  fi
-
+  echo "Waiting until GPU pods of '$pod_label' in namespace '$namespace' are in running state..."
+  oc wait --timeout=${timeout_seconds}s --for=condition=ready pod -n $namespace -l app="$pod_label"
 }
 
 function rerun_accelerator_migration() {
-# As we are adding the GPUs after installing the RHODS operator, those GPUs are not discovered automatically.
-# In order to rerun the migration we need to
-# 1. Delete the migration configmap
-# 2. Rollout restart dashboard deployment, so the configmap is created again and the migration run again
-# Context: https://github.com/opendatahub-io/odh-dashboard/issues/1938
+  # As we are adding the GPUs after installing the RHODS operator, those GPUs are not discovered automatically.
+  # In order to rerun the migration we need to
+  # 1. Delete the migration configmap
+  # 2. Rollout restart dashboard deployment, so the configmap is created again and the migration run again
+  # Context: https://github.com/opendatahub-io/odh-dashboard/issues/1938
 
   echo "Deleting configmap migration-gpu-status"
   if ! oc delete configmap migration-gpu-status -n redhat-ods-applications;
     then
-      printf "ERROR: When trying to delete the migration-gpu-status configmap\n"
+      echo "ERROR: When trying to delete the migration-gpu-status configmap"
       return 1
   fi
 
   echo "Rollout restart rhods-dashboard deployment"
   if ! oc rollout restart deployment.apps/rhods-dashboard -n redhat-ods-applications;
     then
-      printf "ERROR: When trying to rollout restart rhods-dashboard deployment\n"
+      echo "ERROR: When trying to rollout restart rhods-dashboard deployment"
       return 1
   fi
 
@@ -75,7 +48,6 @@ function rerun_accelerator_migration() {
 
   echo "Verifying that an AcceleratorProfiles resource was created in redhat-ods-applications"
   oc describe AcceleratorProfiles -n redhat-ods-applications
-
 }
 
 wait_until_pod_ready_status  "gpu-operator"


### PR DESCRIPTION
Add to gpu_deploy.sh script two verification steps after restarting rhods-dashboard deployment.

1. First wait for all relevant pods to be running.
2. Then delete configmap.
3. Then rollout restart rhods-dashboard deployment.
4. Then wait for rollout status and replicas to be successful.
5. At last verify that an AcceleratorProfiles resource is created.

Notice that the wait for pods running happens before the deployment is restarted.
That is why an additional wait for rollout is necessary to be called after restarting the deployment.
