### PR TITLE
Raise the timeout for wait of the CatalogSource to be ready.

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -292,7 +292,7 @@ Wait for Catalog To Be Ready
     [Arguments]    ${namespace}=openshift-marketplace   ${catalog_name}=odh-catalog-dev   ${timeout}=30
     Log    Waiting for the '${catalog_name}' CatalogSource in '${namespace}' namespace to be in 'Ready' status state
     ...    console=yes
-    Wait Until Keyword Succeeds    6 times   10 seconds
+    Wait Until Keyword Succeeds    12 times   10 seconds
     ...   Catalog Is Ready    ${namespace}   ${catalog_name}
     Log    CatalogSource '${catalog_name}' in '${namespace}' namespace in 'Ready' status now, let's continue
     ...    console=yes


### PR DESCRIPTION
Looks like our current setup to wait 60 seconds still isn't enough as some the runs fails on this wait. Let's double this up to 120 seconds then.

CI: exploratory-test-rhods-deploy/272