### PR TITLE
Revert "[Fix] attempt to stabilize the `Logged Into OpenShift` test (…

### DIFF
--- a/ods_ci/tests/Resources/Page/LoginPage.robot
+++ b/ods_ci/tests/Resources/Page/LoginPage.robot
@@ -55,8 +55,6 @@ Login To Openshift
     Input Text  id=inputUsername  ${ocp_user_name}
     Input Text  id=inputPassword  ${ocp_user_pw}
     Click Element  xpath=/html/body/div/div/main/div/form/div[4]/button
-    # Wait until the page is loaded completely otherwise it doesn't make sense to skip the tour
-    Wait For Condition    return document.readyState == "complete"    timeout=60s
     Maybe Skip Tour
 
 Log In Should Be Requested


### PR DESCRIPTION
…#1065)"

This reverts commit 1cb3109542f44aa129b163dc26fdef79f4fcb84e.

Reason for revert is that it caused issue for Perf testing in the way that the JupyterLab IDE hasn't been loaded properly (splash screen was present on the screenshots from the test execution) and this check returned a failure after cca 15 seconds.

We will have to find a different approach to improve on this in case we'll see the problem in the IDE load in the future.

CI: rhods-ci-pr-test/2398 :white_check_mark: 