### PR TITLE
Reapply "Add support for kueue component"

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -16,6 +16,8 @@ spec:
       managementState: <modelmeshserving_value>
     ray:
       managementState: <ray_value>
+    kueue:
+      managementState: <kueue_value>
     trustyai:
       managementState: <trustyai_value>
     workbenches:

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -8,7 +8,7 @@ Resource   ../../../../tests/Resources/Page/OCPDashboard/UserManagement/Groups.r
 
 *** Variables ***
 ${DSC_NAME} =    default-dsc
-@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai  # robocop: disable
+@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai    kueue  # robocop: disable
 ${SERVERLESS_OP_NAME}=     serverless-operator
 ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless


### PR DESCRIPTION
This reverts commit 1d915ec15be7cd3acc1a715c7377202c149f9034 (#1200).

Kueue is planned to be back in RHOAI 2.8 [1].

* [1] https://issues.redhat.com/browse/RHOAIENG-3234