### PR TITLE
Revert "Add support for kueue component whihc got added in 2.7"

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -16,8 +16,6 @@ spec:
       managementState: <modelmeshserving_value>
     ray:
       managementState: <ray_value>
-    kueue:
-      managementState: <kueue_value>
     trustyai:
       managementState: <trustyai_value>
     workbenches:

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -8,7 +8,7 @@ Resource   ../../../../tests/Resources/Page/OCPDashboard/UserManagement/Groups.r
 
 *** Variables ***
 ${DSC_NAME} =    default-dsc
-@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai    kueue  # robocop: disable
+@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai  # robocop: disable
 ${SERVERLESS_OP_NAME}=     serverless-operator
 ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless


### PR DESCRIPTION
Reverts red-hat-data-services/ods-ci#1183 ..reverting the patch beacue kueue will be removed in 2.7

https://issues.redhat.com/browse/RHOAIENG-3234