### PR TITLE
increase the delete cluster timeout

### DIFF
--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -937,7 +937,7 @@ class OpenshiftClusterManager:
             sys.exit(1)
         self.wait_for_osd_cluster_to_get_deleted()
 
-    def wait_for_osd_cluster_to_get_deleted(self, timeout=3600):
+    def wait_for_osd_cluster_to_get_deleted(self, timeout=5400):
         """Waits for cluster to get deleted"""
 
         count = 0


### PR DESCRIPTION
A few Jenkins jobs failed because of the short timeout of the delete cluster with the following error:

20:06:28  ods-ci-logger: INFO     ocm cluster with name xxxx exists!
20:07:24  ods-ci-logger: ERROR    xxxx not deleted even after an hour. EXITING

increasing the timeout from 60 minutes to 90 minutes

related to jira ticket: RHOAIENG-3917