### PR TITLE
Fix 'Clean All Models Of Current User' KW

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -527,18 +527,23 @@ Clean All Models Of Current User
     ...    controls how many retries are made.
     [Arguments]    ${retries}=5
     Open Model Serving Home Page
-    FOR    ${try}    IN RANGE    0    ${retries}
-        ${status}=    Run Keyword And Return Status    Page Should Contain    Select a project
-        IF    ${status}
-            Capture Page Screenshot
-            Click Button    Select a project
-            RETURN
-        ELSE
-            Clean Up Model Serving Page
-            Clean Up DSP Page
-            Open Model Serving Home Page
-            Reload Page
-            Sleep  5s
+    ${projects_empty}=    Run Keyword And Return Status    Page Should Contain    No data science projects
+    IF    ${projects_empty}
+        Log    No Data Sciense projects exist, skipping cleanup    console=True
+    ELSE
+        FOR    ${try}    IN RANGE    0    ${retries}
+            ${status}=    Run Keyword And Return Status    Page Should Contain    Select a project
+            IF    ${status}
+                Capture Page Screenshot
+                Click Button    Select a project
+                RETURN
+            ELSE
+                Clean Up Model Serving Page
+                Clean Up DSP Page
+                Open Model Serving Home Page
+                Reload Page
+                Sleep  5s
+            END
         END
     END
 
@@ -547,11 +552,10 @@ Set Up Project
     ...                creates caikit runtime. This can be used as test setup
     [Arguments]    ${namespace}    ${single_prj}=${TRUE}    ${enable_metrics}=${FALSE}    ${dc_name}=kserve-connection
     IF    ${single_prj}
-        Clean All Models Of Current User
+        Run Keyword And Continue On Failure    Clean All Models Of Current User
     END
     Open Data Science Projects Home Page
-    Wait For RHODS Dashboard To Load    wait_for_cards=${FALSE}    expected_page=Data Science Projects
-    Create Data Science Project    title=${namespace}    description=kserve test project
+    Create Data Science Project    title=${namespace}    description=kserve test project    existing_project=${TRUE}
     Create S3 Data Connection    project_title=${namespace}    dc_name=${dc_name}
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=${S3.BUCKET_3.NAME}    aws_s3_endpoint=${S3.BUCKET_3.ENDPOINT}


### PR DESCRIPTION
In case the current user does not have permissions to view other DS projects, then the Model Serving page does not include "select a project" link, which causes the 'Clean All Models Of Current User' KW to fail.

The fix includes:
- Skip cleanup if no Data Sciense projects exist
- 'Set Up Project' SETUP KW continues if cleanup failed
- 'Set Up Project' SETUP KW creates DS project only if doesn't exist yet

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/784180ad-8087-4058-84dd-d43868e2bb5a)
