### PR TITLE
Add log gather when pod doesn't get ready by timeout

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -106,7 +106,8 @@ Wait For Pods To Be Ready
     IF    ${pass} == ${FALSE}
         ${rc}    ${events}=    Run And Return Rc And Output    oc get events -n ${namespace}
         Log    ${events}
-        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers -n ${namespace}    # robocop: disable
+        ${rc}    ${podlogs}=    Run And Return Rc And Output
+        ...    oc logs -f -l ${label_selector} --all-containers -n ${namespace}
         Log    ${podlogs}
         Fail
     END

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -102,14 +102,13 @@ Wait For Pods To Be Ready
     ...    status_only=${FALSE}
     ${rc}    ${out}=    Run And Return Rc And Output
     ...    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
-    ${pass}=    Run Keyword And Return Status    Should Be Equal As Numbers    ${rc}    ${0}
-    IF    ${pass} == ${FALSE}
+    IF    ${rc} != ${0}
         ${rc}    ${events}=    Run And Return Rc And Output    oc get events -n ${namespace}
         Log    ${events}
         ${rc}    ${podlogs}=    Run And Return Rc And Output
         ...    oc logs -f -l ${label_selector} --all-containers -n ${namespace}
         Log    ${podlogs}
-        Fail
+        Fail    msg=Pod is not ready by timeout
     END
     IF    "${exp_replicas}" != "${NONE}"
         @{replicas}=    Oc Get    kind=Pod    namespace=${namespace}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -106,7 +106,7 @@ Wait For Pods To Be Ready
     IF    ${pass} == ${FALSE}
         ${rc}    ${events}=    Run And Return Rc And Output    oc get events -n ${namespace}
         Log    ${events}
-        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers -n ${namespace}
+        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers -n ${namespace}    # robocop: disable
         Log    ${podlogs}
         Fail
     END

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -97,7 +97,6 @@ Fetch CA Certificate If RHODS Is Self-Managed
 
 Wait For Pods To Be Ready
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}
-    ...            ${gather_logs}=${TRUE}
     Wait Until Keyword Succeeds    ${timeout}    3s
     ...    Check If Pod Exists    namespace=${namespace}    label_selector=${label_selector}
     ...    status_only=${FALSE}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -106,7 +106,7 @@ Wait For Pods To Be Ready
     IF    ${pass} == ${FALSE}
         ${rc}    ${events}=    Run And Return Rc And Output    oc get events -n ${namespace}
         Log    ${events}
-        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers
+        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers -n ${namespace}
         Log    ${podlogs}
         Fail
     END

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -97,12 +97,20 @@ Fetch CA Certificate If RHODS Is Self-Managed
 
 Wait For Pods To Be Ready
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}
+    ...            ${gather_logs}=${TRUE}
     Wait Until Keyword Succeeds    ${timeout}    3s
     ...    Check If Pod Exists    namespace=${namespace}    label_selector=${label_selector}
     ...    status_only=${FALSE}
     ${rc}    ${out}=    Run And Return Rc And Output
     ...    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
-    Should Be Equal As Numbers    ${rc}    ${0}
+    ${pass}=    Run Keyword And Return Status    Should Be Equal As Numbers    ${rc}    ${0}
+    IF    ${pass} == ${FALSE}
+        ${rc}    ${events}=    Run And Return Rc And Output    oc get events -n ${namespace}
+        Log    ${events}
+        ${rc}    ${podlogs}=    Run And Return Rc And Output    oc logs -f -l ${label_selector} --all-containers
+        Log    ${podlogs}
+        Fail
+    END
     IF    "${exp_replicas}" != "${NONE}"
         @{replicas}=    Oc Get    kind=Pod    namespace=${namespace}
         ...    label_selector=${label_selector}


### PR DESCRIPTION
When `Wait For Pods To Be Ready` hits the timeout, we can't tell why it happened. So, trying to get clear info by capturing pod logs and namespace events (on failure only)