### PR TITLE
Fix model serving tests in 2.6

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -280,7 +280,7 @@ Workbench Launch Link Should Be Disabled
 Get All Displayed Projects
     [Documentation]    Gets all the DS projects visible in the DS Projects home page
     ${projects_names}=    Create List
-    ${elements}=    Get WebElements    xpath=//td[@data-label="Name"]/div/div/a
+    ${elements}=    Get WebElements    xpath=//td[@data-label="Name"]//a
     FOR    ${element}    IN    @{elements}
         ${name}=    Get Text    ${element}
         Append To List    ${projects_names}    ${name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -198,8 +198,9 @@ Get Model Route via UI
     ${route_xpath}=    Set Variable    xpath://div[.="${model_name} "]${MS_TABLE_ENDPOINT_INPUT}
     ${loaded}=    Run Keyword And Return Status    SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s
     IF    ${loaded} == ${FALSE}
+        Log    message=Model Route was not loaded in UI. Trying refreshing!    level=WARN
         SeleniumLibrary.Reload Page
-        SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s        
+        SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s
     END
     ${url}=    SeleniumLibrary.Get Element Attribute    ${route_xpath}    value
     RETURN    ${url}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -198,7 +198,7 @@ Get Model Route via UI
     ${route_xpath}=    Set Variable    xpath://div[.="${model_name} "]${MS_TABLE_ENDPOINT_INPUT}
     ${loaded}=    Run Keyword And Return Status    SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s
     IF    ${loaded} == ${FALSE}
-        Log    message=Model Route was not loaded in UI. Trying refreshing!    level=WARN
+        Log    message=Model Route was not loaded in UI (RHOAIENG-1919). Trying refreshing!    level=WARN
         SeleniumLibrary.Reload Page
         SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -194,8 +194,14 @@ Get Model Route via UI
     [Documentation]    Grabs the serving route (URL) of an already deployed model from the Model Serving page.
     [Arguments]    ${model_name}
     # TODO: Open model serving home page if needed?
-    Page Should Contain Element    xpath://div[.="${model_name} "]
-    ${url}=    Get Element Attribute    xpath://div[.="${model_name} "]${MS_TABLE_ENDPOINT_INPUT}    value
+    SeleniumLibrary.Page Should Contain Element    xpath://div[.="${model_name} "]
+    ${route_xpath}=    Set Variable    xpath://div[.="${model_name} "]${MS_TABLE_ENDPOINT_INPUT}
+    ${loaded}=    Run Keyword And Return Status    SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s
+    IF    ${loaded} == ${FALSE}
+        SeleniumLibrary.Reload Page
+        SeleniumLibrary.Wait Until Page Contains Element    ${route_xpath}    timeout=15s        
+    END
+    ${url}=    SeleniumLibrary.Get Element Attribute    ${route_xpath}    value
     RETURN    ${url}
 
 Open ${section} Options Menu

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm.robot
@@ -493,7 +493,8 @@ Verify User Can Access Model Metrics From UWM
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    TGI Caikit And Istio Metrics Should Exist    thanos_url=${thanos_url}    thanos_token=${token}
+    Wait Until Keyword Succeeds    30 times    4s
+    ...    TGI Caikit And Istio Metrics Should Exist    thanos_url=${thanos_url}    thanos_token=${token}
     Query Model Multiple Times    model_name=${flan_model_name}
     ...    endpoint=${CAIKIT_ALLTOKENS_ENDPOINT}    n_times=3
     ...    namespace=${test_namespace}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm_UI.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm_UI.robot
@@ -243,7 +243,8 @@ Verify User Can Access Model Metrics From UWM Using The UI  # robocop: disable
     Deploy Kserve Model Via UI    ${flan_model_name}    Caikit    kserve-connection    flan-t5-small/${flan_model_name}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    TGI Caikit And Istio Metrics Should Exist    thanos_url=${thanos_url}    thanos_token=${token}
+    Wait Until Keyword Succeeds    30 times    4s
+    ...    TGI Caikit And Istio Metrics Should Exist    thanos_url=${thanos_url}    thanos_token=${token}
     Query Model Multiple Times    model_name=${flan_model_name}
     ...    endpoint=${CAIKIT_ALLTOKENS_ENDPOINT_HTTP}    n_times=3
     ...    namespace=${test_namespace}   protocol=http


### PR DESCRIPTION
Some issues with model serving UI testing faced after the new changes in 2.6.

Likely, we just need to fix the teardown in `ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/422__model_serving_llm_UI.robot`

Other tentative fixes for timing issues:
- MM test often fails because the UI doesn't load the model route in time, it's been there from many releases but in 2.6 we've seen a slightly different behavior (a warning msg instead of obscured input element).
- metrics check in KServe test tends to take some time to fully load, hence adding a `Wait until keyword succeedes` (both UI and CLI test)