### PR TITLE
Update runtime yamls

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -11,13 +11,19 @@ spec:
   containers:
     - name: kserve-container
       image: quay.io/modh/text-generation-inference@sha256:a17a2868644929ee844ceb2778ac3f6db0936824d9b89d11ea7aa059466fcd0b
+      ## Note: cannot add readiness/liveness probes to this container because knative will refuse them
       command: ["text-generation-launcher"]
-      args: ["--model-name=/mnt/models/artifacts/"] 
+      args: ["--model-name=/mnt/models/artifacts/"]
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi
     - name: transformer-container
       image: quay.io/modh/caikit-tgis-serving@sha256:ce6b66bb847608dac5eacd7f9123d2a076a06893d7f37f2da5876a8930527513
+      command: ["python", "-m", "caikit.runtime.grpc_server"]
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models
@@ -25,3 +31,21 @@ spec:
         - containerPort: 8085
           name: h2c
           protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+            - python
+            - -m
+            - caikit_health_probe
+            - readiness
+      livenessProbe:
+        exec:
+          command:
+            - python
+            - -m
+            - caikit_health_probe
+            - liveness
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -23,10 +23,15 @@ spec:
       #     memory: 16Gi
     - name: transformer-container
       image: quay.io/modh/caikit-tgis-serving@sha256:ce6b66bb847608dac5eacd7f9123d2a076a06893d7f37f2da5876a8930527513
-      command: ["python", "-m", "caikit.runtime.grpc_server"]
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
+        - name: RUNTIME_GRPC_ENABLED
+          value: "true"
+        - name: RUNTIME_HTTP_ENABLED
+          value: "false"
       ports:
         - containerPort: 8085
           name: h2c

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:a17a2868644929ee844ceb2778ac3f6db0936824d9b89d11ea7aa059466fcd0b
+      image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
       ## Note: cannot add readiness/liveness probes to this container because knative will refuse them
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
@@ -22,7 +22,7 @@ spec:
       #     cpu: 8
       #     memory: 16Gi
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:ce6b66bb847608dac5eacd7f9123d2a076a06893d7f37f2da5876a8930527513
+      image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -11,7 +11,6 @@ spec:
   containers:
     - name: kserve-container
       image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
-      ## Note: cannot add readiness/liveness probes to this container because knative will refuse them
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -21,6 +20,8 @@ spec:
       #   requests:
       #     cpu: 8
       #     memory: 16Gi
+      ## Note: cannot add readiness/liveness probes to this container because knative will refuse them.
+      # multi-container probing will be available after https://github.com/knative/serving/pull/14853 is merged
     - name: transformer-container
       image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
       env:

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -23,6 +23,8 @@ spec:
     - name: transformer-container
       image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
       env:
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models
         - name: TRANSFORMERS_CACHE

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:a17a2868644929ee844ceb2778ac3f6db0936824d9b89d11ea7aa059466fcd0b
+      image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -21,7 +21,7 @@ spec:
       #     cpu: 8
       #     memory: 16Gi
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:ce6b66bb847608dac5eacd7f9123d2a076a06893d7f37f2da5876a8930527513
+      image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -12,15 +12,43 @@ spec:
     - name: kserve-container
       image: quay.io/modh/text-generation-inference@sha256:a17a2868644929ee844ceb2778ac3f6db0936824d9b89d11ea7aa059466fcd0b
       command: ["text-generation-launcher"]
-      args: ["--model-name=/mnt/models/artifacts/"] 
+      args: ["--model-name=/mnt/models/artifacts/"]
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi
     - name: transformer-container
       image: quay.io/modh/caikit-tgis-serving@sha256:ce6b66bb847608dac5eacd7f9123d2a076a06893d7f37f2da5876a8930527513
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models
+        - name: TRANSFORMERS_CACHE
+          value: /tmp/transformers_cache
+        - name: RUNTIME_GRPC_ENABLED
+          value: "false"
+        - name: RUNTIME_HTTP_ENABLED
+          value: "true"
       ports:
         - containerPort: 8080
           protocol: TCP
+      readinessProbe:
+        exec:
+          command:
+            - python
+            - -m
+            - caikit_health_probe
+            - readiness
+      livenessProbe:
+        exec:
+          command:
+            - python
+            - -m
+            - caikit_health_probe
+            - liveness
+      # resources: # configure as required
+      #   requests:
+      #     cpu: 8
+      #     memory: 16Gi

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
@@ -9,7 +9,7 @@ spec:
       name: pytorch
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:a17a2868644929ee844ceb2778ac3f6db0936824d9b89d11ea7aa059466fcd0b
+      image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
       command: ["text-generation-launcher"]
       args:
         - "--model-name=/mnt/models/"


### PR DESCRIPTION
Aligning our caikit+tgis runtime yaml with https://github.com/opendatahub-io/caikit-tgis-serving/blob/main/demo/kserve/custom-manifests/caikit/caikit-tgis/caikit-tgis-servingruntime-grpc.yaml 

UPDATE: there will be a slight additional update to the manifest https://github.com/opendatahub-io/caikit-tgis-serving/pull/217. So I would wait merging this test PR until we include the new changes