### PR TITLE
Check for pre-created virtual environment to save time on repeated poetry installs

### DIFF
--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -314,7 +314,13 @@ if command -v yq &> /dev/null
 fi
 
 if [[ ${SKIP_INSTALL} -eq 0 ]]; then
-  poetry install
+  # use a pre-created virtual environment if it exists
+  virtenv="${HOME}/.local/ods-ci/.venv"
+  if [[ -d "${virtenv}" ]]; then
+    poetry config --local virtualenvs.in-project true
+    ln --symbolic "${virtenv}" ./.venv
+  fi
+  poetry --no-interaction install --sync --no-root
 fi
 # shellcheck disable=SC1091
 source "$(poetry env info --path)/bin/activate"

--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -320,7 +320,7 @@ if [[ ${SKIP_INSTALL} -eq 0 ]]; then
     poetry config --local virtualenvs.in-project true
     ln --symbolic "${virtenv}" ./.venv
   fi
-  poetry --no-interaction install --sync --no-root
+  poetry --no-interaction install --sync
 fi
 # shellcheck disable=SC1091
 source "$(poetry env info --path)/bin/activate"


### PR DESCRIPTION
CI: rhods-ci-pr-test/2338

## Before
```
12:26:52  Installing dependencies from lock file
12:26:55  
12:26:55  Package operations: 235 installs, 1 update, 0 removals
12:26:55  
12:26:55    • Installing attrs (23.1.0)
```
...
```
12:27:53    • Installing python-openstackclient (6.3.0)
12:27:54  Connection pool is full, discarding connection: pypi.org. Connection pool size: 10
12:27:54  Installing /home/jenkins/workspace/rhods/rhods-ci-pr-test/ods-ci/.venv/lib/python3.9/site-packages/RPA_PDF.libspec over existing file
12:27:55  Installing /home/jenkins/workspace/rhods/rhods-ci-pr-test/ods-ci/.venv/lib/python3.9/site-packages/robot/__main__.py over existing file
12:28:01  
12:28:01  Installing the current project: ods-ci (0.1.0)
12:28:05  ==============================================================================
12:28:05  Tests   
```

## After

```
13:12:50  skipping OC login as per parameter --skip-oclogin
13:12:53  Installing dependencies from lock file
13:12:55  
13:12:55  No dependencies to install or update
13:12:59  [ ERROR ] Suite 'Tests' contains no tests matching tag 'ODS-nosuchtest' and not matching tags 'TBC', 'AutomationBug' or 'ProductBug'.
```

## Conclusion

Great success