### PR TITLE
Skip a PV Storage test on disconnected

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -155,8 +155,10 @@ Verify User Can Create A PV Storage
     Storage Size Should Be    name=${pv_name}    namespace=${ns_name}  size=${PV_SIZE}
 
 Verify User Can Create And Start A Workbench Adding A New PV Storage
-    [Tags]    Smoke    Sanity    ODS-1816    Tier1
+    [Tags]    Smoke    Sanity    ODS-1816    Tier1    ExcludeOnDisconnected
     [Documentation]    Verifies users can create a workbench and connect a new PersistenVolume
+    ...    We skip this test on Disconnected environment because we have a PVs predefined there hardcoded to 100Gi.
+    ...    Since there is a size check in this test, it would fail unless some extra condition to be brought in here.
     ${pv_name}=    Set Variable    ${PV_BASENAME}-new
     ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}


### PR DESCRIPTION
Let's skip this test on Disconnected environment because we have a PVs predefined there hardcoded to 100Gi. Since there is a size check in this test, it would fail unless some extra condition to be brought in here. I believe that it is okay to check just on regular cluster for now and skip on disconnected safely.

Note, PV and PVC is always 1-to-1 connection [1]. We can improve our
disconnected infrastructrue so that the dynamic PV provisioning is
enabled and then we can re-enable this test back.

* [1] https://kubernetes.io/docs/concepts/storage/persistent-volumes/#binding