### PR TITLE
Fix 'Csv Is Ready' KW that fails due to wrong oc command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ __pycache__/
 robocop.log
 infrastructure_configuration.yaml
 log/
+text-generation-inference/

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -13,7 +13,7 @@ ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless
 ${SERVICEMESH_OP_NAME}=     servicemeshoperator
 ${SERVICEMESH_SUB_NAME}=    servicemeshoperator
-${RHODS_CSV_LABEL}=    olm.copiedFrom\=opendatahub-operator
+${RHODS_CSV_LABEL}=    olm.copiedFrom\=redhat-ods-operator
 ${ODH_CSV_LABEL}=    olm.copiedFrom\=opendatahub-operator
 
 *** Keywords ***
@@ -54,15 +54,6 @@ Install RHODS
       END
   END
   Wait Until Csv Is Ready    ${operator_csv_label}
-
-Wait Until Csv Is Ready
-  [Documentation]   Waits ${timeout} for Operator CSV '${csv_label}' to have 'Succeeded' status phase
-  [Arguments]    ${csv_label}    ${timeout}=3m
-  Log    Waiting for the '${csv_label}' operator CSV in 'Succeeded' status condition    console=yes
-  ${rc}    ${output} =    Run And Return Rc And Output
-  ...    oc wait --timeout\=${timeout} --for jsonpath\='{.status.phase}'\=Succeeded csv -n openshift-operators -l ${csv_label}
-  Should Be Equal As Integers  ${rc}   ${0}   msg=Timeout exceeded waiting for '${csv_label}' CSV to be successful
-  Log    ${output}    console=yes
 
 Verify RHODS Installation
   # Needs to be removed ASAP

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -59,17 +59,10 @@ Wait Until Csv Is Ready
   [Documentation]   Waits some time for given CSV to be in Succeeded status condition
   [Arguments]    ${csv_name}
   Log    Waiting for the '${csv_name}' operator CSV in 'Succeeded' status condition    console=yes
-  Wait Until Keyword Succeeds    6 times   20 seconds
-  ...    Csv Is Ready    ${csv_name}
-  Log    Operator '${csv_name}' CSV is in 'Succeeded' status condition now, let's continue    console=yes
-
-Csv Is Ready
-  [Documentation]   Check whether given CSV to be in Succeeded status condition
-  [Arguments]    ${csv_name}
   ${rc}    ${output} =    Run And Return Rc And Output
-  ...    oc get csv --namespace openshift-operators --output=json | jq --raw-output --exit-status '.items[] | select(.metadata.name | test("${csv_name}")).status.conditions[] | select(.phase == "Succeeded").phase'    # robocop: disable:line-too-long
-  Should Be Equal As Integers    ${rc}    0
-  Should Be Equal As Strings    Succeeded    ${output}
+  ...    oc wait --timeout=3m --for jsonpath='{.status.phase}'=Succeeded csv -n openshift-operators ${csv_name}
+  Should Be Equal As Integers  ${rc}   ${0}   msg=Timeout exceeded waiting for '${csv_name}' CSV to be successful
+  Log    ${output}    console=yes
 
 Verify RHODS Installation
   # Needs to be removed ASAP

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -13,21 +13,21 @@ ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless
 ${SERVICEMESH_OP_NAME}=     servicemeshoperator
 ${SERVICEMESH_SUB_NAME}=    servicemeshoperator
-${RHODS_CSV_LABEL}=    olm.copiedFrom\=redhat-ods-operator
-${ODH_CSV_LABEL}=    operators.coreos.com/rhods-operator.openshift-operators
+${RHODS_CSV_DISPLAY}=    Red Hat OpenShift AI
+${ODH_CSV_DISPLAY}=    Open Data Hub Operator
 
 *** Keywords ***
 Install RHODS
   [Arguments]  ${cluster_type}     ${image_url}
   Install Kserve Dependencies
   Clone OLM Install Repo
-  ${operator_csv_label} =    Set Variable    ${RHODS_CSV_LABEL}
+  ${csv_display_name} =    Set Variable    ${RHODS_CSV_DISPLAY}
   IF  "${cluster_type}" == "selfmanaged"
       IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi"
             IF  "${UPDATE_CHANNEL}" != "odh-nightlies"
                  Install RHODS In Self Managed Cluster Using CLI  ${cluster_type}     ${image_url}
             ELSE
-                 ${operator_csv_label} =    Set Variable    ${ODH_CSV_LABEL}
+                 ${csv_display_name} =    Set Variable    ${ODH_CSV_DISPLAY}
                  Create Catalog Source For Operator
                  Oc Apply    kind=List    src=tasks/Resources/Files/odh_nightly_sub.yml
             END
@@ -45,7 +45,7 @@ Install RHODS
            IF  "${UPDATE_CHANNEL}" != "odh-nightlies"
                 Install RHODS In Managed Cluster Using CLI  ${cluster_type}     ${image_url}
            ELSE
-                ${operator_csv_label} =    Set Variable    ${ODH_CSV_LABEL}
+                ${csv_display_name} =    Set Variable    ${ODH_CSV_DISPLAY}
                 Create Catalog Source For Operator
                 Oc Apply    kind=List    src=tasks/Resources/Files/odh_nightly_sub.yml
            END
@@ -53,7 +53,7 @@ Install RHODS
           FAIL    Provided test envrioment is not supported
       END
   END
-  Wait Until Csv Is Ready    ${operator_csv_label}
+  Wait Until Csv Is Ready    ${csv_display_name}
 
 Verify RHODS Installation
   # Needs to be removed ASAP

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -14,7 +14,7 @@ ${SERVERLESS_NS}=    openshift-serverless
 ${SERVICEMESH_OP_NAME}=     servicemeshoperator
 ${SERVICEMESH_SUB_NAME}=    servicemeshoperator
 ${RHODS_CSV_LABEL}=    olm.copiedFrom\=redhat-ods-operator
-${ODH_CSV_LABEL}=    olm.copiedFrom\=opendatahub-operator
+${ODH_CSV_LABEL}=    operators.coreos.com/rhods-operator.openshift-operators
 
 *** Keywords ***
 Install RHODS

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -146,9 +146,9 @@ Wait Until Csv Is Ready
   [Arguments]    ${csv_label}    ${timeout}=3m    ${opeartors_namespace}=openshift-operators
   Log    Waiting ${timeout} for Operator CSV with Label '${csv_label}' to have a 'Succeeded' status phase    console=yes
   ${rc}    ${output} =    Run And Return Rc And Output
-  ...    oc wait --timeout\=${timeout} --for jsonpath\='{.status.phase}'\=Succeeded csv -n ${opeartors_namespace} -l ${csv_label}
+  ...    oc wait --timeout\=${timeout} --for jsonpath\='{.status.phase}'\=Succeeded csv -n ${opeartors_namespace} -l '${csv_label}'
   Should Be Equal As Integers  ${rc}   ${0}
-  ...    msg=${timeout} Timeout exceeded waiting for CSV '${csv_label}' in ${opeartors_namespace} to be successful
+  ...    msg=${timeout} Timeout exceeded waiting for CSV '${csv_label}' in ${opeartors_namespace} to be successful. ${output}
   Log    ${output}    console=yes
 
 Get Cluster ID

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -140,6 +140,17 @@ Get CodeFlare Version
     Log  Product:${PRODUCT} CodeFlare Version:${CODEFLARE_VERSION}
     RETURN  ${CODEFLARE_VERSION}
 
+#robocop: disable: line-too-long
+Wait Until Csv Is Ready
+  [Documentation]   Waits ${timeout} for Operator CSV with Label '${csv_label}' to have a 'Succeeded' status phase
+  [Arguments]    ${csv_label}    ${timeout}=3m    ${opeartors_namespace}=openshift-operators
+  Log    Waiting ${timeout} for Operator CSV with Label '${csv_label}' to have a 'Succeeded' status phase    console=yes
+  ${rc}    ${output} =    Run And Return Rc And Output
+  ...    oc wait --timeout\=${timeout} --for jsonpath\='{.status.phase}'\=Succeeded csv -n ${opeartors_namespace} -l ${csv_label}
+  Should Be Equal As Integers  ${rc}   ${0}
+  ...    msg=${timeout} Timeout exceeded waiting for CSV '${csv_label}' in ${opeartors_namespace} to be successful
+  Log    ${output}    console=yes
+
 Get Cluster ID
     [Documentation]     Retrieves the ID of the currently connected cluster
     ${cluster_id}=   Run    oc get clusterversion -o json | jq .items[].spec.clusterID


### PR DESCRIPTION
The current KW runs:
`oc get csv --namespace openshift-operators --output=json | jq --raw-output --exit-status '.items[] | select(.metadata.name | test("${csv_name}")).status.conditions[] |
select(.phase == "Succeeded").phase'`

Which may return error 4 on certain conditions, for example:
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/53564800-46a2-4eab-a14c-dabb08a560fb)


The fix is to use k8s native wait for resource objects to be ready: 
`oc wait --timeout=5m --for jsonpath='{.status.phase}'=Succeeded csv -n openshift-operators ${csv_name}`
It also removes the loop of internal keyword as used previously.

The Keyboard `Wait Until Csv Is Ready` moved to Common.robot, and it includes the arguments:
`${description}    ${timeout}=3m    ${opeartors_namespace}=openshift-operators`

For example for ODH install, this is the result with the fix:
![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/2f4634c7-df29-4c3e-8466-da57fe5ddbe0)

And in console:
```
18:30:22  ==============================================================================
18:30:22  Rhods Olm :: Perform and verify RHODS OLM tasks                               
18:30:22  ==============================================================================
18:30:22  Can Install RHODS Operator                                            Cluster type: selfmanaged
18:30:22  Checking if RHODS is installed with "selfmanaged" "odh-nightlies" "CLi"
18:30:22  Getting CSV from subscription rhods-odh-nightly-operator namespace openshift-operators
18:30:23  Error from server (NotFound): subscriptions.operators.coreos.com "rhods-odh-nightly-operator" not found
18:30:23  Got CSV  from subscription rhods-odh-nightly-operator, result: 0
18:30:23  Operator with sub rhods-odh-nightly-operator is installed result: False
18:30:23  RHODS is installed: False
18:30:23  Installing RHODS operator in selfmanaged
18:30:24  ServiceMesh Operator is already installed
18:30:25  Serverless Operator is already installed
18:30:31  Cloning into '/home/jenkins/workspace/rhods/rhods-ci-pr-test/ods-ci/ods_ci/rhodsolm'...
18:30:34  Waiting for the 'odh-catalog-dev' CatalogSource in 'openshift-marketplace' namespace to be in 'Ready' status state
18:30:34  CatalogSource 'odh-catalog-dev' in 'openshift-marketplace' namespace in 'Ready' status now, let's continue
18:30:34  Waiting 3m for Operator CSV 'Open Data Hub Operator' in openshift-operators to have status phase 'Succeeded'
18:31:01  clusterserviceversion.operators.coreos.com/opendatahub-operator.1.18.0 condition met
```