### PR TITLE
Add error message and continue on failure of bug RHOAIENG-404

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -256,8 +256,8 @@ Load Expected Data Of RHODS Explore Section
 
 Wait Until Cards Are Loaded
     [Documentation]    Waits until the Application cards are displayed in the page
-    Wait Until Page Contains Element    xpath:${CARDS_XP}
-    ...    timeout=15s
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element
+    ...    xpath:${CARDS_XP}    timeout=15s    error="This might be caused by bug RHOAIENG-404"
 
 Get App ID From Card
     [Arguments]  ${card_locator}


### PR DESCRIPTION
Due to bug RHOAIENG-404 there are arbitrary failures during execution
of `Wait Until Cards Are Loaded` KW in Dashboard tests.
For example:

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/fac3f650-657c-4786-a349-d4c96a93f31f)

With this PR it continues if the error above occurs, and shows an error message about potential bug RHOAIENG-404, in order not to break arbitrary tests (or tests setup).