### PR TITLE
Add TGIS test for bigscience/mt0-xxl model

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -254,7 +254,7 @@ Query Model Multiple Times
     ...                  - streaming: it returns the streamed generated response (i.e., one word per time)
     [Arguments]    ${model_name}    ${namespace}    ${runtime}=caikit-tgis-runtime    ${isvc_name}=${model_name}
     ...            ${inference_type}=all-tokens    ${n_times}=10    ${query_idx}=0    ${validate_response}=${TRUE}
-    ...            ${protocol}=grpc    ${host}=${NONE}    ${port}=443    &{args}
+    ...            ${protocol}=grpc    ${port_forwarding}=${FALSE}    ${port}=443    &{args}
     IF    "${inference_type}" == "streaming"
         ${streamed_response}=    Set Variable    ${TRUE}
     ELSE
@@ -265,10 +265,16 @@ Query Model Multiple Times
     ELSE
         ${skip_json_load_response}=    Set Variable    ${streamed_response}    # always skip if using streaming endpoint
     END
-    IF    $host is None
+    IF    ${port_forwarding}
+        ${host}=    Set Variable    localhost    # temp - we might need to query using service URL
+        ${port}=    Extract Service Port    service_name=${isvc_name}-predictor    protocol=${protocol}    namespace=${namespace}
+        ${insecure}=    Set Variable    ${FALSE}
+        ${plaintext}=    Set Variable    ${TRUE}
+    ELSE
         ${host}=    Get KServe Inference Host Via CLI    isvc_name=${isvc_name}   namespace=${namespace}
+        ${insecure}=    Set Variable    ${TRUE}
+        ${plaintext}=    Set Variable    ${FALSE}
     END
-    
     ${body}    ${header}    ${extra_args}=    llm.Prepare Payload    runtime=${runtime}    protocol=${protocol}
     ...    inference_type=${inference_type}    model_name=${model_name}
     ...    query_text=${EXP_RESPONSES}[queries][${query_idx}][query_text]
@@ -281,7 +287,7 @@ Query Model Multiple Times
             ${res}=    Query Model With GRPCURL   host=${host}    port=${port}
             ...    endpoint=${endpoint}
             ...    json_body=${body}    json_header=${header}
-            ...    insecure=${TRUE}    skip_res_json=${skip_json_load_response}
+            ...    insecure=${insecure}    plaintext=${plaintext}    skip_res_json=${skip_json_load_response}
             ...    &{args}
          ELSE IF    "${protocol}" == "http"
             ${payload}=     ODHDashboardAPI.Prepare Payload     body=${body}    str_to_json=${TRUE}
@@ -638,3 +644,15 @@ Create PVC And Download Model From S3
     Wait For Pods To Be Ready    label_selector=name=download-${model_name}    namespace=${namespace}
     Wait For Pods To Succeed    label_selector=name=download-${model_name}    namespace=${namespace}
     ...    timeout=${download_timeout}
+
+Extract Service Port
+    [Arguments]    ${service_name}    ${namespace}    ${protocol}    
+    IF    "${protocol}" == "grpc"
+        ${port_name}=    Set Variable    h2c
+    ELSE
+        ${port_name}=    Set Variable    ${protocol}
+    END
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    oc get svc/${service_name} -n ${namespace} -o jsonpath='{range .spec.ports[?(@.name=="${port_name}")]}{@.targetPort}{end}'
+    Should Be Equal As Integers    ${rc}    ${0}    msg=${out}
+    RETURN    ${out}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -254,7 +254,7 @@ Query Model Multiple Times
     ...                  - streaming: it returns the streamed generated response (i.e., one word per time)
     [Arguments]    ${model_name}    ${namespace}    ${runtime}=caikit-tgis-runtime    ${isvc_name}=${model_name}
     ...            ${inference_type}=all-tokens    ${n_times}=10    ${query_idx}=0    ${validate_response}=${TRUE}
-    ...            ${protocol}=grpc    &{args}
+    ...            ${protocol}=grpc    ${host}=${NONE}    ${port}=443    &{args}
     IF    "${inference_type}" == "streaming"
         ${streamed_response}=    Set Variable    ${TRUE}
     ELSE
@@ -265,7 +265,10 @@ Query Model Multiple Times
     ELSE
         ${skip_json_load_response}=    Set Variable    ${streamed_response}    # always skip if using streaming endpoint
     END
-    ${host}=    Get KServe Inference Host Via CLI    isvc_name=${isvc_name}   namespace=${namespace}
+    IF    $host is None
+        ${host}=    Get KServe Inference Host Via CLI    isvc_name=${isvc_name}   namespace=${namespace}
+    END
+    
     ${body}    ${header}    ${extra_args}=    llm.Prepare Payload    runtime=${runtime}    protocol=${protocol}
     ...    inference_type=${inference_type}    model_name=${model_name}
     ...    query_text=${EXP_RESPONSES}[queries][${query_idx}][query_text]
@@ -275,7 +278,7 @@ Query Model Multiple Times
     FOR    ${counter}    IN RANGE    0    ${n_times}    1
         Log    ${counter}
         IF    "${protocol}" == "grpc"
-            ${res}=    Query Model With GRPCURL   host=${host}    port=443
+            ${res}=    Query Model With GRPCURL   host=${host}    port=${port}
             ...    endpoint=${endpoint}
             ...    json_body=${body}    json_header=${header}
             ...    insecure=${TRUE}    skip_res_json=${skip_json_load_response}
@@ -283,7 +286,7 @@ Query Model Multiple Times
          ELSE IF    "${protocol}" == "http"
             ${payload}=     ODHDashboardAPI.Prepare Payload     body=${body}    str_to_json=${TRUE}
             Log Dictionary    ${args}
-            Set To Dictionary    ${args}    url=https://${host}:443/${endpoint}   expected_status=any
+            Set To Dictionary    ${args}    url=https://${host}:${port}/${endpoint}   expected_status=any
             ...             headers=${header}   json=${payload}    verify=${False}
             ${is_timeout}=    Run Keyword And Return Status    Dictionary Should Contain Key    ${args}    timeout
             IF    ${is_timeout} == ${FALSE}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -20,6 +20,8 @@ ${MODELS_BUCKET}=    ${S3.BUCKET_3}
 ${SERVICEMESH_CR_NS}=    istio-system
 &{RUNTIME_FLIEPATHS}=    caikit-tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/caikit_tgis_servingruntime_{{protocol}}.yaml
 ...                      tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/tgis_servingruntime_{{protocol}}.yaml
+${DOWNLOAD_PVC_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/download_model_in_pvc.yaml
+${DOWNLOAD_PVC_FILLED_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/download_model_in_pvc_filled.yaml
 
 
 *** Keywords ***
@@ -57,11 +59,18 @@ Set Project And Runtime
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}    ${runtime}=caikit-tgis-runtime    ${protocol}=grpc
     ...            ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}
     ...            ${endpoint}=${MODELS_BUCKET.ENDPOINT}    ${verify_ssl}=${TRUE}
+    ...            ${download_in_pvc}=${FALSE}    ${model_name}=${NONE}    ${download_timeout}=${NONE}
     Set Up Test OpenShift Project    test_ns=${namespace}
-    Create Secret For S3-Like Buckets    endpoint=${endpoint}
-    ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
-    ...    access_key_id=${access_key_id}    access_key=${access_key}
-    ...    verify_ssl=${verify_ssl}
+    IF    ${download_in_pvc}
+        Create PVC And Download Model From S3    model_name=${model_name}    bucket_name=${MODELS_BUCKET}
+        ...    endpoint=${MODELS_BUCKET.ENDPOINT}    region=${MODELS_BUCKET.REGION}    ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}
+        ...    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}    ${use_https}=${USE_BUCKET_HTTPS}    download_timeout=${download_timeout}
+    ELSE
+        Create Secret For S3-Like Buckets    endpoint=${endpoint}
+        ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
+        ...    access_key_id=${access_key_id}    access_key=${access_key}
+        ...    verify_ssl=${verify_ssl}
+    END
     Deploy Serving Runtime    namespace=${namespace}    runtime=${runtime}    protocol=${protocol}
     IF   ${enable_metrics} == ${TRUE}
         Enable User Workload Monitoring
@@ -216,7 +225,7 @@ Prepare Payload
             Log    ${index}: ${sub_header}
             ${pair}=    Split String    ${sub_header}    separator=:
             Log    ${pair}
-            Set To Dictionary    ${dict_header}    ${pair}[0]=${pair}[1]    
+            Set To Dictionary    ${dict_header}    ${pair}[0]=${pair}[1]
         END
         ${header}=    Set Variable    ${dict_header}
     END
@@ -229,7 +238,7 @@ Prepare Payload
             Log    ${index}: ${arg}
             ${pair}=    Split String    ${arg}    separator==
             Log    ${pair}
-            Set To Dictionary    ${args}    ${pair}[0]=${pair}[1]    
+            Set To Dictionary    ${args}    ${pair}[0]=${pair}[1]
         END
     END
     RETURN    ${body}    ${header}    ${args}
@@ -287,7 +296,7 @@ Query Model Multiple Times
             ${response_container_field}=    Set Variable    ${runtime_details}[response_fields_map][response]
             IF    "${response_container_field}" != "${EMPTY}"
                 # runtimes may support multiple queries per time. Here forcing to use only 1 for sake of simplicity.
-                ${res}=    Set Variable    ${res}[${response_container_field}][0]            
+                ${res}=    Set Variable    ${res}[${response_container_field}][0]
             END
             Run Keyword And Continue On Failure
             ...    Model Response Should Match The Expectation    model_response=${res}    model_name=${model_name}
@@ -499,7 +508,7 @@ Get KServe Inference Host Via CLI
     RETURN    ${ksvc_host}
 
 Get Current Revision ID
-    [Documentation]    Fetches the knative revision ID for the given model 
+    [Documentation]    Fetches the knative revision ID for the given model
     [Arguments]    ${model_name}    ${namespace}
     ${rc}    ${id}=    Run And Return Rc And Output
     ...    oc get pod -n ${namespace} -l serving.kserve.io/inferenceservice=${model_name} -ojson | jq '.items[0].metadata.labels."serving.knative.dev/revisionUID"' | tr -d '"'
@@ -602,3 +611,14 @@ Clean Up Test Project
     ELSE
         Log    Project deletion started, but won't wait for it to finish..
     END
+
+Create PVC And Download Model From S3
+    [Arguments]    ${model_name}    ${bucket_name}    ${endpoint}
+    ...            ${region}    ${access_key_id}    ${access_key}
+    ...            ${use_https}    ${namespace}    ${downoad_timeout}=300s
+    Create File From Template    ${DOWNLOAD_PVC_FILEPATH}    ${DOWNLOAD_PVC_FILLED_FILEPATH}
+    ${rc}    ${out}=    Run And Return Rc And Output    oc -n ${namespace} apply -f ${DOWNLOAD_PVC_FILLED_FILEPATH}
+    Should Be Equal As Integers    ${rc}    ${0}
+    Wait For Pods To Be Ready    label_selector=name=download-${model_name}    namespace=${namespace}
+    Wait For Pods To Succeed    label_selector=name=download-${model_name}    namespace=${namespace}
+    ...    timeout=${downoad_timeout}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -62,9 +62,9 @@ Set Project And Runtime
     ...            ${download_in_pvc}=${FALSE}    ${model_name}=${NONE}    ${download_timeout}=${NONE}
     Set Up Test OpenShift Project    test_ns=${namespace}
     IF    ${download_in_pvc}
-        Create PVC And Download Model From S3    model_name=${model_name}    bucket_name=${MODELS_BUCKET}
-        ...    endpoint=${MODELS_BUCKET.ENDPOINT}    region=${MODELS_BUCKET.REGION}    ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}
-        ...    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}    ${use_https}=${USE_BUCKET_HTTPS}    download_timeout=${download_timeout}
+        Create PVC And Download Model From S3    model_name=${model_name}    namespace=${namespace}    bucket_name=${MODELS_BUCKET.NAME}
+        ...    endpoint=${MODELS_BUCKET.ENDPOINT}    region=${MODELS_BUCKET.REGION}    access_key_id=${S3.AWS_ACCESS_KEY_ID}
+        ...    access_key=${S3.AWS_SECRET_ACCESS_KEY}    use_https=${USE_BUCKET_HTTPS}    download_timeout=${download_timeout}
     ELSE
         Create Secret For S3-Like Buckets    endpoint=${endpoint}
         ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
@@ -615,10 +615,20 @@ Clean Up Test Project
 Create PVC And Download Model From S3
     [Arguments]    ${model_name}    ${bucket_name}    ${endpoint}
     ...            ${region}    ${access_key_id}    ${access_key}
-    ...            ${use_https}    ${namespace}    ${downoad_timeout}=300s
+    ...            ${use_https}    ${namespace}    ${download_timeout}=300s
+    Set Log Level    NONE
+    Set Test Variable    ${model_name}
+    Set Test Variable    ${bucket_name}
+    Set Test Variable    ${endpoint}
+    Set Test Variable    ${region}
+    Set Test Variable    ${access_key_id}
+    Set Test Variable    ${access_key}
+    Set Test Variable    ${use_https}
+    Set Test Variable    ${namespace}
+    Set Log Level    INFO
     Create File From Template    ${DOWNLOAD_PVC_FILEPATH}    ${DOWNLOAD_PVC_FILLED_FILEPATH}
     ${rc}    ${out}=    Run And Return Rc And Output    oc -n ${namespace} apply -f ${DOWNLOAD_PVC_FILLED_FILEPATH}
     Should Be Equal As Integers    ${rc}    ${0}
     Wait For Pods To Be Ready    label_selector=name=download-${model_name}    namespace=${namespace}
     Wait For Pods To Succeed    label_selector=name=download-${model_name}    namespace=${namespace}
-    ...    timeout=${downoad_timeout}
+    ...    timeout=${download_timeout}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -59,12 +59,13 @@ Set Project And Runtime
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}    ${runtime}=caikit-tgis-runtime    ${protocol}=grpc
     ...            ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}
     ...            ${endpoint}=${MODELS_BUCKET.ENDPOINT}    ${verify_ssl}=${TRUE}
-    ...            ${download_in_pvc}=${FALSE}    ${model_name}=${NONE}    ${download_timeout}=${NONE}
+    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${download_timeout}=${NONE}
     Set Up Test OpenShift Project    test_ns=${namespace}
     IF    ${download_in_pvc}
         Create PVC And Download Model From S3    model_name=${model_name}    namespace=${namespace}    bucket_name=${MODELS_BUCKET.NAME}
         ...    endpoint=${MODELS_BUCKET.ENDPOINT}    region=${MODELS_BUCKET.REGION}    access_key_id=${S3.AWS_ACCESS_KEY_ID}
         ...    access_key=${S3.AWS_SECRET_ACCESS_KEY}    use_https=${USE_BUCKET_HTTPS}    download_timeout=${download_timeout}
+        ...    storage_size=${storage_size}
     ELSE
         Create Secret For S3-Like Buckets    endpoint=${endpoint}
         ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
@@ -627,7 +628,8 @@ Clean Up Test Project
 Create PVC And Download Model From S3
     [Arguments]    ${model_name}    ${bucket_name}    ${endpoint}
     ...            ${region}    ${access_key_id}    ${access_key}
-    ...            ${use_https}    ${namespace}    ${download_timeout}=300s
+    ...            ${use_https}    ${namespace}    ${storage_size}
+    ...            ${download_timeout}=300s
     Set Log Level    NONE
     Set Test Variable    ${model_name}
     Set Test Variable    ${bucket_name}
@@ -637,6 +639,7 @@ Create PVC And Download Model From S3
     Set Test Variable    ${access_key}
     Set Test Variable    ${use_https}
     Set Test Variable    ${namespace}
+    Set Test Variable    ${storage_size}
     Set Log Level    INFO
     Create File From Template    ${DOWNLOAD_PVC_FILEPATH}    ${DOWNLOAD_PVC_FILLED_FILEPATH}
     ${rc}    ${out}=    Run And Return Rc And Output    oc -n ${namespace} apply -f ${DOWNLOAD_PVC_FILLED_FILEPATH}
@@ -646,7 +649,7 @@ Create PVC And Download Model From S3
     ...    timeout=${download_timeout}
 
 Extract Service Port
-    [Arguments]    ${service_name}    ${namespace}    ${protocol}    
+    [Arguments]    ${service_name}    ${namespace}    ${protocol}
     IF    "${protocol}" == "grpc"
         ${port_name}=    Set Variable    h2c
     ELSE

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -59,7 +59,7 @@ Set Project And Runtime
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}    ${runtime}=caikit-tgis-runtime    ${protocol}=grpc
     ...            ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}
     ...            ${endpoint}=${MODELS_BUCKET.ENDPOINT}    ${verify_ssl}=${TRUE}
-    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${download_timeout}=${NONE}
+    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${download_timeout}=600s
     Set Up Test OpenShift Project    test_ns=${namespace}
     IF    ${download_in_pvc}
         Create PVC And Download Model From S3    model_name=${model_name}    namespace=${namespace}    bucket_name=${MODELS_BUCKET.NAME}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -125,7 +125,7 @@ Create Secret For S3-Like Buckets
 Compile Inference Service YAML
     [Documentation]    Prepare the Inference Service YAML file in order to deploy a model
     [Arguments]    ${isvc_name}    ${model_storage_uri}    ${model_format}=caikit    ${serving_runtime}=caikit-tgis-runtime
-    ...            ${sa_name}=${DEFAULT_BUCKET_SA_NAME}    ${canaryTrafficPercent}=${EMPTY}    ${min_replicas}=1
+    ...            ${kserve_mode}=Serverless    ${sa_name}=${DEFAULT_BUCKET_SA_NAME}    ${canaryTrafficPercent}=${EMPTY}    ${min_replicas}=1
     ...            ${scaleTarget}=1    ${scaleMetric}=concurrency  ${auto_scale}=${NONE}
     ...            ${requests_dict}=&{EMPTY}    ${limits_dict}=&{EMPTY}
     IF   '${auto_scale}' == '${NONE}'
@@ -160,6 +160,9 @@ Compile Inference Service YAML
             Should Be Equal As Integers    ${rc}    ${0}    msg=${out}
         END
     END
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    yq -i '.metadata.annotations."serving.kserve.io/deploymentMode" = "${kserve_mode}"' ${INFERENCESERVICE_FILLED_FILEPATH}    # robocop: disable
+    Should Be Equal As Integers    ${rc}    ${0}    msg=${out}
 
 Model Response Should Match The Expectation
     [Documentation]    Checks that the actual model response matches the expected answer.

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -1,0 +1,57 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: ${model_name}-claim
+spec:
+  accessModes:
+    - ReadWriteOnce
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 100Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: download-${model_name}
+labels:
+  name: download-${model_name}
+spec:
+  volumes:
+    - name: model-volume
+      persistentVolumeClaim:
+        claimName: ${model_name}-claim
+  restartPolicy: Never
+  initContainers:
+    - name: fix-volume-permissions
+      image: quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d 
+      command: ["sh"]
+      args: ["-c", "mkdir -p /mnt/models/${model_name} && chmod -R 777 /mnt/models"]
+      volumeMounts:
+        - mountPath: "/mnt/models/"
+          name: model-volume
+  containers:
+    - name: download-model
+      imagePullPolicy: IfNotPresent
+      image: quay.io/modh/kserve-storage-initializer@sha256:330af2d517b17dbf0cab31beba13cdbe7d6f4b9457114dea8f8485a011e3b138
+      args:
+        - 's3://ods-ci-wisdom/${model_name}'
+        - /mnt/models/${model_name}
+      env:
+        - name: AWS_ACCESS_KEY_ID
+          value: ${access_key_id}
+        - name: AWS_SECRET_ACCESS_KEY
+          value: ${secret_access_key}
+        - name: BUCKET_NAME
+          value: ${bucket_name}
+        - name: S3_USE_HTTPS
+          value: ${use_https}
+        - name: S3_ENDPOINT
+          value: ${endpoint}
+        - name: awsAnonymousCredential
+          value: 'false'
+        - name: AWS_DEFAULT_REGION
+          value: ${region}
+      volumeMounts:
+        - mountPath: "/mnt/models/"
+          name: model-volume

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -8,7 +8,7 @@ spec:
   volumeMode: Filesystem
   resources:
     requests:
-      storage: 100Gi
+      storage: ${storage_size}
 ---
 apiVersion: v1
 kind: Pod

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -14,8 +14,8 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: download-${model_name}
-labels:
-  name: download-${model_name}
+  labels:
+    name: download-${model_name}
 spec:
   volumes:
     - name: model-volume
@@ -41,7 +41,7 @@ spec:
         - name: AWS_ACCESS_KEY_ID
           value: ${access_key_id}
         - name: AWS_SECRET_ACCESS_KEY
-          value: ${secret_access_key}
+          value: ${access_key}
         - name: BUCKET_NAME
           value: ${bucket_name}
         - name: S3_USE_HTTPS

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -35,7 +35,7 @@ spec:
       imagePullPolicy: IfNotPresent
       image: quay.io/modh/kserve-storage-initializer@sha256:330af2d517b17dbf0cab31beba13cdbe7d6f4b9457114dea8f8485a011e3b138
       args:
-        - 's3://ods-ci-wisdom/${model_name}'
+        - 's3://$(BUCKET_NAME)/${model_name}'
         - /mnt/models/${model_name}
       env:
         - name: AWS_ACCESS_KEY_ID

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -34,6 +34,17 @@
                     "streamed_response_text":   "{'details':{'input_token_count':'10'}}{'generated_text':'This','tokens':[{'text':'▁This','logprob':<logprob_removed>}],'details':{'generated_tokens':1}}{'generated_text':'is','tokens':[{'text':'▁is','logprob':<logprob_removed>}],'details':{'generated_tokens':2}}{'generated_text':'','tokens':[{'text':'▁','logprob':<logprob_removed>}],'details':{'generated_tokens':3}}{'generated_text':'a','tokens':[{'text':'a','logprob':<logprob_removed>}],'details':{'generated_tokens':4}}{'generated_text':'very','tokens':[{'text':'▁very','logprob':<logprob_removed>}],'details':{'generated_tokens':5}}{'generated_text':'wrong','tokens':[{'text':'▁wrong','logprob':<logprob_removed>}],'details':{'generated_tokens':6}}{'generated_text':'phrase','tokens':[{'text':'▁phrase','logprob':<logprob_removed>}],'details':{'generated_tokens':7}}{'generated_text':'.','tokens':[{'text':'.','logprob':<logprob_removed>}],'details':{'generated_tokens':8}}{'tokens':[{'text':'</s>','logprob':<logprob_removed>}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':9}}"
                 }
             }
+        },
+        {
+            "query_text": "Elementary Watson! Translate to French",
+            "models": {
+                "mt0-xxl-hf": {
+                    "response_tokens":  13,
+                    "response_text": "Watson, c'est très simple !",
+                    "streamed_response_text":   "{ 'inputTokenCount': 10 } { 'generatedTokenCount': 1, 'text': 'temperature' } { 'generatedTokenCount': 2, 'text': ' of' } { 'generatedTokenCount': 3, 'text': ' 180' } { 'generatedTokenCount': 4, 'text': ' ' } { 'generatedTokenCount': 5, 'text': '°' } { 'generatedTokenCount': 6, 'text': 'C' } { 'generatedTokenCount': 7, 'stopReason': 'EOS_TOKEN' }"
+                }
+            }
+
         }
     ]
 }

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
@@ -18,32 +18,6 @@ spec:
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache
-      # resources: # configure as required
-      #   requests:
-      #     cpu: 8
-      #     memory: 16Gi
-
-      ## NOTE: can't use grpc probes with knative-serving <1.12, so we will
-      ## probe the health endpoint for the http server instead
-      # livenessProbe:
-      #   grpc:
-      #     port: 8033
-      # readinessProbe:
-      #   grpc:
-      #     port: 8033
-      readinessProbe: # Use exec probes instad of httpGet since the probes' port gets rewritten to the containerPort
-        exec:
-          command:
-            - curl
-            - localhost:3000/health
-        initialDelaySeconds: 5
-      livenessProbe:
-        exec:
-          command:
-            - curl
-            - localhost:3000/health
-        initialDelaySeconds: 5
-        # periodSeconds: 5
       ports:
         - containerPort: 8033
           name: h2c

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -115,7 +115,25 @@ Wait For Pods To Be Ready
     ...    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
     IF    ${rc} != ${0}
         ${events}    ${podlogs}=    Get Events And Pod Logs    ${namespace}    ${label_selector}
+
         Fail    msg=Pod is not ready by timeout
+    END
+    IF    "${exp_replicas}" != "${NONE}"
+        @{replicas}=    Oc Get    kind=Pod    namespace=${namespace}
+        ...    label_selector=${label_selector}
+        Length Should Be  ${replicas}  ${exp_replicas}
+    END
+
+Wait For Pods To Succeed
+    [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}
+    Wait Until Keyword Succeeds    ${timeout}    3s
+    ...    Check If Pod Exists    namespace=${namespace}    label_selector=${label_selector}
+    ...    status_only=${FALSE}
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    oc wait --for=jsonpath='{.status.phase}'=Succeeded pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
+    IF    ${rc} != ${0}
+        ${events}    ${podlogs}=    Get Events And Pod Logs    ${namespace}    ${label_selector}
+        Fail    msg=Pod did not succeed by timeout
     END
     IF    "${exp_replicas}" != "${NONE}"
         @{replicas}=    Oc Get    kind=Pod    namespace=${namespace}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -213,8 +213,8 @@ Click Minus Button
 
 Query Model With GRPCURL
     [Arguments]    ${host}    ${port}    ${endpoint}    ${json_body}
-    ...            ${json_header}=${NONE}    ${insecure}=${FALSE}    ${background}=${NONE}
-    ...            ${skip_res_json}=${FALSE}    &{args}
+    ...            ${json_header}=${NONE}    ${insecure}=${FALSE}    ${plaintext}=${FALSE}
+    ...            ${background}=${NONE}    ${skip_res_json}=${FALSE}    &{args}
     ${cmd}=    Set Variable    grpcurl -d ${json_body}
     IF    $json_header != None
         ${cmd}=    Catenate    ${cmd}    -H ${json_header}
@@ -222,9 +222,9 @@ Query Model With GRPCURL
     IF    ${insecure} == ${TRUE}
         ${cmd}=    Catenate    ${cmd}    -insecure
     END
-    # IF    ${plaintext} == ${TRUE}
-    #     ${cmd}=    Catenate    ${cmd}    -plaintext
-    # END
+    IF    ${plaintext} == ${TRUE}
+        ${cmd}=    Catenate    ${cmd}    -plaintext
+    END
     # IF    "${proto_filepath}" != "${NONE}"
     #     ${cmd}=    Catenate    ${cmd}    -proto ${proto_filepath}
     # END
@@ -235,11 +235,13 @@ Query Model With GRPCURL
     ${cmd}=    Catenate    ${cmd}    ${host}:${port}
     ${cmd}=    Catenate    ${cmd}    ${endpoint}
     IF   '${background}' == '${NONE}'
-          ${rc}    ${response}=    Run And Return Rc And Output    ${cmd}
-          # ${query_process}=    Run Process    command=${cmd}    stderr=STDOUT    cwd=${PROTO_DIRPATH}    shell=yes
+          # ${rc}    ${response}=    Run And Return Rc And Output    ${cmd}
+          ${query_process}=    Run Process    command=${cmd}    stderr=STDOUT  shell=yes
           # Run Keyword And Continue On Failure    Should Be Equal As Integers    ${query_process.rc}    ${0}
+          ${rc}=    Set Variable    ${query_process.rc}
           Run Keyword And Continue On Failure    Should Be Equal As Integers    ${rc}    ${0}
           # Log    ${query_process.stdout}    console=yes
+          ${response}=    Set Variable    ${query_process.stdout}
           Log    ${response}    console=yes
           # ${json_res}=    Load Json String    ${query_process.stdout}
           IF    ${skip_res_json} == ${TRUE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -26,7 +26,8 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     Setup Test Variables    model_name=mt0-xxl-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
-    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}    
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}  
+    ...    storage_size=70Gi  
     Compile Inference Service YAML    isvc_name=${model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${storage_uri}
@@ -35,7 +36,7 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${test_namespace}
+    ...    namespace=${test_namespace}    timeout=900s
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
     ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
@@ -89,4 +90,3 @@ Start Port-forwarding
     [Arguments]    ${namespace}    ${model_name}
     ${process}=    Start Process    oc -n ${namespace} port-forward svc/${model_name}-predictor 8033:80
     ...    alias=llm-query-process    stderr=STDOUT    shell=yes
-

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -1,5 +1,5 @@
 *** Settings ***
-Documentation     Collection of CLI tests to validate the model serving stack for Large Language Models (LLM).
+Documentation     Collection of CLI tests to validate the model serving stack for different Large Language Models (LLM).
 ...               These tests leverage on TGIS Standalone Serving Runtime
 Resource          ../../../../Resources/OCP.resource
 Resource          ../../../../Resources/CLI/ModelServing/llm.resource

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -5,7 +5,7 @@ Resource          ../../../../Resources/OCP.resource
 Resource          ../../../../Resources/CLI/ModelServing/llm.resource
 Library            OpenShiftLibrary
 Suite Setup       Suite Setup
-Suite Teardown    RHOSi Teardown
+# Suite Teardown    RHOSi Teardown
 Test Tags         KServe
 
 
@@ -13,7 +13,7 @@ Test Tags         KServe
 ${TEST_NS}=    tgis-models
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
 ${USE_PVC}=    ${TRUE}
-${DOWNLOAD_IN_PVC}=    ${TRUE}
+${DOWNLOAD_IN_PVC}=    ${FALSE}
 ${USE_GPU}=    ${FALSE}
 
 
@@ -32,16 +32,16 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     ...    limits_dict=${limits}
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
-    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${test_namespace}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=all-tokens    n_times=1
-    ...    namespace=${test_namespace}    validate_response=${FALSE}    # temp
-    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=streaming    n_times=1
-    ...    namespace=${test_namespace}    validate_response=${FALSE}
-    [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    # Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    # ...    namespace=${test_namespace}
+    # Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    # ...    inference_type=all-tokens    n_times=1
+    # ...    namespace=${test_namespace}    validate_response=${FALSE}    # temp
+    # Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    # ...    inference_type=streaming    n_times=1
+    # ...    namespace=${test_namespace}    validate_response=${FALSE}
+    # [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
+    # ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 
 *** Keywords ***
@@ -54,19 +54,19 @@ Suite Setup
 
 Setup Test Variables
     [Arguments]    ${model_name}    ${use_pvc}=${FALSE}    ${use_gpu}=${FALSE}
-    ${model_name}=    Set Test Variable    ${model_name}
+    Set Test Variable    ${model_name}
     ${models_names}=    Create List    ${model_name}
-    ${models_names}=    Set Test Variable    ${models_names}
-    ${test_namespace}=    Set Test Variable     ${TEST_NS}-${model_name}
+    Set Test Variable    ${models_names}
+    Set Test Variable    ${test_namespace}     ${TEST_NS}-${model_name}
     IF    ${use_pvc}
-        ${storage_uri}=    Set Test Variable    pvc://${model_name}-claim/${model_name}
+        Set Test Variable    ${storage_uri}    pvc://${model_name}-claim/${model_name}
     ELSE
-        ${storage_uri}=    Set Test Variable    s3://${S3.BUCKET_3.NAME}/${model_name}
+        Set Test Variable    ${storage_uri}    s3://${S3.BUCKET_3.NAME}/${model_name}
     END
     IF   ${use_gpu}
         ${limits}=    Create Dictionary    nvidia.com/gpu=1
-        ${limits}=    Set Test Variable    ${limits}
+        Set Test Variable    ${limits}
     ELSE
-        ${limits}=    Set Test Variable    ${limits}    &{EMPTY}
+        Set Test Variable    ${limits}    &{EMPTY}
     END
     

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -12,23 +12,24 @@ Test Tags         KServe
 *** Variables ***
 ${TEST_NS}=    tgis-models
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
+${USE_PVC}=    ${TRUE}
+${DOWNLOAD_IN_PVC}=    ${TRUE}
+${USE_GPU}=    ${FALSE}
 
 
- 
 *** Test Cases ***
 Verify User Can Serve And Query A bigscience/mt0-xxl Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and Caikit+TGIS runtime
     [Tags]    Tier1
-    ${test_namespace}=    Set Variable     ${TEST_NS}-mt0-xxl
+    Setup Test Variables    model_name=mt0-xxl-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
-    ${model_name}=    Set Variable    mt0-xxl
-    ${models_names}=    Create List    ${model_name}
-    ${storage_uri}=    Set Variable    s3://${S3.BUCKET_3.NAME}/mt0-xxl
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}    
     Compile Inference Service YAML    isvc_name=${model_name}
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${storage_uri}
     ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
+    ...    limits_dict=${limits}
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
@@ -36,11 +37,11 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    validate_response=${FALSE}    # temp
-    # Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    # ...    inference_type=streaming    n_times=1
-    # ...    namespace=${test_namespace}    validate_response=${FALSE}
-    # [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
-    # ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=streaming    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${FALSE}
+    [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
 
 
 *** Keywords ***
@@ -50,3 +51,22 @@ Suite Setup
     #RHOSi Setup
     Load Expected Responses
     Run    git clone https://github.com/IBM/text-generation-inference/
+
+Setup Test Variables
+    [Arguments]    ${model_name}    ${use_pvc}=${FALSE}    ${use_gpu}=${FALSE}
+    ${model_name}=    Set Test Variable    ${model_name}
+    ${models_names}=    Create List    ${model_name}
+    ${models_names}=    Set Test Variable    ${models_names}
+    ${test_namespace}=    Set Test Variable     ${TEST_NS}-${model_name}
+    IF    ${use_pvc}
+        ${storage_uri}=    Set Test Variable    pvc://${model_name}-claim/${model_name}
+    ELSE
+        ${storage_uri}=    Set Test Variable    s3://${S3.BUCKET_3.NAME}/${model_name}
+    END
+    IF   ${use_gpu}
+        ${limits}=    Create Dictionary    nvidia.com/gpu=1
+        ${limits}=    Set Test Variable    ${limits}
+    ELSE
+        ${limits}=    Set Test Variable    ${limits}    &{EMPTY}
+    END
+    

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -13,9 +13,9 @@ Test Tags         KServe
 ${TEST_NS}=    tgis-models
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
 ${USE_PVC}=    ${TRUE}
-${DOWNLOAD_IN_PVC}=    ${FALSE}
+${DOWNLOAD_IN_PVC}=    ${TRUE}
 ${USE_GPU}=    ${FALSE}
-
+${KSERVE_MODE}=    RawDeployment
 
 *** Test Cases ***
 Verify User Can Serve And Query A bigscience/mt0-xxl Model
@@ -29,11 +29,11 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
     ...    model_storage_uri=${storage_uri}
     ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
-    ...    limits_dict=${limits}
+    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
-    # Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    # ...    namespace=${test_namespace}
+    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}
     # Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     # ...    inference_type=all-tokens    n_times=1
     # ...    namespace=${test_namespace}    validate_response=${FALSE}    # temp

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -1,0 +1,52 @@
+*** Settings ***
+Documentation     Collection of CLI tests to validate the model serving stack for Large Language Models (LLM).
+...               These tests leverage on TGIS Standalone Serving Runtime
+Resource          ../../../../Resources/OCP.resource
+Resource          ../../../../Resources/CLI/ModelServing/llm.resource
+Library            OpenShiftLibrary
+Suite Setup       Suite Setup
+Suite Teardown    RHOSi Teardown
+Test Tags         KServe
+
+
+*** Variables ***
+${TEST_NS}=    tgis-models
+${TGIS_RUNTIME_NAME}=    tgis-runtime
+
+
+ 
+*** Test Cases ***
+Verify User Can Serve And Query A bigscience/mt0-xxl Model
+    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
+    ...                using Kserve and Caikit+TGIS runtime
+    [Tags]    Tier1
+    ${test_namespace}=    Set Variable     ${TEST_NS}-mt0-xxl
+    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
+    ${model_name}=    Set Variable    mt0-xxl
+    ${models_names}=    Create List    ${model_name}
+    ${storage_uri}=    Set Variable    s3://${S3.BUCKET_3.NAME}/mt0-xxl
+    Compile Inference Service YAML    isvc_name=${model_name}
+    ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
+    ...    model_storage_uri=${storage_uri}
+    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
+    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
+    ...    namespace=${test_namespace}
+    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=all-tokens    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${FALSE}    # temp
+    # Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    # ...    inference_type=streaming    n_times=1
+    # ...    namespace=${test_namespace}    validate_response=${FALSE}
+    # [Teardown]    Clean Up Test Project    test_ns=${test_namespace}
+    # ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+
+
+*** Keywords ***
+Suite Setup
+    [Documentation]
+    Skip If Component Is Not Enabled    kserve
+    #RHOSi Setup
+    Load Expected Responses
+    Run    git clone https://github.com/IBM/text-generation-inference/

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -22,7 +22,7 @@ ${KSERVE_MODE}=    RawDeployment
 Verify User Can Serve And Query A bigscience/mt0-xxl Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and Caikit+TGIS runtime
-    [Tags]    Tier1
+    [Tags]    Tier1    RHOAIENG-3477
     Setup Test Variables    model_name=mt0-xxl-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -27,9 +27,9 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     ...    kserve_mode=${KSERVE_MODE}
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
     ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}  
-    ...    storage_size=70Gi  
+    ...    storage_size=70Gi 
     Compile Inference Service YAML    isvc_name=${model_name}
-    ...    sa_name=${DEFAULT_BUCKET_SA_NAME}
+    ...    sa_name=${EMPTY}
     ...    model_storage_uri=${storage_uri}
     ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
     ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
@@ -58,7 +58,7 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
 Suite Setup
     [Documentation]
     Skip If Component Is Not Enabled    kserve
-    #RHOSi Setup
+    RHOSi Setup
     Load Expected Responses
     Run    git clone https://github.com/IBM/text-generation-inference/
 


### PR DESCRIPTION
Implementations:
1. set Raw deployment mode at ISVC level
2. implement logic to query via port-forwarding instead of Route - _needs to be further extended to be able to query with service URL instead of localhost (for future PRs)_
3. add test case for bigscience/mt0-xxl (will be deprecated soon, but could be a guideline to add tests for other models)


Validation of the PR:
- validated locally the new code + regression tests on previous TGIS suite which leveraged on Serverless deployment
- on CI was having issues, will try again