### PR TITLE
Add Polarion ID to Run Data Science Pipelines Operator Integration Tests

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/436__test-run-data-science-pipelines-operator-e2e-tests.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/436__test-run-data-science-pipelines-operator-e2e-tests.robot
@@ -1,7 +1,7 @@
 *** Settings ***
-Documentation     Data Science Pipelines Operator E2E tests - https://github.com/opendatahub-io/data-science-pipelines-operator/tree/main/tests
-Suite Setup       Prepare Data Science Pipelines Operator E2E Test Suite
-Suite Teardown    Teardown Data Science Pipelines Operator E2E Test Suite
+Documentation     Data Science Pipelines Operator Integration Tests - https://github.com/opendatahub-io/data-science-pipelines-operator/tree/main/tests
+Suite Setup       Prepare Data Science Pipelines Operator Integration Tests Suite
+Suite Teardown    Teardown Data Science Pipelines Operator Integration Tests Suite
 Library           OperatingSystem
 Library           Process
 Resource          ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -19,22 +19,23 @@ ${KUBECONFIGPATH}                                         %{HOME}/.kube/config
 
 #robocop: disable: line-too-long
 *** Test Cases ***
-Run Data Science Pipelines Operator E2E Test
-    [Documentation]    Run Data Science Pipelines Operator E2E Test
+Run Data Science Pipelines Operator Integration Tests
+    [Documentation]    Run Data Science Pipelines Operator Integration Tests
     [Tags]
     ...     Sanity
     ...     DataSciencePipelines
     ...     Tier1
+    ...     ODS-2632
     ${openshift_api}    Get Openshift Server
     Log    ${openshift_api}
     ${return_code}    ${output}    Run And Return Rc And Output    cd ${DATA-SCIENCE-PIPELINES-OPERATOR-SDK_DIR} && make integrationtest K8SAPISERVERHOST=${openshift_api} DSPANAMESPACE=${DSPANAMESPACE} KUBECONFIGPATH=${KUBECONFIGPATH}
     Log    ${output}
-    Should Be Equal As Integers	   ${return_code}	 0  msg= Run Data Science Pipelines Operator E2E Test failed
+    Should Be Equal As Integers	   ${return_code}	 0  msg= Run Data Science Pipelines Operator Integration Tests failed
 
 #robocop: disable: line-too-long
 *** Keywords ***
-Prepare Data Science Pipelines Operator E2E Test Suite
-    [Documentation]    Prepare Data Science Pipelines Operator E2E Test Suite
+Prepare Data Science Pipelines Operator Integration Tests Suite
+    [Documentation]    Prepare Data Science Pipelines Operator Integration Tests Suite
     ${return_code}    ${output}     Run And Return Rc And Output    rm -fR ${DATA-SCIENCE-PIPELINES-OPERATOR-SDK_DIR}
     Log    ${output}
     ${return_code}    ${output}     Run And Return Rc And Output    git clone ${DATA-SCIENCE-PIPELINES-OPERATOR-SDK_REPO_URL} ${DATA-SCIENCE-PIPELINES-OPERATOR-SDK_DIR}
@@ -46,7 +47,7 @@ Prepare Data Science Pipelines Operator E2E Test Suite
     ${rc}    ${out}=    Run And Return Rc And Output    oc new-project ${DSPANAMESPACE}
     Should Be Equal As Integers	   ${rc}	 0  msg=Cannot create a new project ${DSPANAMESPACE}
 
-Teardown Data Science Pipelines Operator E2E Test Suite
+Teardown Data Science Pipelines Operator Integration Tests Suite
     ${return_code}    ${output}     Run And Return Rc And Output    oc delete project ${DSPANAMESPACE} --force --grace-period=0
     Log    ${output}
     RHOSi Teardown


### PR DESCRIPTION
```
2024-02-19 14:03:13,517 - RPA.core.certificates - DEBUG - Current 'pip' version 23.2 doesn't satisfy minimum of 23.2.1.
2024-02-19 14:03:13,517 - RPA.core.certificates - INFO - Truststore not in use, HTTPS traffic validated against `certifi` package. (requires Python 3.10.12 and 'pip' 23.2.1 at minimum)
Tests.Ods Dashboard.Data Science Pipelines.Test-Run-Data-Science-Pipelines-...
==============================================================================
[ WARN ] No Prometheus namespace found
Run Data Science Pipelines Operator Integration Tests :: Run Data ... | PASS |
------------------------------------------------------------------------------
Tests.Ods Dashboard.Data Science Pipelines.Test-Run-Data-Science-P... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Data Science Pipelines                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================

```