### PR TITLE
Fix broken sanity tests + Add skip wait option in test teardown in model serving 

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -568,7 +568,7 @@ Generate Client TLS Certificates
 Clean Up Test Project
     [Documentation]    Deletes the given InferenceServices, check the NS gets removed from ServiceMeshMemberRoll
     ...                and deletes the DS Project
-    [Arguments]    ${test_ns}    ${isvc_names}    ${isvc_delete}=${TRUE}
+    [Arguments]    ${test_ns}    ${isvc_names}    ${isvc_delete}=${TRUE}    ${wait_prj_deletion}=${TRUE}
     IF    ${isvc_delete} == ${TRUE}
         FOR    ${index}    ${isvc_name}    IN ENUMERATE    @{isvc_names}
               Log    Deleting ${isvc_name}
@@ -581,5 +581,9 @@ Clean Up Test Project
     ...    namespace=${test_ns}
     ${rc}    ${out}=    Run And Return Rc And Output    oc delete project ${test_ns}
     Should Be Equal As Integers    ${rc}    ${0}
-    ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=300s
-    Should Be Equal As Integers    ${rc}    ${0}
+    IF    ${wait_prj_deletion}
+        ${rc}    ${out}=    Run And Return Rc And Output    oc wait --for=delete namespace ${test_ns} --timeout=300s
+        Should Be Equal As Integers    ${rc}    ${0}
+    ELSE
+        Log    Project deletion started, but won't wait for it to finish..
+    END

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -304,6 +304,7 @@ Compile Deploy And Query LLM model
     Query Model Multiple Times    isvc_name=${isvc_name}    model_name=${model_name}
     ...    n_times=${n_queries}    namespace=${namespace}    query_idx=${query_idx}
     ...    validate_response=${validate_response}    protocol=${protocol}
+    ...    runtime=${runtime}    inference_type=${inference_type}
 
 Upgrade Caikit Runtime Image
     [Documentation]    Replaces the image URL of the Caikit Runtim with the given

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -15,9 +15,7 @@ ${DEFAULT_BUCKET_SECRET_NAME}=    models-bucket-secret
 ${DEFAULT_BUCKET_SA_NAME}=        models-bucket-sa
 ${BUCKET_SECRET_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/bucket_secret.yaml
 ${BUCKET_SA_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/bucket_sa.yaml
-${USE_BUCKET_HTTPS}=    "1"
-${UWM_ENABLE_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/uwm_cm_enable.yaml
-${UWM_CONFIG_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/uwm_cm_conf.yaml  
+${USE_BUCKET_HTTPS}=    "1" 
 ${MODELS_BUCKET}=    ${S3.BUCKET_3}
 ${SERVICEMESH_CR_NS}=    istio-system
 &{RUNTIME_FLIEPATHS}=    caikit-tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/caikit_tgis_servingruntime_{{protocol}}.yaml
@@ -63,7 +61,7 @@ Set Project And Runtime
     Deploy Serving Runtime    namespace=${namespace}    runtime=${runtime}    protocol=${protocol}
     IF   ${enable_metrics} == ${TRUE}
         Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
-        Oc Apply    kind=ConfigMap    src=${UWM_ENABLE_FILEPATH}
+        Oc Apply    kind=ConfigMap    src=${MONITORING_CONFIG_FILEPATH}
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.
     END

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -15,7 +15,7 @@ ${DEFAULT_BUCKET_SECRET_NAME}=    models-bucket-secret
 ${DEFAULT_BUCKET_SA_NAME}=        models-bucket-sa
 ${BUCKET_SECRET_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/bucket_secret.yaml
 ${BUCKET_SA_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/bucket_sa.yaml
-${USE_BUCKET_HTTPS}=    "1" 
+${USE_BUCKET_HTTPS}=    "1"
 ${MODELS_BUCKET}=    ${S3.BUCKET_3}
 ${SERVICEMESH_CR_NS}=    istio-system
 &{RUNTIME_FLIEPATHS}=    caikit-tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/caikit_tgis_servingruntime_{{protocol}}.yaml

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -60,8 +60,8 @@ Set Project And Runtime
     ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
     Deploy Serving Runtime    namespace=${namespace}    runtime=${runtime}    protocol=${protocol}
     IF   ${enable_metrics} == ${TRUE}
-        Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
         Oc Apply    kind=ConfigMap    src=${MONITORING_CONFIG_FILEPATH}
+        Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.
     END

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -292,6 +292,7 @@ Compile Deploy And Query LLM model
     [Documentation]    Group together the test steps for preparing, deploying
     ...                and querying a model
     [Arguments]    ${model_storage_uri}    ${model_name}    ${isvc_name}=${model_name}
+    ...            ${runtime}=caikit-tgis-runtime    ${protocol}=grpc    ${inference_type}=all-tokens
     ...            ${canaryTrafficPercent}=${EMPTY}   ${namespace}=${TEST_NS}  ${sa_name}=${DEFAULT_BUCKET_SA_NAME}
     ...            ${n_queries}=${1}    ${query_idx}=${0}    ${validate_response}=${TRUE}
     Compile Inference Service YAML    isvc_name=${isvc_name}
@@ -303,8 +304,8 @@ Compile Deploy And Query LLM model
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${isvc_name}
     ...    namespace=${namespace}
     Query Model Multiple Times    isvc_name=${isvc_name}    model_name=${model_name}
-    ...    endpoint=${CAIKIT_ALLTOKENS_ENDPOINT}    n_times=${n_queries}    streamed_response=${FALSE}
-    ...    namespace=${namespace}    query_idx=${query_idx}    validate_response=${validate_response}
+    ...    n_times=${n_queries}    namespace=${namespace}    query_idx=${query_idx}
+    ...    validate_response=${validate_response}    protocol=${protocol}
 
 Upgrade Caikit Runtime Image
     [Documentation]    Replaces the image URL of the Caikit Runtim with the given

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -60,8 +60,8 @@ Set Project And Runtime
     ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
     Deploy Serving Runtime    namespace=${namespace}    runtime=${runtime}    protocol=${protocol}
     IF   ${enable_metrics} == ${TRUE}
-        Oc Apply    kind=ConfigMap    src=${MONITORING_CONFIG_FILEPATH}
-        Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
+        Enable User Workload Monitoring
+        Configure User Workload Monitoring
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -11,7 +11,7 @@ ${SCRATCH_RUNTIME_BTN_XP}=    //button[text()="Start from scratch"]
 ${EDITOR_RUNTIME_BTN_XP}=    //div[contains(@class, "odh-dashboard__code-editor")]
 &{PLATFORM_NAMES_MAPPING}=    single=Single-model serving platform    multi=Multi-model serving platform
 ...    both=Single-model and multi-model serving platforms
-&{PLATFORM_LABELS_MAPPING}=    single=Single model    multi=Multi-model
+&{PLATFORM_LABELS_MAPPING}=    single=Single-model    multi=Multi-model
 
 
 *** Keywords ***

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -9,8 +9,8 @@ ${SUBMIT_RUNTIME_BTN_XP}=    //button[text()="Create"]
 ${UPLOAD_RUNTIME_BTN_XP}=    //button[text()="Upload files"]
 ${SCRATCH_RUNTIME_BTN_XP}=    //button[text()="Start from scratch"]
 ${EDITOR_RUNTIME_BTN_XP}=    //div[contains(@class, "odh-dashboard__code-editor")]
-&{PLATFORM_NAMES_MAPPING}=    single=Single model serving platform    multi=Multi-model serving platform
-...    both=Both single and multi-model serving platforms
+&{PLATFORM_NAMES_MAPPING}=    single=Single-model serving platform    multi=Multi-model serving platform
+...    both=Single-model and multi-model serving platforms
 &{PLATFORM_LABELS_MAPPING}=    single=Single model    multi=Multi-model
 
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -294,6 +294,7 @@ Verify Model Inference With Retries
             ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
             Exit For Loop If    ${status}
             ${retry} =    Evaluate    ${retry} + 1
+            Sleep    5s
         END        
     END
     

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -282,7 +282,7 @@ Verify Model Inference With Retries
     [Arguments]    ${model_name}    ${inference_input}    ${expected_inference_output}
     ...            ${token_auth}=${FALSE}    ${project_title}=${NONE}    ${retries}=${5}
     ${status}=    Run Keyword And Return Status    Verify Model Inference
-        ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
+    ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
     IF    not ${status}
         ${retry}=    Set Variable    ${0}
         WHILE    ${retry} < ${retries}
@@ -291,13 +291,15 @@ Verify Model Inference With Retries
                 ...    level=WARN
             END
             ${status}=    Run Keyword And Return Status    Verify Model Inference
-            ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
-            Exit For Loop If    ${status}
-            ${retry} =    Evaluate    ${retry} + 1
+            ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}
+            ...    ${project_title}
+            IF    ${status}
+                BREAK
+            END
+            ${retry}=    Evaluate    ${retry} + 1
             Sleep    5s
-        END        
+        END
     END
-    
 
 Clean Up Model Serving Page
     [Documentation]    Deletes all currently deployed models, if any are present.

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -246,7 +246,7 @@ Get Model Inference
     ...    ${project_title}=${NONE}
     ${self_managed} =    Is RHODS Self-Managed
     ${url}=    Get Model Route via UI    ${model_name}
-    ${curl_cmd}=     Set Variable    curl -s ${url} -d @${inference_input}
+    ${curl_cmd}=     Set Variable    curl -s ${url} -d ${inference_input}
     IF    ${token_auth}
         IF    "${project_title}" == "${NONE}"
             ${project_title}=    Get Model Project    ${model_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -26,8 +26,6 @@ ${MS_TABLE_STATUS_FAILURE}=     //span[contains(@class,"pf-v5-c-icon__content")]
 ${KSERVE_MODAL_HEADER}=    //header[@class="pf-v5-c-modal-box__header"]/h1[.="Deploy model"]
 ${KSERVE_RUNTIME_DROPDOWN}=    //span[.="Serving runtime"]/../../..//div[@id="serving-runtime-template-selection"]
 ${LLM_RESOURCES_DIRPATH}=    ods_ci/tests/Resources/Files/llm
-${UWM_ENABLE_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/uwm_cm_enable.yaml
-${UWM_CONFIG_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/uwm_cm_conf.yaml
 
 
 *** Keywords ***
@@ -491,7 +489,7 @@ Set Up Project
     ...            aws_bucket_name=${S3.BUCKET_3.NAME}    aws_s3_endpoint=${S3.BUCKET_3.ENDPOINT}
     ...            aws_region=${S3.BUCKET_3.REGION}
     IF   ${enable_metrics}
-        Oc Apply    kind=ConfigMap    src=${UWM_ENABLE_FILEPATH}
+        Oc Apply    kind=ConfigMap    src=${MONITORING_CONFIG_FILEPATH}
         Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -274,6 +274,24 @@ Verify Model Inference
         Fail    msg=comparison between expected and actual failed, ${list}
     END
 
+Verify Model Inference With Retries
+    [Documentation]    We see the inference failing often in the tests. One possible cause might be
+    ...                timing: model not ready to reply yet, despite the pod is up and running and the
+    ...                endpoint exposed.
+    ...                This is a temporary mitigation meanwhile we find a better way to check the model
+    [Arguments]    ${model_name}    ${inference_input}    ${expected_inference_output}
+    ...            ${token_auth}=${FALSE}    ${project_title}=${NONE}    ${retries}=${5}
+    ${retry}=    Set Variable    ${5}
+    WHILE    ${retry} < ${retries}
+        IF    ${retry} > 0
+            Log    message=Modelmesh inference call failed ${retry}/${retries}.
+            ...    level=WARN
+        END
+        ${status}=    Run Keyword And Return Status    Verify Model Inference
+        ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
+        Exit For Loop If    ${status}
+    END
+
 Clean Up Model Serving Page
     [Documentation]    Deletes all currently deployed models, if any are present.
     # Returns an empty list if no matching elements found

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -56,8 +56,8 @@ Serve Model
     [Arguments]    ${project_name}    ${model_name}    ${framework}    ${data_connection_name}    ${model_path}
     ...    ${existing_data_connection}=${TRUE}    ${model_server}=Model Serving Test
     # TODO: Does not work if there's already a model deployed
-    SeleniumLibrary.Wait Until Page Does Not Contain Element    //article[@id="multi-serving-platform-card"]
-    SeleniumLibrary.Wait Until Page Does Not Contain Element    //article[@id="single-serving-platform-card"]
+    SeleniumLibrary.Wait Until Page Does Not Contain Element    //div[@id="multi-serving-platform-card"]
+    SeleniumLibrary.Wait Until Page Does Not Contain Element    //div[@id="single-serving-platform-card"]
     SeleniumLibrary.Wait Until Page Contains    Deploy model
     SeleniumLibrary.Click Button    Deploy model
     SeleniumLibrary.Wait Until Page Contains Element    xpath://h1[.="Deploy model"]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -281,16 +281,22 @@ Verify Model Inference With Retries
     ...                This is a temporary mitigation meanwhile we find a better way to check the model
     [Arguments]    ${model_name}    ${inference_input}    ${expected_inference_output}
     ...            ${token_auth}=${FALSE}    ${project_title}=${NONE}    ${retries}=${5}
-    ${retry}=    Set Variable    ${5}
-    WHILE    ${retry} < ${retries}
-        IF    ${retry} > 0
-            Log    message=Modelmesh inference call failed ${retry}/${retries}.
-            ...    level=WARN
-        END
-        ${status}=    Run Keyword And Return Status    Verify Model Inference
+    ${status}=    Run Keyword And Return Status    Verify Model Inference
         ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
-        Exit For Loop If    ${status}
+    IF    not ${status}
+        ${retry}=    Set Variable    ${0}
+        WHILE    ${retry} < ${retries}
+            IF    ${retry} > 0
+                Log    message=Modelmesh inference call failed ${retry}/${retries}.
+                ...    level=WARN
+            END
+            ${status}=    Run Keyword And Return Status    Verify Model Inference
+            ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}
+            Exit For Loop If    ${status}
+            ${retry} =    Evaluate    ${retry} + 1
+        END        
     END
+    
 
 Clean Up Model Serving Page
     [Documentation]    Deletes all currently deployed models, if any are present.

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -489,8 +489,8 @@ Set Up Project
     ...            aws_bucket_name=${S3.BUCKET_3.NAME}    aws_s3_endpoint=${S3.BUCKET_3.ENDPOINT}
     ...            aws_region=${S3.BUCKET_3.REGION}
     IF   ${enable_metrics}
-        Oc Apply    kind=ConfigMap    src=${MONITORING_CONFIG_FILEPATH}
-        Oc Apply    kind=ConfigMap    src=${UWM_CONFIG_FILEPATH}
+        Enable User Workload Monitoring
+        Configure User Workload Monitoring
     ELSE
         Log    message=Skipping UserWorkloadMonitoring enablement.
     END

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -12,8 +12,8 @@ Suite Teardown    Model Serving Suite Teardown
 Test Tags         ModelMesh
 
 *** Variables ***
-${INFERENCE_INPUT}=    ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
-${INFERENCE_INPUT_OPENVINO}=    ods_ci/tests/Resources/Files/openvino-example-input.json
+${INFERENCE_INPUT}=    @ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
+${INFERENCE_INPUT_OPENVINO}=    @ods_ci/tests/Resources/Files/openvino-example-input.json
 ${EXPECTED_INFERENCE_OUTPUT}=    {"model_name":"test-model__isvc-83d6fab7bd","model_version":"1","outputs":[{"name":"Plus214_Output_0","datatype":"FP32","shape":[1,10],"data":[-8.233053,-7.7497034,-3.4236815,12.3630295,-12.079103,17.266596,-10.570976,0.7130762,3.321715,1.3621228]}]}
 ${EXPECTED_INFERENCE_OUTPUT_OPENVINO}=    {"model_name":"test-model__isvc-8655dc7979","model_version":"1","outputs":[{"name":"Func/StatefulPartitionedCall/output/_13:0","datatype":"FP32","shape":[1,1],"data":[0.99999994]}]}
 ${PRJ_TITLE}=    model-serving-project

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -63,7 +63,7 @@ Test Inference With Token Authentication
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
     [Tags]    Sanity    Tier1
     ...    ODS-1920
-    # Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}    # robocop: ignore
+    # Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}    # robocop: disable
     Run Keyword And Continue On Failure    Verify Model Inference With Retries
     ...    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
     # Testing the same endpoint without token auth, should receive login page

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -12,8 +12,8 @@ Suite Teardown    Model Serving Suite Teardown
 Test Tags         ModelMesh
 
 *** Variables ***
-${INFERENCE_INPUT}=    @ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
-${INFERENCE_INPUT_OPENVINO}=    @ods_ci/tests/Resources/Files/openvino-example-input.json
+${INFERENCE_INPUT}=    ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
+${INFERENCE_INPUT_OPENVINO}=    ods_ci/tests/Resources/Files/openvino-example-input.json
 ${EXPECTED_INFERENCE_OUTPUT}=    {"model_name":"test-model__isvc-83d6fab7bd","model_version":"1","outputs":[{"name":"Plus214_Output_0","datatype":"FP32","shape":[1,10],"data":[-8.233053,-7.7497034,-3.4236815,12.3630295,-12.079103,17.266596,-10.570976,0.7130762,3.321715,1.3621228]}]}
 ${EXPECTED_INFERENCE_OUTPUT_OPENVINO}=    {"model_name":"test-model__isvc-8655dc7979","model_version":"1","outputs":[{"name":"Func/StatefulPartitionedCall/output/_13:0","datatype":"FP32","shape":[1,1],"data":[0.99999994]}]}
 ${PRJ_TITLE}=    model-serving-project
@@ -177,9 +177,9 @@ Model Serving Suite Teardown
     # Even if kw fails, deleting the whole project will also delete the model
     # Failure will be shown in the logs of the run nonetheless
     IF    ${MODEL_CREATED}
-        Run Keyword And Continue On Failure    Delete Model Via UI    test-model
+    Run Keyword And Continue On Failure    Delete Model Via UI    test-model
     ELSE
-        Log    Model not deployed, skipping deletion step during teardown    console=true
+    Log    Model not deployed, skipping deletion step during teardown    console=true
     END
     ${projects}=    Create List    ${PRJ_TITLE}
     Delete Data Science Projects From CLI   ocp_projects=${projects}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -63,8 +63,9 @@ Test Inference With Token Authentication
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
     [Tags]    Sanity    Tier1
     ...    ODS-1920
-    # Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
-    Run Keyword And Continue On Failure    Verify Model Inference With Retries    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
+    # Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}    # robocop: ignore
+    Run Keyword And Continue On Failure    Verify Model Inference With Retries
+    ...    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
     # Testing the same endpoint without token auth, should receive login page
     Open Model Serving Home Page
     ${out}=    Get Model Inference   ${MODEL_NAME}    ${INFERENCE_INPUT}    token_auth=${FALSE}
@@ -178,9 +179,9 @@ Model Serving Suite Teardown
     # Even if kw fails, deleting the whole project will also delete the model
     # Failure will be shown in the logs of the run nonetheless
     IF    ${MODEL_CREATED}
-    Run Keyword And Continue On Failure    Delete Model Via UI    test-model
+        Run Keyword And Continue On Failure    Delete Model Via UI    test-model
     ELSE
-    Log    Model not deployed, skipping deletion step during teardown    console=true
+        Log    Model not deployed, skipping deletion step during teardown    console=true
     END
     ${projects}=    Create List    ${PRJ_TITLE}
     Delete Data Science Projects From CLI   ocp_projects=${projects}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -63,7 +63,8 @@ Test Inference With Token Authentication
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
     [Tags]    Sanity    Tier1
     ...    ODS-1920
-    Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
+    # Run Keyword And Continue On Failure    Verify Model Inference    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
+    Run Keyword And Continue On Failure    Verify Model Inference With Retries    ${MODEL_NAME}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_OUTPUT}    token_auth=${TRUE}
     # Testing the same endpoint without token auth, should receive login page
     Open Model Serving Home Page
     ${out}=    Get Model Inference   ${MODEL_NAME}    ${INFERENCE_INPUT}    token_auth=${FALSE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -80,13 +80,15 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=ods-ci-s3
     Create Model Server    server_name=${MODEL_SERVER_NAME}    runtime=${UPLOADED_OVMS_DISPLAYED_NAME}
-    Serve Model    project_name=${PRJ_TITLE}    model_name=${model_name}    framework=onnx    existing_data_connection=${TRUE}
+    Serve Model    project_name=${PRJ_TITLE}    model_name=${model_name}    framework=onnx
+    ...    existing_data_connection=${TRUE}
     ...    data_connection_name=model-serving-connection    model_path=mnist-8.onnx
     Wait Until Runtime Pod Is Running    server_name=${MODEL_SERVER_NAME}
     ...    project_title=${PRJ_TITLE}    timeout=40s
     Verify Model Status    ${model_name}    success
-    Verify Model Inference With Retries    ${model_name}    ${inference_input}    ${exp_inference_output}    token_auth=${TRUE}
-    ...    project_title=${PRJ_TITLE} 
+    Verify Model Inference With Retries    ${model_name}    ${inference_input}    ${exp_inference_output}
+    ...    token_auth=${TRUE}
+    ...    project_title=${PRJ_TITLE}
     
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -94,7 +94,6 @@ Custom Serving Runtime Suite Setup
     [Documentation]    Suite setup steps for testing DSG. It creates some test variables
     ...                and runs RHOSi setup
     Set Library Search Order    SeleniumLibrary
-    Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     RHOSi Setup
     Fetch CA Certificate If RHODS Is Self-Managed
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -73,7 +73,7 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     ...    Create Data Science Project If Not Exists    project_title=${PRJ_TITLE}    username=${TEST_USER_3.USERNAME}
     ...    description=${PRJ_DESCRIPTION}
     ${model_name}=    Set Variable    test-model-csr
-    ${inference_input}=    Set Variable    ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
+    ${inference_input}=    Set Variable    @ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
     ${exp_inference_output}=    Set Variable    {"model_name":"test-model-csr__isvc-85fe09502b","model_version":"1","outputs":[{"name":"Plus214_Output_0","datatype":"FP32","shape":[1,10],"data":[-8.233053,-7.7497034,-3.4236815,12.3630295,-12.079103,17.266596,-10.570976,0.7130762,3.321715,1.3621228]}]}
     Open Data Science Project Details Page    project_title=${PRJ_TITLE}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=model-serving-connection

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -73,7 +73,7 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     ...    Create Data Science Project If Not Exists    project_title=${PRJ_TITLE}    username=${TEST_USER_3.USERNAME}
     ...    description=${PRJ_DESCRIPTION}
     ${model_name}=    Set Variable    test-model-csr
-    ${inference_input}=    Set Variable    @ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
+    ${inference_input}=    Set Variable    ods_ci/tests/Resources/Files/modelmesh-mnist-input.json
     ${exp_inference_output}=    Set Variable    {"model_name":"test-model-csr__isvc-85fe09502b","model_version":"1","outputs":[{"name":"Plus214_Output_0","datatype":"FP32","shape":[1,10],"data":[-8.233053,-7.7497034,-3.4236815,12.3630295,-12.079103,17.266596,-10.570976,0.7130762,3.321715,1.3621228]}]}
     Open Data Science Project Details Page    project_title=${PRJ_TITLE}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=model-serving-connection
@@ -83,10 +83,10 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     Serve Model    project_name=${PRJ_TITLE}    model_name=${model_name}    framework=onnx    existing_data_connection=${TRUE}
     ...    data_connection_name=model-serving-connection    model_path=mnist-8.onnx
     Wait Until Runtime Pod Is Running    server_name=${MODEL_SERVER_NAME}
-    ...    project_title=${PRJ_TITLE}    timeout=15s
+    ...    project_title=${PRJ_TITLE}    timeout=40s
     Verify Model Status    ${model_name}    success
-    Verify Model Inference    ${model_name}    ${inference_input}    ${exp_inference_output}    token_auth=${TRUE}
-    ...    project_title=${PRJ_TITLE}
+    Verify Model Inference With Retries    ${model_name}    ${inference_input}    ${exp_inference_output}    token_auth=${TRUE}
+    ...    project_title=${PRJ_TITLE} 
     
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/424_model_serving_bias_metrics.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/424_model_serving_bias_metrics.robot
@@ -148,7 +148,7 @@ Send Batch Inference Data to Model
     [Documentation]    Send Batch Inference data to the already deployed model using Curl commands
     [Arguments]        ${model_name}   ${project_name}    ${lower_range}=1     ${upper_range}=5
     FOR    ${counter}    IN RANGE    ${lower_range}    ${upper_range}
-        ${inference_input}=  Set Variable   ods_ci/tests/Resources/Files/TrustyAI/loan_default_batched/batch_${counter}.json
+        ${inference_input}=  Set Variable   @ods_ci/tests/Resources/Files/TrustyAI/loan_default_batched/batch_${counter}.json
         ${inference_output} =    Get Model Inference    ${model_name}    ${inference_input}    token_auth=${FALSE}
         ...    project_title=${project_name}
         Should Contain    ${inference_output}    model_name

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
@@ -56,8 +56,8 @@ Verify User Can Serve And Query A Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and Caikit+TGIS runtime
     [Tags]    Sanity    Tier1    ODS-2341
-    [Setup]    Set Project And Runtime    namespace=${TEST_NS}
-    ${test_namespace}=    Set Variable     ${TEST_NS}
+    [Setup]    Set Project And Runtime    namespace=${TEST_NS}-cli
+    ${test_namespace}=    Set Variable     ${TEST_NS}-cli
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
@@ -74,7 +74,7 @@ Verify User Can Serve And Query A Model
     ...    inference_type=streaming    n_times=1
     ...    namespace=${test_namespace}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Deploy Multiple Models In The Same Namespace
     [Documentation]    Checks if user can deploy and query multiple models in the same namespace
@@ -107,7 +107,7 @@ Verify User Can Deploy Multiple Models In The Same Namespace
     Query Model Multiple Times    model_name=${model_two_name}
     ...    n_times=10    namespace=${test_namespace}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Deploy Multiple Models In Different Namespaces
     [Documentation]    Checks if user can deploy and query multiple models in the different namespaces
@@ -138,8 +138,10 @@ Verify User Can Deploy Multiple Models In Different Namespaces
     Query Model Multiple Times    model_name=${model_two_name}    n_times=2
     ...    namespace=singlemodel-multi2
     [Teardown]    Run Keywords    Clean Up Test Project    test_ns=singlemodel-multi1    isvc_names=${models_names_ns_1}
+    ...           wait_prj_deletion=${FALSE}
     ...           AND
     ...           Clean Up Test Project    test_ns=singlemodel-multi2    isvc_names=${models_names_ns_2}
+    ...           wait_prj_deletion=${FALSE}
 
 Verify Model Upgrade Using Canaray Rollout
     [Documentation]    Checks if user can apply Canary Rollout as deployment strategy
@@ -177,7 +179,7 @@ Verify Model Upgrade Using Canaray Rollout
     Traffic Should Be Redirected Based On Canary Percentage    exp_percentage=${100}
     ...    isvc_name=${isvc_name}    model_name=${model_name}    namespace=${test_namespace}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${isvcs_names}
+    ...    isvc_names=${isvcs_names}    wait_prj_deletion=${FALSE}
 
 Verify Model Pods Are Deleted When No Inference Service Is Present
     [Documentation]    Checks if model pods gets successfully deleted after
@@ -197,6 +199,7 @@ Verify Model Pods Are Deleted When No Inference Service Is Present
     Should Be Equal As Integers    ${rc}    ${0}
     [Teardown]   Clean Up Test Project    test_ns=no-infer-kserve
     ...    isvc_names=${models_names}   isvc_delete=${FALSE}
+    ...    wait_prj_deletion=${FALSE}
 
 Verify User Can Change The Minimum Number Of Replicas For A Model
     [Documentation]    Checks if user can change the minimum number of replicas
@@ -233,7 +236,7 @@ Verify User Can Change The Minimum Number Of Replicas For A Model
     Query Model Multiple Times    model_name=${model_name}    n_times=3
     ...    namespace=${test_namespace}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Autoscale Using Concurrency
     [Documentation]    Checks if model successfully scale up based on concurrency metrics (KPA)
@@ -258,7 +261,7 @@ Verify User Can Autoscale Using Concurrency
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Validate Scale To Zero
     [Documentation]    Checks if model successfully scale down to 0 if there's no traffic
@@ -295,7 +298,7 @@ Verify User Can Validate Scale To Zero
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=autoscale-zero
     [Teardown]   Clean Up Test Project    test_ns=autoscale-zero
-    ...    isvc_names=${model_name}
+    ...    isvc_names=${model_name}    wait_prj_deletion=${FALSE}
 
 Verify User Can Set Requests And Limits For A Model
     [Documentation]    Checks if user can set HW request and limits on their inference service object
@@ -332,7 +335,7 @@ Verify User Can Set Requests And Limits For A Model
     ...    pod_label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}    exp_requests=${new_requests}    exp_limits=${NONE}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify Model Can Be Served And Query On A GPU Node
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model on GPU node
@@ -362,7 +365,7 @@ Verify Model Can Be Served And Query On A GPU Node
     Query Model Multiple Times    model_name=${model_name}    n_times=5
     ...    namespace=${test_namespace}    inference_type=streaming
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${model_name}
+    ...    isvc_names=${model_name}    wait_prj_deletion=${FALSE}
 
 Verify Non Admin Can Serve And Query A Model
     [Documentation]    Basic tests leveraging on a non-admin user for preparing, deploying and querying a LLM model
@@ -391,6 +394,7 @@ Verify Non Admin Can Serve And Query A Model
     ...    namespace=${test_namespace}
     [Teardown]  Run Keywords   Login To OCP Using API    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}   AND
     ...        Clean Up Test Project    test_ns=${test_namespace}   isvc_names=${models_names}
+    ...        wait_prj_deletion=${FALSE}
 
 Verify User Can Serve And Query Flan-t5 Grammar Syntax Corrector
     [Documentation]    Deploys and queries flan-t5-large-grammar-synthesis model
@@ -413,7 +417,7 @@ Verify User Can Serve And Query Flan-t5 Grammar Syntax Corrector
     ...    inference_type=streaming    n_times=1
     ...    namespace=${test_namespace}    query_idx=${1}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Serve And Query Flan-t5 Large
     [Documentation]    Deploys and queries flan-t5-large model
@@ -436,7 +440,7 @@ Verify User Can Serve And Query Flan-t5 Large
     ...    inference_type=streaming    n_times=1
     ...    namespace=${test_namespace}    query_idx=${0}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify Runtime Upgrade Does Not Affect Deployed Models
     [Documentation]    Upgrades the caikit runtime inthe same NS where a model
@@ -445,8 +449,8 @@ Verify Runtime Upgrade Does Not Affect Deployed Models
     ...                ATTENTION: this is an approximation of the runtime upgrade scenario, however
     ...                the real case scenario will be defined once RHODS actually ships the Caikit runtime.
     [Tags]    Sanity    Tier1    ODS-2404
-    [Setup]    Set Project And Runtime    namespace=${TEST_NS}
-    ${test_namespace}=    Set Variable     ${TEST_NS}
+    [Setup]    Set Project And Runtime    namespace=${TEST_NS}-up
+    ${test_namespace}=    Set Variable     ${TEST_NS}-up
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
     ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
@@ -471,7 +475,7 @@ Verify Runtime Upgrade Does Not Affect Deployed Models
     Should Be Equal    ${created_at}    ${created_at_after}
     Should Be Equal As Strings    ${caikitsha}    ${caikitsha_after}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Access Model Metrics From UWM
     [Documentation]    Verifies that model metrics are available for users in the
@@ -514,7 +518,7 @@ Verify User Can Access Model Metrics From UWM
     ...    User Can Fetch Number Of Requests Over Defined Time    thanos_url=${thanos_url}    thanos_token=${token}
     ...    model_name=${flan_model_name}    query_kind=stream    namespace=${test_namespace}    period=5m    exp_value=1
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Query A Model Using HTTP Calls
     [Documentation]    From RHOAI 2.5 HTTP is allowed and default querying protocol.
@@ -540,7 +544,7 @@ Verify User Can Query A Model Using HTTP Calls
     ...    inference_type=streaming    n_times=1
     ...    namespace=${test_namespace}    query_idx=${0}    validate_response=${FALSE}
     [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
@@ -241,7 +241,7 @@ Verify User Can Autoscale Using Concurrency
     [Setup]    Set Project And Runtime    namespace=autoscale-con
     ${test_namespace}=    Set Variable    autoscale-con
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
-    ${model_name}=    Create List    ${flan_model_name}
+    ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${FLAN_STORAGE_URI}
@@ -258,7 +258,7 @@ Verify User Can Autoscale Using Concurrency
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
     [Teardown]   Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${model_name}
+    ...    isvc_names=${models_names}
 
 Verify User Can Validate Scale To Zero
     [Documentation]    Checks if model successfully scale down to 0 if there's no traffic

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
@@ -203,7 +203,8 @@ Verify Model Pods Are Deleted When No Inference Service Is Present
 
 Verify User Can Change The Minimum Number Of Replicas For A Model
     [Documentation]    Checks if user can change the minimum number of replicas
-    ...                of a deployed model
+    ...                of a deployed model.
+    ...                Affected by:  https://issues.redhat.com/browse/SRVKS-1175
     [Tags]    Sanity    Tier1    ODS-2376
     [Setup]    Set Project And Runtime    namespace=${TEST_NS}-reps
     ${test_namespace}=    Set Variable     ${TEST_NS}-reps

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm.robot
@@ -269,7 +269,7 @@ Verify User Can Validate Scale To Zero
     [Tags]    Sanity    Tier1    ODS-2379
     [Setup]    Set Project And Runtime    namespace=autoscale-zero
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit
-    ${model_name}=    Create List    ${flan_model_name}
+    ${models_names}=    Create List    ${flan_model_name}
     Compile Inference Service YAML    isvc_name=${flan_model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${FLAN_STORAGE_URI}
@@ -299,7 +299,7 @@ Verify User Can Validate Scale To Zero
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=autoscale-zero
     [Teardown]   Clean Up Test Project    test_ns=autoscale-zero
-    ...    isvc_names=${model_name}    wait_prj_deletion=${FALSE}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 Verify User Can Set Requests And Limits For A Model
     [Documentation]    Checks if user can set HW request and limits on their inference service object


### PR DESCRIPTION
Fixing: 

- Verify RHODS Admins Can Import A Custom Serving Runtime Template For Each Serving Platform
- Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
- Verify Model Upgrade Using Canaray Rollout
- Verify User Can Autoscale Using Concurrency

In addition, the PR is adding the option to skip waiting for project to be deleted in test teardown. The reason is that the project deletion takes very much time in model serving test (OCP takes from 3 to 6 minutes to delete it)
