### PR TITLE
Fix for RHOAM check of the tile on the Explore page

### DIFF
--- a/ods_ci/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -39,7 +39,6 @@ Verify RHOAM Availability Based On RHODS Installation Type
         Verify Service Is Not Available In The Explore Page    OpenShift API Management
     ELSE
         Verify Service Is Available In The Explore Page    OpenShift API Management
-        ...    split_last=${TRUE}
         Verify Service Provides "Get Started" Button In The Explore Page    OpenShift API Management
         ...    app_id=rhoam
     END


### PR DESCRIPTION
The product name isn't split anymore.

CI: rhods/job/rhods-ci-pr-test/2361 :white_check_mark: 