### PR TITLE
Fix pipeline url

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
@@ -13,7 +13,7 @@ Suite Teardown      RHOSi Teardown
 
 
 *** Variables ***
-${URL_TEST_PIPELINE_RUN_YAML}=                 https://raw.githubusercontent.com/opendatahub-io/data-science-pipelines-operator/main/tests/resources/dsp-operator/test-pipeline-run.yaml
+${URL_TEST_PIPELINE_RUN_YAML}=                 https://raw.githubusercontent.com/opendatahub-io/data-science-pipelines-operator/main/tests/resources/test-pipeline-run.yaml
 
 
 *** Test Cases ***


### PR DESCRIPTION
For the context - this got moved by this PR opendatahub-io/data-science-pipelines-operator#384 (https://github.com/opendatahub-io/data-science-pipelines-operator/commit/73b95d89536c79c4d34606cf8ea1499bd986a4b6).

```
Tests.Ods Dashboard.Data Science Pipelines.Data-Science-Pipelines-... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Data Science Pipelines                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================
```