### PR TITLE
Fix Custom Serving Runtime sanity tests

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -82,7 +82,7 @@ Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
     Create Model Server    server_name=${MODEL_SERVER_NAME}    runtime=${UPLOADED_OVMS_DISPLAYED_NAME}
     Serve Model    project_name=${PRJ_TITLE}    model_name=${model_name}    framework=onnx
-    ...    existing_data_connection=${TRUE}
+    ...    existing_data_connection=${TRUE}    model_server=${MODEL_SERVER_NAME}
     ...    data_connection_name=model-serving-connection    model_path=mnist-8.onnx
     Wait Until Runtime Pod Is Running    server_name=${MODEL_SERVER_NAME}
     ...    project_title=${PRJ_TITLE}    timeout=5m

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -109,6 +109,7 @@ Custom Serving Runtime Suite Teardown
     Delete Data Science Project From CLI    displayed_name=${PRJ_TITLE}
     Delete Serving Runtime Template From CLI    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}
     SeleniumLibrary.Close All Browsers
+    Remove File    openshift_ca.crt
     RHOSi Teardown
 
 Create Test Serving Runtime Template If Not Exists


### PR DESCRIPTION
2 fixes:
1. remove ca bundle in teardown to avoid impact on next tests
2. fix deployment test to use correct runtime