### PR TITLE
[Fix] the image content source repo link has changed recently

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Disconnect/icsp.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Disconnect/icsp.yaml
@@ -33,6 +33,10 @@ spec:
     - registry.rh-ods.com:8443/openshift4
     source: registry.redhat.io/openshift4
   - mirrors:
+    - registry.rh-ods.com:8443/rhoai
+    source: registry.redhat.io/rhoai
+  # This one is a legacy one and we may want to remove it in the future
+  - mirrors:
     - registry.rh-ods.com:8443/rhods
     source: registry.redhat.io/rhods
   - mirrors:


### PR DESCRIPTION
This is because of the rebranding initiative.

I'm not really sure this file is still needed, but let's get updated it for now.