### PR TITLE
[Fix] image creation via Dockerfile after move to Python 3.11

### DIFF
--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -18,8 +18,9 @@ ARG OC_CHANNEL=stable
 
 RUN dnf -y update &&\
     dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
-    dnf install -y jq git unzip chromium chromedriver python3-distro httpd-tools &&\
-    dnf clean all &&\
+    dnf install -y jq git unzip chromium chromedriver httpd-tools gcc \
+                   python3 python3-devel python3-distro python-pip python3.11 python3.11-devel &&\
+    dnf clean all && rm -rf /var/cache/yum &&\
     curl --proto "=https" -L https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -o /usr/bin/yq &&\
     chmod +x /usr/bin/yq &&\
     curl --proto "=https" -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \


### PR DESCRIPTION
This is a followup of [1,2] and fixes image build creation after we moved from Python 3.9 to Python 3.11

On top of that, it also removes dnf cache after all installation is done. There is no change in the sice of resulting image but it's a standard step to do in the Dockerfiles in general.

[1] #1118
[2] 867a617bc224726cf98fa3354293f8e50b4f5eb5