### PR TITLE
fix: New xpath on model serving runtime selection dropdown

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -92,6 +92,6 @@ Select Model Serving Platform
     [Documentation]    Selects which model serving platform the serving runtime could be executed on
     [Arguments]    ${platform}="both"
     ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
-    SeleniumLibrary.Click Element    css:div#custom-serving-runtime-selection > button
+    SeleniumLibrary.Click Element    xpath://div[@data-testid="custom-serving-runtime-selection"]//button
     SeleniumLibrary.Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]
     SeleniumLibrary.Click Link    ${platform_link_name}


### PR DESCRIPTION
The xpath for the Model Serving selection dropdown has changed in the 2.8

Fix for tests:
- ODS-2276: Verify RHODS Admins Can Import A Custom Serving Runtime Template By Uploading A YAML file
- ODS-2279: Verify RHODS Admins Can Delete A Custom Serving Runtime Template


![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/5ab6ad21-1145-4a4f-ae60-4fc5e4661b2b)
