### PR TITLE
Add query to ModelInfo and Tokenize endpoints

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -207,7 +207,12 @@ Model Response Should Be
     ${cleaned_response_text}=    Replace String Using Regexp    ${response}    \\s+    ${SPACE}
     ${rc}    ${cleaned_response_text}=    Run And Return Rc And Output    echo -e '${cleaned_response_text}'
     ${cleaned_response_text}=    Replace String Using Regexp    ${cleaned_response_text}    "    '
-    ${cleaned_exp_response_text}=    Replace String Using Regexp    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]    \\s+    ${SPACE}    # robocop: disable
+    IF    "${inference_type}" == "model-info"
+        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]
+    ELSE
+        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[${inference_type}][${model_name}]
+    END
+    ${cleaned_exp_response_text}=    Replace String Using Regexp    ${exp_response}    \\s+    ${SPACE}    # robocop: disable
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${cleaned_response_text}    ${cleaned_exp_response_text}
 
 Load Runtime Query Formats

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -208,9 +208,9 @@ Model Response Should Be
     ${rc}    ${cleaned_response_text}=    Run And Return Rc And Output    echo -e '${cleaned_response_text}'
     ${cleaned_response_text}=    Replace String Using Regexp    ${cleaned_response_text}    "    '
     IF    "${inference_type}" == "model-info"
-        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]
-    ELSE
         ${exp_response}=    Set Variable    ${EXP_RESPONSES}[${inference_type}][${model_name}]
+    ELSE
+        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]
     END
     ${cleaned_exp_response_text}=    Replace String Using Regexp    ${exp_response}    \\s+    ${SPACE}    # robocop: disable
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${cleaned_response_text}    ${cleaned_exp_response_text}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -202,6 +202,14 @@ Model Response Should Match The Expectation
         Should Be Equal    ${cleaned_response_text}    ${cleaned_exp_response_text}
     END
 
+Model Response Should Be
+    [Arguments]    ${response}    ${model_name}    ${inference_type}    ${query_idx}=${0}
+    ${cleaned_response_text}=    Replace String Using Regexp    ${response}    \\s+    ${SPACE}
+    ${rc}    ${cleaned_response_text}=    Run And Return Rc And Output    echo -e '${cleaned_response_text}'
+    ${cleaned_response_text}=    Replace String Using Regexp    ${cleaned_response_text}    "    '
+    ${cleaned_exp_response_text}=    Replace String Using Regexp    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]    \\s+    ${SPACE}    # robocop: disable
+    Run Keyword And Continue On Failure    Should Be Equal As Strings    ${cleaned_response_text}    ${cleaned_exp_response_text}
+
 Load Runtime Query Formats
     [Documentation]    Loads the json file containing the expected query format for each
     ...                serving runtime
@@ -255,13 +263,13 @@ Query Model Multiple Times
     ...                  - streaming: it returns the streamed generated response (i.e., one word per time)
     [Arguments]    ${model_name}    ${namespace}    ${runtime}=caikit-tgis-runtime    ${isvc_name}=${model_name}
     ...            ${inference_type}=all-tokens    ${n_times}=10    ${query_idx}=0    ${validate_response}=${TRUE}
-    ...            ${protocol}=grpc    ${port_forwarding}=${FALSE}    ${port}=443    &{args}
+    ...            ${string_check_only}=${FALSE}    ${protocol}=grpc    ${port_forwarding}=${FALSE}    ${port}=443    &{args}
     IF    "${inference_type}" == "streaming"
         ${streamed_response}=    Set Variable    ${TRUE}
     ELSE
         ${streamed_response}=    Set Variable    ${FALSE}
     END
-    IF    ${validate_response} == ${FALSE}
+    IF    ${validate_response} == ${FALSE} or ${string_check_only}
         ${skip_json_load_response}=    Set Variable    ${TRUE}
     ELSE
         ${skip_json_load_response}=    Set Variable    ${streamed_response}    # always skip if using streaming endpoint
@@ -306,15 +314,20 @@ Query Model Multiple Times
         END
         Log    ${res}
         IF    ${validate_response} == ${TRUE}
-            ${response_container_field}=    Set Variable    ${runtime_details}[response_fields_map][response]
-            IF    "${response_container_field}" != "${EMPTY}"
-                # runtimes may support multiple queries per time. Here forcing to use only 1 for sake of simplicity.
-                ${res}=    Set Variable    ${res}[${response_container_field}][0]
+            IF    ${string_check_only}
+                Model Response Should Be    response=${res}    model_name=${model_name}    inference_type=${inference_type}
+                ...    query_idx=${query_idx}
+            ELSE
+                ${response_container_field}=    Set Variable    ${runtime_details}[response_fields_map][response]
+                IF    "${response_container_field}" != "${EMPTY}"
+                    # runtimes may support multiple queries per time. Here forcing to use only 1 for sake of simplicity.
+                    ${res}=    Set Variable    ${res}[${response_container_field}][0]
+                END
+                Run Keyword And Continue On Failure
+                ...    Model Response Should Match The Expectation    model_response=${res}    model_name=${model_name}
+                ...    runtime_details=${runtime_details}    runtime=${runtime}
+                ...    streamed_response=${streamed_response}    query_idx=${query_idx}
             END
-            Run Keyword And Continue On Failure
-            ...    Model Response Should Match The Expectation    model_response=${res}    model_name=${model_name}
-            ...    runtime_details=${runtime_details}    runtime=${runtime}
-            ...    streamed_response=${streamed_response}    query_idx=${query_idx}
         END
     END
 

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -59,7 +59,7 @@ Set Project And Runtime
     [Arguments]    ${namespace}    ${enable_metrics}=${FALSE}    ${runtime}=caikit-tgis-runtime    ${protocol}=grpc
     ...            ${access_key_id}=${S3.AWS_ACCESS_KEY_ID}    ${access_key}=${S3.AWS_SECRET_ACCESS_KEY}
     ...            ${endpoint}=${MODELS_BUCKET.ENDPOINT}    ${verify_ssl}=${TRUE}
-    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${model_path}=${NONE}    ${download_timeout}=600s
+    ...            ${download_in_pvc}=${FALSE}    ${storage_size}=70Gi    ${model_name}=${NONE}    ${model_path}=${model_name}    ${download_timeout}=600s
     Set Up Test OpenShift Project    test_ns=${namespace}
     IF    ${download_in_pvc}
         Create PVC And Download Model From S3    model_name=${model_name}    namespace=${namespace}    bucket_name=${MODELS_BUCKET.NAME}
@@ -203,14 +203,14 @@ Model Response Should Match The Expectation
     END
 
 Model Response Should Be
-    [Arguments]    ${response}    ${model_name}    ${inference_type}    ${query_idx}=${0}
+    [Arguments]    ${response}    ${model_name}    ${inference_type}    ${runtime}    ${query_idx}=${0}
     ${cleaned_response_text}=    Replace String Using Regexp    ${response}    \\s+    ${SPACE}
     ${rc}    ${cleaned_response_text}=    Run And Return Rc And Output    echo -e '${cleaned_response_text}'
     ${cleaned_response_text}=    Replace String Using Regexp    ${cleaned_response_text}    "    '
     IF    "${inference_type}" == "model-info"
-        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[${inference_type}][${model_name}]
+        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[${inference_type}][${model_name}][${runtime}]
     ELSE
-        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${inference_type}_response_text]
+        ${exp_response}=    Set Variable    ${EXP_RESPONSES}[queries][${query_idx}][models][${model_name}][${runtime}][${inference_type}_response_text]
     END
     ${cleaned_exp_response_text}=    Replace String Using Regexp    ${exp_response}    \\s+    ${SPACE}    # robocop: disable
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${cleaned_response_text}    ${cleaned_exp_response_text}
@@ -321,7 +321,7 @@ Query Model Multiple Times
         IF    ${validate_response} == ${TRUE}
             IF    ${string_check_only}
                 Model Response Should Be    response=${res}    model_name=${model_name}    inference_type=${inference_type}
-                ...    query_idx=${query_idx}
+                ...    runtime=${runtime}    query_idx=${query_idx}
             ELSE
                 ${response_container_field}=    Set Variable    ${runtime_details}[response_fields_map][response]
                 IF    "${response_container_field}" != "${EMPTY}"

--- a/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/download_model_in_pvc.yaml
@@ -24,7 +24,7 @@ spec:
   restartPolicy: Never
   initContainers:
     - name: fix-volume-permissions
-      image: quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d 
+      image: quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d
       command: ["sh"]
       args: ["-c", "mkdir -p /mnt/models/${model_path} && chmod -R 777 /mnt/models"]
       volumeMounts:

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -80,6 +80,17 @@
 
                 }
             }
+        },
+        {
+            "query_text": "桜の木についての話を書く",
+            "models": {
+                "elyza-japanese-llama-2-7b-instruct-hf": {
+                    "response_tokens":  20,
+                    "response_text": "。\n桜の木は、桜の花が咲くと",
+                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
+
+                }
+            }
         }
     ]
 }

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -84,7 +84,7 @@
         {
             "query_text": "桜の木についての話を書く",
             "models": {
-                "elyza-japanese-llama-2-7b-instruct-hf": {
+                "elyza-japanese": {
                     "response_tokens":  20,
                     "response_text": "。\n桜の木は、桜の花が咲くと",
                     "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -6,12 +6,14 @@
                 "flan-t5-small-caikit": {
                     "response_tokens":  5,
                     "response_text": "74 degrees F",
-                    "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}"
+                    "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}",
+                    "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
                 },
                 "flan-t5-small-hf": {
                     "response_tokens":  5,
                     "response_text": "74 degrees F",
-                    "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}"
+                    "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}",
+                    "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
                 },
                 "bloom-560m-caikit": {
                     "response_tokens":  20,
@@ -45,7 +47,8 @@
                 "mt0-xxl-hf": {
                     "response_tokens":  13,
                     "response_text": "Watson, c'est très simple !",
-                    "streamed_response_text":   "{ 'inputTokenCount': 10 } { 'generatedTokenCount': 1, 'text': 'temperature' } { 'generatedTokenCount': 2, 'text': ' of' } { 'generatedTokenCount': 3, 'text': ' 180' } { 'generatedTokenCount': 4, 'text': ' ' } { 'generatedTokenCount': 5, 'text': '°' } { 'generatedTokenCount': 6, 'text': 'C' } { 'generatedTokenCount': 7, 'stopReason': 'EOS_TOKEN' }"
+                    "streamed_response_text":   "{ 'inputTokenCount': 10 } { 'generatedTokenCount': 1, 'text': 'temperature' } { 'generatedTokenCount': 2, 'text': ' of' } { 'generatedTokenCount': 3, 'text': ' 180' } { 'generatedTokenCount': 4, 'text': ' ' } { 'generatedTokenCount': 5, 'text': '°' } { 'generatedTokenCount': 6, 'text': 'C' } { 'generatedTokenCount': 7, 'stopReason': 'EOS_TOKEN' }",
+                    "tokenize_response_text": ""
                 }
             }
 
@@ -95,13 +98,19 @@
         {
             "query_text": "桜の木についての話を書く",
             "models": {
-                "elyza-japanese-llama-2-7b-instruct-hf": {
+                "elyza-japanese": {
                     "response_tokens":  20,
                     "response_text": "。\n桜の木は、桜の花が咲くと",
-                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
-
+                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }",
+                    "tokenize_response_text": ""
                 }
             }
         }
-    ]
+    ],
+    "model-info": {
+        "flan-t5-small-hf": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }",
+        "flan-t5-small-caikit": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }",
+        "mt0-xxl-hf": "",
+        "elyza-japanese" : ""
+    }
 }

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -91,6 +91,17 @@
 
                 }
             }
+        },
+        {
+            "query_text": "桜の木についての話を書く",
+            "models": {
+                "elyza-japanese-llama-2-7b-instruct-hf": {
+                    "response_tokens":  20,
+                    "response_text": "。\n桜の木は、桜の花が咲くと",
+                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
+
+                }
+            }
         }
     ]
 }

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -7,14 +7,17 @@
                     "response_tokens":  5,
                     "response_text": "74 degrees F",
                     "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}",
-                    "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
+                    "tgis-runtime":{
+                        "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
+                    }
                 },
                 "flan-t5-small-hf": {
                     "response_tokens":  5,
                     "response_text": "74 degrees F",
                     "streamed_response_text":   "{'details':{'input_token_count':'8'}}{'tokens':[{'text':'▁','logprob':-1.6961838006973267}],'details':{'generated_tokens':1}}{'generated_text':'74','tokens':[{'text':'74','logprob':-3.250730037689209}],'details':{'generated_tokens':2}}{'generated_text':'degrees','tokens':[{'text':'▁degrees','logprob':-0.4324559271335602}],'details':{'generated_tokens':3}}{'generated_text':'F','tokens':[{'text':'▁F','logprob':-1.361091136932373}],'details':{'generated_tokens':4}}{'tokens':[{'text':'\u003c/s\u003e','logprob':-0.010431881994009018}],'details':{'finish_reason':'EOS_TOKEN','generated_tokens':5}}",
-                    "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
-                },
+                    "tgis-runtime":{
+                        "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 8, 'tokens': [ '▁At', '▁what', '▁temperature', '▁does', '▁water', '▁boil', '?', '\u003c/s\u003e' ] } ] }"
+                    }                },
                 "bloom-560m-caikit": {
                     "response_tokens":  20,
                     "response_text": "The temperature of water boiling depends on the temperature of the water. The boiling point of water is the"
@@ -27,7 +30,10 @@
                 "mpt-7b-instruct2": {
                     "response_tokens": 20,
                     "response_text": "\nWater boils at 100 degrees Celsius (or 212 degrees Fahrenheit).\nWhat",
-                    "streamed_response_text": "{    'inputTokenCount': 10}{    'generatedTokenCount': 2,    'text': '\n'}{    'generatedTokenCount': 3,    'text': 'I a'}{    'generatedTokenCount': 4,    'text': 'm no'}{    'generatedTokenCount': 5,    'text': 't sur'}{    'generatedTokenCount': 6,    'text': 'e i'}{    'generatedTokenCount': 7,    'text': 'f thi'}{    'generatedTokenCount': 8,    'text': 's i'}{    'generatedTokenCount': 9,    'text': 's th'}{    'generatedTokenCount': 10,    'text': 'e righ'}{    'generatedTokenCount': 11,    'text': 't plac'}{    'generatedTokenCount': 12,    'text': 'e t'}{    'generatedTokenCount': 13,    'text': 'o as'}{    'generatedTokenCount': 14,    'text': 'k thi'}{    'generatedTokenCount': 15,    'text': 's questio'}{    'generatedTokenCount': 16,    'text': 'n'}{    'generatedTokenCount': 17,    'text': ', bu'}{    'generatedTokenCount': 18,    'text': 't '}{    'generatedTokenCount': 19,    'text': 'I a'}{    'generatedTokenCount': 20,    'text': 'm trying',    'stopReason': 'MAX_TOKENS'}"
+                    "streamed_response_text": "{    'inputTokenCount': 10}{    'generatedTokenCount': 2,    'text': '\n'}{    'generatedTokenCount': 3,    'text': 'I a'}{    'generatedTokenCount': 4,    'text': 'm no'}{    'generatedTokenCount': 5,    'text': 't sur'}{    'generatedTokenCount': 6,    'text': 'e i'}{    'generatedTokenCount': 7,    'text': 'f thi'}{    'generatedTokenCount': 8,    'text': 's i'}{    'generatedTokenCount': 9,    'text': 's th'}{    'generatedTokenCount': 10,    'text': 'e righ'}{    'generatedTokenCount': 11,    'text': 't plac'}{    'generatedTokenCount': 12,    'text': 'e t'}{    'generatedTokenCount': 13,    'text': 'o as'}{    'generatedTokenCount': 14,    'text': 'k thi'}{    'generatedTokenCount': 15,    'text': 's questio'}{    'generatedTokenCount': 16,    'text': 'n'}{    'generatedTokenCount': 17,    'text': ', bu'}{    'generatedTokenCount': 18,    'text': 't '}{    'generatedTokenCount': 19,    'text': 'I a'}{    'generatedTokenCount': 20,    'text': 'm trying',    'stopReason': 'MAX_TOKENS'}",
+                    "tgis-runtime": {
+                        "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 7, 'tokens': [ 'At', 'Ġwhat', 'Ġtemperature', 'Ġdoes', 'Ġwater', 'Ġboil', '?' ] } ] }"
+                    }
                 }
             }
         },
@@ -48,10 +54,11 @@
                     "response_tokens":  13,
                     "response_text": "Watson, c'est très simple !",
                     "streamed_response_text":   "{ 'inputTokenCount': 10 } { 'generatedTokenCount': 1, 'text': 'temperature' } { 'generatedTokenCount': 2, 'text': ' of' } { 'generatedTokenCount': 3, 'text': ' 180' } { 'generatedTokenCount': 4, 'text': ' ' } { 'generatedTokenCount': 5, 'text': '°' } { 'generatedTokenCount': 6, 'text': 'C' } { 'generatedTokenCount': 7, 'stopReason': 'EOS_TOKEN' }",
-                    "tokenize_response_text": ""
+                    "tgis-runtime":{
+                        "tokenize_response_text": "{   'responses': [     {       'tokenCount': 9,       'tokens': [         '▁',         'Elementary',         '▁',         'Watson',         '!',         '▁Translate',         '▁to',         '▁French',         '\u003c/s\u003e'       ]     }   ] }"
+                    }
                 }
             }
-
         },
         {
             "query_text": "translate English to German: How old are you?",
@@ -59,38 +66,26 @@
                 "flan-t5-xl-hf": {
                     "response_tokens":  6,
                     "response_text": "Wie alt sind Sie?",
-                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }"
+                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }",
+                    "tgis-runtime": {
+                        "tokenize_response_text": "{   'responses': [     {       'tokenCount': 11,       'tokens': [         '▁translate',         '▁English',         '▁to',         '▁German',         ':',         '▁How',         '▁old',         '▁are',         '▁you',         '?',         '\u003c/s\u003e'       ]     }   ] }"
+                    }
                 },
                 "flan-t5-xxl-hf": {
                     "response_tokens":  6,
                     "response_text": "Wie alt sind Sie?",
-                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }"
+                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }",
+                    "tgis-runtime": {
+                        "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 11, 'tokens': [ '▁translate', '▁English', '▁to', '▁German', ':', '▁How', '▁old', '▁are', '▁you', '?', '\u003c/s\u003e' ] } ] }"
+                    }
                 },
                 "flan-ul2-hf": {
                     "response_tokens":  6,
                     "response_text": "Wie alt sind Sie?",
-                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }"
-                }
-            }
-        },
-        {
-            "query_text": "桜の木についての話を書く",
-            "models": {
-                "elyza-japanese": {
-                    "response_tokens":  20,
-                    "response_text": "。\n桜の木は、桜の花が咲くと",
-                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
-
-                }
-            }
-        },
-        {
-            "query_text": "桜の木についての話を書く",
-            "models": {
-                "elyza-japanese": {
-                    "response_tokens":  20,
-                    "response_text": "。\n桜の木は、桜の花が咲くと",
-                    "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }"
+                    "streamed_response_text":   "{ 'inputTokenCount': 11 } { 'generatedTokenCount': 1, 'text': 'Wie' } { 'generatedTokenCount': 2, 'text': ' alt' } { 'generatedTokenCount': 3, 'text': ' sind' } { 'generatedTokenCount': 4, 'text': ' Sie' } { 'generatedTokenCount': 5, 'text': '?' } { 'generatedTokenCount': 6, 'stopReason': 'EOS_TOKEN' }",
+                    "tgis-runtime": {
+                        "tokenize_response_text": "{ 'responses': [ { 'tokenCount': 11, 'tokens': [ '▁translate', '▁English', '▁to', '▁German', ':', '▁How', '▁old', '▁are', '▁you', '?', '\u003c/s\u003e' ] } ] }"
+                    }
 
                 }
             }
@@ -102,15 +97,37 @@
                     "response_tokens":  20,
                     "response_text": "。\n桜の木は、桜の花が咲くと",
                     "streamed_response_text":   "{ 'inputTokenCount': 16 } { 'generatedTokenCount': 2, 'text': '。' } { 'generatedTokenCount': 5, 'text': '\n' } { 'generatedTokenCount': 6, 'text': '桜' } { 'generatedTokenCount': 7, 'text': 'の' } { 'generatedTokenCount': 8, 'text': '木' } { 'generatedTokenCount': 9, 'text': 'は' } { 'generatedTokenCount': 12, 'text': '、' } { 'generatedTokenCount': 13, 'text': '桜' } { 'generatedTokenCount': 14, 'text': 'の' } { 'generatedTokenCount': 15, 'text': '花' } { 'generatedTokenCount': 18, 'text': 'が' } { 'generatedTokenCount': 19, 'text': '咲' } { 'generatedTokenCount': 20, 'text': 'くと', 'stopReason': 'MAX_TOKENS' }",
-                    "tokenize_response_text": ""
+                    "tgis-runtime":{
+                        "tokenize_response_text": "{   'responses': [     {       'tokenCount': 16,       'tokens': [         '\u003cs\u003e',         '▁',         '\u003c0xE6\u003e',         '\u003c0xA1\u003e',         '\u003c0x9C\u003e',         'の',         '木',         'に',         'つ',         'い',         'て',         'の',         '話',         'を',         '書',         'く'       ]     }   ] }"
+                    }                
                 }
             }
         }
     ],
     "model-info": {
-        "flan-t5-small-hf": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }",
-        "flan-t5-small-caikit": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }",
-        "mt0-xxl-hf": "",
-        "elyza-japanese" : ""
+        "flan-t5-small-hf": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }"
+        },
+        "flan-t5-small-caikit": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }"
+        },
+        "mt0-xxl-hf": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 2048, 'maxNewTokens': 1024 }"
+        },
+        "flan-t5-xl-hf": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }"
+        },
+        "flan-t5-xxl-hf": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 2048, 'maxNewTokens': 1024 }"
+        },
+        "flan-ul2-hf": {
+            "tgis-runtime": "{ 'modelKind': 'ENCODER_DECODER', 'maxSequenceLength': 512, 'maxNewTokens': 511 }"
+        },
+        "elyza-japanese" : {
+            "tgis-runtime": "{   'maxSequenceLength': 4096,   'maxNewTokens': 1024 }"
+        },
+        "mpt-7b-instruct2":{
+            "tgis-runtime": "{     'maxSequenceLength': 2048,     'maxNewTokens': 1024   }"
+        }
     }
 }

--- a/ods_ci/tests/Resources/Files/llm/runtime_query_formats.json
+++ b/ods_ci/tests/Resources/Files/llm/runtime_query_formats.json
@@ -65,6 +65,30 @@
                     "response": ""
                 }
             }
+        },
+        "tokenize": {
+            "grpc": {
+                "endpoint": "fmaas.GenerationService/Tokenize",
+                "header": "mm-model-id: ${model_name}",
+                "body": "{'requests': [{'text':'${query_text}'}], 'return_tokens':'true'}",
+                "args": "proto=text-generation-inference/proto/generation.proto",
+                "response_fields_map": {
+                    "response": "",
+                    "response_tokens":  "",
+                    "response_text":    ""
+                }
+            }
+        },
+        "model-info": {
+            "grpc": {
+                "endpoint": "fmaas.GenerationService/ModelInfo",
+                "header": "",
+                "body": "{'model_id': '${model_name}'}",
+                "args": "proto=text-generation-inference/proto/generation.proto",
+                "response_fields_map": {
+                    "response": ""
+                }
+            }
         }
     }
 }

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -155,6 +155,39 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
+Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
+    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
+    ...                using Kserve and TGIS standalone runtime
+    [Tags]    Tier1    RHOAIENG-3479
+    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
+    ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
+    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
+    ...    storage_size=70Gi    model_path=${model_path}
+    Compile Inference Service YAML    isvc_name=${model_name}
+    ...    sa_name=${EMPTY}
+    ...    model_storage_uri=${storage_uri}
+    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
+    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
+    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
+    ...    namespace=${test_namespace}
+    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}    timeout=900s
+    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
+    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=all-tokens    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=streaming    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
+    ...    port_forwarding=${use_port_forwarding}
+    [Teardown]    Run Keywords
+    ...    Clean Up Test Project    test_ns=${test_namespace}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    ...    AND
+    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
 
 Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -47,6 +47,14 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
     ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1    query_idx=2
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
@@ -81,6 +89,14 @@ Verify User Can Serve And Query A google/flan-t5-xl Model
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=3    validate_response=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1    query_idx=3
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
@@ -117,71 +133,13 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=3    validate_response=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
-    [Teardown]    Run Keywords
-    ...    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
-    ...    AND
-    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
-Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
-    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
-    ...                using Kserve and TGIS standalone runtime
-    [Tags]    Tier1    RHOAIENG-3479
-    Setup Test Variables    model_name=elyza-japanese    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
-    ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
-    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
-    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
-    ...    storage_size=70Gi    model_path=${model_path}
-    Compile Inference Service YAML    isvc_name=${model_name}
-    ...    sa_name=${EMPTY}
-    ...    model_storage_uri=${storage_uri}
-    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
-    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
-    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
-    ...    namespace=${test_namespace}
-    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${test_namespace}    timeout=900s
-    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=all-tokens    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
+    ...    inference_type=tokenize    n_times=1    query_idx=3
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=streaming    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
-    ...    port_forwarding=${use_port_forwarding}
-    [Teardown]    Run Keywords
-    ...    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
-    ...    AND
-    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
-Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
-    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
-    ...                using Kserve and TGIS standalone runtime
-    [Tags]    Tier1    RHOAIENG-3479
-    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
-    ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
-    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
-    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
-    ...    storage_size=70Gi    model_path=${model_path}
-    Compile Inference Service YAML    isvc_name=${model_name}
-    ...    sa_name=${EMPTY}
-    ...    model_storage_uri=${storage_uri}
-    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
-    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
-    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
-    ...    namespace=${test_namespace}
-    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${test_namespace}    timeout=900s
-    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=all-tokens    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
-    ...    inference_type=streaming    n_times=1    protocol=grpc
-    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
@@ -216,6 +174,14 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=4    validate_response=${FALSE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1    query_idx=4
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
@@ -252,12 +218,20 @@ Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=0    validate_response=${FALSE}
     ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1    query_idx=0
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
-    
+
 Verify User Can Serve And Query A google/flan-ul-2 Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and TGIS runtime
@@ -286,6 +260,14 @@ Verify User Can Serve And Query A google/flan-ul-2 Model
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=streaming    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}    query_idx=3    validate_response=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1    query_idx=3
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -122,6 +122,39 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
+Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
+    [Documentation]    Basic tests for preparing, deploying and querying a LLM model
+    ...                using Kserve and TGIS standalone runtime
+    [Tags]    Tier1    RHOAIENG-3479
+    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
+    ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
+    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
+    ...    storage_size=70Gi    model_path=${model_path}
+    Compile Inference Service YAML    isvc_name=${model_name}
+    ...    sa_name=${EMPTY}
+    ...    model_storage_uri=${storage_uri}
+    ...    model_format=pytorch    serving_runtime=${TGIS_RUNTIME_NAME}
+    ...    limits_dict=${limits}    kserve_mode=${KSERVE_MODE}
+    Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
+    ...    namespace=${test_namespace}
+    Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    ...    namespace=${test_namespace}    timeout=900s
+    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
+    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=all-tokens    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}   query_idx=3    validate_response=${TRUE}    # temp
+    ...    port_forwarding=${use_port_forwarding}
+    Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=streaming    n_times=1    protocol=grpc
+    ...    namespace=${test_namespace}    query_idx=2    validate_response=${FALSE}
+    ...    port_forwarding=${use_port_forwarding}
+    [Teardown]    Run Keywords
+    ...    Clean Up Test Project    test_ns=${test_namespace}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    ...    AND
+    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
 
 Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -126,7 +126,7 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and TGIS standalone runtime
     [Tags]    Tier1    RHOAIENG-3479
-    Setup Test Variables    model_name=elyza-japanese-llama-2-7b-instruct-hf    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
+    Setup Test Variables    model_name=elyza-japanese    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
     Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${test_namespace}
     ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
@@ -22,7 +22,7 @@ ${TEST_NS}=    tgis-standalone
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
 @{SEARCH_METRICS}=    tgi_    istio_
 
-
+ 
 *** Test Cases ***
 Verify User Can Serve And Query A Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
@@ -43,6 +43,12 @@ Verify User Can Serve And Query A Model
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}
+    Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=tokenize    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+    Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
+    ...    inference_type=model-info    n_times=1
+    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=streaming    n_times=1
     ...    namespace=${test_namespace}    validate_response=${FALSE}


### PR DESCRIPTION
Adding query and response validation against ModelInfo and Tokenize endpoints for all the models in `ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot` and `flan-t5-small` in `ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot`.

Besides, this PR wants to start rewriting the logic for response validation which is becoming too complex and not scalable on the differences btw runtimes.
It is not affecting Generate and GenerateStream endpoint validation, they will be handled in another PR later.