### PR TITLE
Add test for  ELYZA-japanese-Llama-2-7b-instruct

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -59,13 +59,13 @@ Set Project And Runtime
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}    ${runtime}=caikit-tgis-runtime    ${protocol}=grpc
     ...            ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}
     ...            ${endpoint}=${MODELS_BUCKET.ENDPOINT}    ${verify_ssl}=${TRUE}
-    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${download_timeout}=600s
+    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${model_path}=${NONE}    ${download_timeout}=600s
     Set Up Test OpenShift Project    test_ns=${namespace}
     IF    ${download_in_pvc}
         Create PVC And Download Model From S3    model_name=${model_name}    namespace=${namespace}    bucket_name=${MODELS_BUCKET.NAME}
         ...    endpoint=${MODELS_BUCKET.ENDPOINT}    region=${MODELS_BUCKET.REGION}    access_key_id=${S3.AWS_ACCESS_KEY_ID}
         ...    access_key=${S3.AWS_SECRET_ACCESS_KEY}    use_https=${USE_BUCKET_HTTPS}    download_timeout=${download_timeout}
-        ...    storage_size=${storage_size}
+        ...    storage_size=${storage_size}    model_path=${model_path}
     ELSE
         Create Secret For S3-Like Buckets    endpoint=${endpoint}
         ...    region=${MODELS_BUCKET.REGION}    namespace=${namespace}
@@ -629,7 +629,7 @@ Create PVC And Download Model From S3
     [Arguments]    ${model_name}    ${bucket_name}    ${endpoint}
     ...            ${region}    ${access_key_id}    ${access_key}
     ...            ${use_https}    ${namespace}    ${storage_size}
-    ...            ${download_timeout}=500s
+    ...            ${model_path}    ${download_timeout}=500s
     Set Log Level    NONE
     Set Test Variable    ${model_name}
     Set Test Variable    ${bucket_name}
@@ -640,6 +640,7 @@ Create PVC And Download Model From S3
     Set Test Variable    ${use_https}
     Set Test Variable    ${namespace}
     Set Test Variable    ${storage_size}
+    Set Test Variable    ${model_path}
     Set Log Level    INFO
     Create File From Template    ${DOWNLOAD_PVC_FILEPATH}    ${DOWNLOAD_PVC_FILLED_FILEPATH}
     ${rc}    ${out}=    Run And Return Rc And Output    oc -n ${namespace} apply -f ${DOWNLOAD_PVC_FILLED_FILEPATH}

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -59,12 +59,12 @@ End Non JupyterLab Web Test
 Load Json File
     [Arguments]   ${file_path}
     ${j_file}=    Get File    ${file_path}
-    ${obj}=    Evaluate    json.loads('''${j_file}''')    json
+    ${obj}=    Evaluate    json.loads(r'''${j_file}''')    json
     RETURN    ${obj}
 
 Load Json String
     [Arguments]     ${json_string}
-    ${obj}=     Evaluate  json.loads("""${json_string}""")
+    ${obj}=     Evaluate  json.loads(r"""${json_string}""")
     RETURN    ${obj}
 
 Create File From Template

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -26,7 +26,7 @@ spec:
     - name: fix-volume-permissions
       image: quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d 
       command: ["sh"]
-      args: ["-c", "mkdir -p /mnt/models/${model_name} && chmod -R 777 /mnt/models"]
+      args: ["-c", "mkdir -p /mnt/models/${model_path} && chmod -R 777 /mnt/models"]
       volumeMounts:
         - mountPath: "/mnt/models/"
           name: model-volume
@@ -35,8 +35,8 @@ spec:
       imagePullPolicy: IfNotPresent
       image: quay.io/modh/kserve-storage-initializer@sha256:330af2d517b17dbf0cab31beba13cdbe7d6f4b9457114dea8f8485a011e3b138
       args:
-        - 's3://$(BUCKET_NAME)/${model_name}'
-        - /mnt/models/${model_name}
+        - 's3://$(BUCKET_NAME)/${model_path}'
+        - /mnt/models/${model_path}
       env:
         - name: AWS_ACCESS_KEY_ID
           value: ${access_key_id}

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -35,7 +35,7 @@ spec:
       imagePullPolicy: IfNotPresent
       image: quay.io/modh/kserve-storage-initializer@sha256:330af2d517b17dbf0cab31beba13cdbe7d6f4b9457114dea8f8485a011e3b138
       args:
-        - 's3://$(BUCKET_NAME)/${model_path}'
+        - 's3://$(BUCKET_NAME)/${model_path}/'
         - /mnt/models/${model_path}
       env:
         - name: AWS_ACCESS_KEY_ID

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -64,7 +64,7 @@
         {
             "query_text": "桜の木についての話を書く",
             "models": {
-                "elyza-japanese-llama-2-7b-instruct-hf": {
+                "elyza-japanese": {
                     "response_tokens":  20,
                     "response_text": "。\n桜の木は、桜の花が咲くと",
                     "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -60,6 +60,17 @@
                     "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }"
                 }
             }
+        },
+        {
+            "query_text": "桜の木についての話を書く",
+            "models": {
+                "elyza-japanese-llama-2-7b-instruct-hf": {
+                    "response_tokens":  20,
+                    "response_text": "。\n桜の木は、桜の花が咲くと",
+                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
+
+                }
+            }
         }
     ]
 }

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -10,7 +10,7 @@ Test Tags         KServe
 
 
 *** Variables ***
-${TEST_NS}=    tgis-models
+${TEST_NS}=    tgismodel
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
 ${USE_PVC}=    ${TRUE}
 ${DOWNLOAD_IN_PVC}=    ${TRUE}
@@ -126,7 +126,7 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and TGIS standalone runtime
     [Tags]    Tier1    RHOAIENG-3479
-    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
+    Setup Test Variables    model_name=elyza-japanese    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
     ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -122,6 +122,39 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
+Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
+    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
+    ...                using Kserve and TGIS standalone runtime
+    [Tags]    Tier1    RHOAIENG-3479
+    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
+    ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
+    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
+    ...    storage_size=70Gi    model_path=${model_path}
+    Compile Inference Service YAML    isvc_name=${model_name}
+    ...    sa_name=${EMPTY}
+    ...    model_storage_uri=${storage_uri}
+    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
+    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
+    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
+    ...    namespace=${test_namespace}
+    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}    timeout=900s
+    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
+    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=all-tokens    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=streaming    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
+    ...    port_forwarding=${use_port_forwarding}
+    [Teardown]    Run Keywords
+    ...    Clean Up Test Project    test_ns=${test_namespace}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    ...    AND
+    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
 
 *** Keywords ***
 Suite Setup
@@ -133,14 +166,16 @@ Suite Setup
 
 Setup Test Variables
     [Arguments]    ${model_name}    ${kserve_mode}=Serverless    ${use_pvc}=${FALSE}    ${use_gpu}=${FALSE}
+    ...    ${model_path}=${model_name}
     Set Test Variable    ${model_name}
     ${models_names}=    Create List    ${model_name}
     Set Test Variable    ${models_names}
+    Set Test Variable    ${model_path}
     Set Test Variable    ${test_namespace}     ${TEST_NS}-${model_name}
     IF    ${use_pvc}
-        Set Test Variable    ${storage_uri}    pvc://${model_name}-claim/${model_name}
+        Set Test Variable    ${storage_uri}    pvc://${model_name}-claim/${model_path}
     ELSE
-        Set Test Variable    ${storage_uri}    s3://${S3.BUCKET_3.NAME}/${model_name}
+        Set Test Variable    ${storage_uri}    s3://${S3.BUCKET_3.NAME}/${model_path}
     END
     IF   ${use_gpu}
         ${limits}=    Create Dictionary    nvidia.com/gpu=1

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -144,11 +144,11 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
+    ...    namespace=${test_namespace}   query_idx=4    validate_response=${TRUE}    # temp
     ...    port_forwarding=${use_port_forwarding}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=streaming    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
+    ...    namespace=${test_namespace}    query_idx=4    validate_response=${FALSE}
     ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}


### PR DESCRIPTION
1. adding the test case for Elyza llama model
2. adding model_path variable to unbind the model path from model name (wasn't working for this model)
3. making keyword to read json files and string reading data as "raw" - this model is returning "\n" in the responses (like other models as well) and this was breaking the code.

PR validation (including regression): 
`rhods-ci-pr-test/2561` - regression OK - the failures are automation bug not related to this PR
 `rhods-ci-pr-test/2565` PASS - only Elyza TC