### PR TITLE
Increase timeouts for Kuberay tests

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
@@ -61,6 +61,9 @@ Run Kuberay E2E Test
     [Arguments]    ${test_name}
     Log To Console    Running Kuberay E2E test: ${test_name}
     ${result} =    Run Process    go test -timeout 30m -parallel 1 -v ./test/e2e -run ${test_name}
+    ...    env:KUBERAY_TEST_TIMEOUT_SHORT=2m
+    ...    env:KUBERAY_TEST_TIMEOUT_MEDIUM=7m
+    ...    env:KUBERAY_TEST_TIMEOUT_LONG=10m
     ...    env:KUBERAY_TEST_RAY_IMAGE=quay.io/project-codeflare/ray:latest-py39-cu118
     ...    shell=true
     ...    stderr=STDOUT


### PR DESCRIPTION
It was not possible to create Kuberay cluster in 120s if there was not image already downloaded in OpenShift.