### PR TITLE
Option to use KUBECONFIG when running ODS-CI Image

### DIFF
--- a/ods_ci/build/run.sh
+++ b/ods_ci/build/run.sh
@@ -1,28 +1,32 @@
 #!/bin/bash
+set -e
+
 echo RUN SCRIPT ARGS: "${RUN_SCRIPT_ARGS}"
 echo ROBOT EXTRA ARGS: "${ROBOT_EXTRA_ARGS}"
 echo SET TEST ENVIRONMENT: "${SET_ENVIRONMENT}"
 echo -- USE OCM to install IDPs: "${USE_OCM_IDP}"
 
+echo "Set Kubeconfig file path to: ${KUBECONFIG}"
+export "KUBECONFIG=${KUBECONFIG}"
+
 # feature requested for MPS pipeline onboarding
-if [ "${SET_ENVIRONMENT}" -eq 1 ]; then \
-  if [ -z "${OC_HOST}" ]
-      then
-        echo -e "\033[0;33m You must set the OC_HOST env variable to automatically set the Test Environment for ODS-CI \033[0m"
+if [ "${SET_ENVIRONMENT}" -eq 1 ]; then
+  if [ -z "${OC_HOST}" ]; then
+    echo -e "\033[0;33m You must set the OC_HOST env variable to automatically set the Test Environment for ODS-CI \033[0m"
+    exit 0
+  else
+    if [ "${USE_OCM_IDP}" -eq 0 ]; then
+      actual_host="$(oc whoami --show-server)"
+      if [ -z "${RUN_FROM_CONTAINER}" ] && [ "${actual_host}" != "${OC_HOST}" ]; then
+        echo "-----| USE_OCM_IDP option is disabled, but you are connected to a different cluster than ${OC_HOST}. To prevent you to change IDPs of the wrong cluster, ODS-CI stops here... |-----"
         exit 0
-      else
-        if [ "${USE_OCM_IDP}" -eq 0 ]
-          then
-            actual_host="$(oc whoami --show-server)"
-            if [ -z "${RUN_FROM_CONTAINER}" ]  && [ "${actual_host}" != "${OC_HOST}" ]
-              then
-                  echo "-----| USE_OCM_IDP option is disabled, but you are connected to a different cluster than ${OC_HOST}. To prevent you to change IDPs of the wrong cluster, ODS-CI stops here...|-----"
-                  exit 0
-            fi
-        fi
-        echo "-----| SET_ENVIRONMENT option is enabled. ODS-CI is going to configure the test environment for you..|-----"
-        ./ods_ci/build/install_idp.sh
+      fi
+    fi
+      echo "-----| SET_ENVIRONMENT option is enabled. ODS-CI is going to create IDP users |-----"
+      ./ods_ci/build/install_idp.sh
   fi
+else
+  echo "-----| SET_ENVIRONMENT option is disabled. Skipping test environment setup |-----"
 fi
 echo "-----| ODS-CI is starting the tests run...|-----"
 ./ods_ci/run_robot_test.sh --skip-install ${RUN_SCRIPT_ARGS} --extra-robot-args "${ROBOT_EXTRA_ARGS}"

--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -268,7 +268,7 @@ if command -v yq &> /dev/null
                     then
                         oc_host=${api_server}
                     else
-                        oc_host=$(yq -er '.OCP_API_URL' "${TEST_VARIABLES_FILE}") || {
+                        oc_host=$(yq -e '.OCP_API_URL' "${TEST_VARIABLES_FILE}") || {
                             echo "Couldn't find '.OCP_API_URL' variable in provided '${TEST_VARIABLES_FILE}'."
                             echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
                             exit 1
@@ -279,12 +279,12 @@ if command -v yq &> /dev/null
                 if [ -z "${SERVICE_ACCOUNT}" ]
                     then
                         echo "Performing oc login using username and password"
-                        oc_user=$(yq -er '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}") || {
+                        oc_user=$(yq -e '.OCP_ADMIN_USER.USERNAME' "${TEST_VARIABLES_FILE}") || {
                             echo "Couldn't find '.OCP_ADMIN_USER.USERNAME' variable in provided '${TEST_VARIABLES_FILE}'."
                             echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
                             exit 1
                         }
-                        oc_pass=$(yq -er '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}") || {
+                        oc_pass=$(yq -e '.OCP_ADMIN_USER.PASSWORD' "${TEST_VARIABLES_FILE}") || {
                             echo "Couldn't find '.OCP_ADMIN_USER.PASSWORD' variable in provided '${TEST_VARIABLES_FILE}'."
                             echo "Please either provide it or use '--skip-oclogin true' (don't forget to login to the testing cluster manually then)."
                             exit 1


### PR DESCRIPTION
- Add option to use KUBECONFIG when calling ods_ci/build/run.sh

- Fix yq commands for yq version 4.25 (-r is not supported)

Running example:

```
podman run --rm \
-v $PWD/.setup/test-variables.yml:/tmp/ods-ci/ods_ci/test-variables.yml:Z \
-v $PWD/ods_ci/test-output:/tmp/ods-ci/ods_ci/test-output:Z \
-v ${KUBECONFIG}:/tmp/kubeconfig:Z -e KUBECONFIG=/tmp/kubeconfig \
-e RUN_SCRIPT_ARGS='--skip-oclogin true' \
-e ROBOT_EXTRA_ARGS='--include smoke' \
-e SET_ENVIRONMENT=1 -e USE_OCM_IDP=0 \
-e OC_HOST='https://api.rhoai-cluster:6443' \
ods-ci:latest
```

Output:
```
RUN SCRIPT ARGS: --skip-oclogin true
ROBOT EXTRA ARGS: --include smoke
SET TEST ENVIRONMENT: 1
-- USE OCM to install IDPs: 0
Set Kubeconfig file path to: /tmp/kubeconfig
-----| SET_ENVIRONMENT option is enabled. ODS-CI is going to create IDP users |-----
Stage) validating user_config.json
user_config.json found! Starting json validation..
--> Going through requested users configuration
validating prefix: htp-user-
--> suffix type: incremental_with_rand_base
validating prefix: htp-basic-user-
--> suffix type: incremental_with_rand_base
--> Going through requested users configuration

validating prefix: ldap-op-
--> suffix type: incremental_with_rand_base
validating prefix: ldap-usr-
--> suffix type: incremental_with_rand_base
validating prefix: ldap-noaccess-
--> suffix type: incremental_with_rand_base
validating prefix: ldap-special
--> suffix type: custom
-----| ODS-CI is starting the tests run...|-----
ods_ci/test-variables.yml
INFO: we found a yq executable
skipping OC login as per parameter --skip-oclogin
```