### PR TITLE
Update Dockerfile to use minimal CentOS and microdnf

### DIFF
--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -20,7 +20,7 @@ RUN microdnf -y update &&\
     curl -OL https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
     rpm -ivh ./epel-release-latest-9.noarch.rpm &&\
     rm epel-release-latest-9.noarch.rpm &&\
-    microdnf install -y jq git unzip chromium chromedriver httpd-tools gcc \
+    microdnf install -y jq git tar unzip chromium chromedriver httpd-tools gcc \
                    python3.11 python3.11-devel python3.11-pip &&\
     microdnf clean all && rm -rf /var/cache/yum &&\
     python3.11 -m pip install distro &&\

--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -17,7 +17,9 @@ ARG OC_CHANNEL=stable
 
 
 RUN microdnf -y update &&\
-    microdnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
+    curl -OL https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
+    rpm -ivh ./epel-release-latest-9.noarch.rpm &&\
+    rm epel-release-latest-9.noarch.rpm &&\
     microdnf install -y jq git unzip chromium chromedriver httpd-tools gcc \
                    python3.11 python3.11-devel python3.11-pip &&\
     microdnf clean all && rm -rf /var/cache/yum &&\

--- a/ods_ci/build/Dockerfile
+++ b/ods_ci/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream9-minimal
 
 # Use this build arg to set any default test script arguments
 ENV RUN_SCRIPT_ARGS=${RUN_SCRIPT_ARGS}
@@ -16,11 +16,12 @@ ARG OC_VERSION=4.13
 ARG OC_CHANNEL=stable
 
 
-RUN dnf -y update &&\
-    dnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
-    dnf install -y jq git unzip chromium chromedriver httpd-tools gcc \
-                   python3 python3-devel python3-distro python-pip python3.11 python3.11-devel &&\
-    dnf clean all && rm -rf /var/cache/yum &&\
+RUN microdnf -y update &&\
+    microdnf -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm &&\
+    microdnf install -y jq git unzip chromium chromedriver httpd-tools gcc \
+                   python3.11 python3.11-devel python3.11-pip &&\
+    microdnf clean all && rm -rf /var/cache/yum &&\
+    python3.11 -m pip install distro &&\
     curl --proto "=https" -L https://github.com/mikefarah/yq/releases/download/v4.34.1/yq_linux_amd64 -o /usr/bin/yq &&\
     chmod +x /usr/bin/yq &&\
     curl --proto "=https" -L https://mirror.openshift.com/pub/openshift-v$(echo $OC_VERSION | cut -d'.' -f 1)/x86_64/clients/ocp/$OC_CHANNEL-$OC_VERSION/openshift-client-linux.tar.gz -o $HOME/oc_client.tar.gz && \


### PR DESCRIPTION
The Dockerfile has been updated to use a minimal version of CentOS. Furthermore, `dnf` commands have been replaced with `microdnf` to save space and enhance performance. The dependency installation steps were also adjusted accordingly.