### PR TITLE
Decrease TTL for our DNS records for the cluster creation.

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
@@ -90,7 +90,7 @@ echo "Updating DNS records (cluster api's) in AWS Route53"
 RESPONSE=$(aws route53 change-resource-record-sets --hosted-zone-id "$ZONE_ID" --change-batch \
 '{ "Comment": "Update A record for cluster API", "Changes": 
 [ { "Action": "UPSERT", "ResourceRecordSet": { "Name": "api.'"$CLUSTER_NAME"'.'"$BASE_DOMAIN"'", 
-"Type": "A", "TTL":  172800, "ResourceRecords": [ { "Value": "'"$FIP_API"'" } ] } } ] }' --output json) || rc=$?
+"Type": "A", "TTL":  300, "ResourceRecords": [ { "Value": "'"$FIP_API"'" } ] } } ] }' --output json) || rc=$?
 if [[ -n "$rc" ]] ; then
   echo -e "Failed to update DNS A record in AWS for cluster API. 
   \n Releasing previously allocated floating IP in $OS_CLOUD ($FIP_API)"
@@ -105,7 +105,7 @@ echo "Updating DNS records (cluster ingress) in AWS Route53"
 RESPONSE=$(aws route53 change-resource-record-sets --hosted-zone-id "$ZONE_ID" --change-batch \
 '{ "Comment": "Update A record for cluster APPS", "Changes": 
 [ { "Action": "UPSERT", "ResourceRecordSet": { "Name": "*.apps.'"$CLUSTER_NAME"'.'"$BASE_DOMAIN"'", 
-"Type": "A", "TTL":  172800, "ResourceRecords": [ { "Value": "'"$FIP_APPS"'" } ] } } ] }' --output json) || rc=$?
+"Type": "A", "TTL":  300, "ResourceRecords": [ { "Value": "'"$FIP_APPS"'" } ] } } ] }' --output json) || rc=$?
 
 if [[ -n "$rc" ]] ; then
   echo -e "Failed to update DNS A record in AWS for cluster APPS. 


### PR DESCRIPTION
At the moment we have 2days TTL for the DNS records for the cluster IPs. Since this causes us troubles when we want to recreate the cluster with the very same name (the records is probably still in the DNS cache of the system where the new cluster is being created), let's reduce this TTL value to 5minutes only.

The overhead with the DNS shouldn't be hopefully that bad.

---

CI: autotrigger-smoke/6 :white_check_mark: - cluster creation failed due to different reason, although we can clearly see that the DNS records have expected TTL set now. 