### PR TITLE
RHOAIENG-3783 - Fix codeflare sdk tests

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
@@ -11,52 +11,78 @@ Resource          ../../Resources/RHOSi.resource
 *** Variables ***
 ${CODEFLARE-SDK_DIR}                codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}           %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
-${CODEFLARE-SDK_REPO_BRANCH}        %{CODEFLARE-SDK_REPO_BRANCH=main}
+${VIRTUAL_ENV_NAME}                 venv3.9
 
 
 *** Test Cases ***
 Run TestMNISTRayClusterSDK test
-    [Documentation]    Run Go E2E test: TestMNISTRayClusterSDK
+    [Documentation]    Run Python E2E test: TestMNISTRayClusterSDK
+    ...    ProductBug: https://issues.redhat.com/browse/RHOAIENG-3981 https://issues.redhat.com/browse/RHOAIENG-4240
     [Tags]  ODS-2544
-    ...     Sanity    Tier1
+    ...     Tier1
     ...     DistributedWorkloads
     ...     Codeflare-sdk
-    Run Codeflare-sdk E2E Test    TestMNISTRayClusterSDK
+    ...   	ProductBug
+    Skip    "Skipping because of RHOAIENG-3981 and RHOAIENG-4240."
+    Run Codeflare-sdk E2E Test    mnist_raycluster_sdk_test.py
 
+Run TestRayClusterSDKOauth test
+    [Documentation]    Run Python E2E test: TestRayClusterSDKOauth
+    [Tags]
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Codeflare-sdk
+    Run Codeflare-sdk E2E Test    mnist_raycluster_sdk_oauth_test.py
 
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite
     [Documentation]    Prepare codeflare-sdk E2E Test Suite
-    ${result} =    Run Process    git clone -b ${CODEFLARE-SDK_REPO_BRANCH} ${CODEFLARE-SDK_REPO_URL} ${CODEFLARE-SDK_DIR}
+    ${result} =    Run Process    git clone ${CODEFLARE-SDK_REPO_URL} ${CODEFLARE-SDK_DIR}
     ...    shell=true    stderr=STDOUT
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
-        FAIL    Unable to clone codeflare-sdk repo ${CODEFLARE-SDK_REPO_URL}:${CODEFLARE-SDK_REPO_BRANCH}:${CODEFLARE-SDK_DIR}
+        FAIL    Unable to clone codeflare-sdk repo ${CODEFLARE-SDK_REPO_URL}
     END
+
+    ${result} =    Run Process  virtualenv -p python3.9 ${VIRTUAL_ENV_NAME}
+    ...    shell=true    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL    Unable to setup Python virtual environment
+    END
+
     Enable Component    codeflare
     Enable Component    ray
-    Create Directory    %{WORKSPACE}/codeflare-sdk-e2e-logs
     RHOSi Setup
 
 Teardown Codeflare-sdk E2E Test Suite
     [Documentation]    Teardown codeflare-sdk E2E Test Suite
+
+    ${result} =    Run Process  rm -rf ${VIRTUAL_ENV_NAME}
+    ...    shell=true    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL   Unable to cleanup Python virtual environment
+    END
+
+    ${result} =    Run Process    poetry env use 3.11
+    ...    shell=true    stderr=STDOUT
+    IF    ${result.rc} != 0
+        FAIL   Unable to switch python environment 3.11
+    END
+
     Disable Component    codeflare
     Disable Component    ray
     RHOSi Teardown
 
 Run Codeflare-sdk E2E Test
     [Documentation]    Run codeflare-sdk E2E Test
-    [Arguments]    ${test_name}
-    Log To Console    Running codeflare-sdk test: ${test_name}
-    ${result} =    Run Process    go test -timeout 30m -v ./tests/e2e -run ${test_name}
+    [Arguments]    ${TEST_NAME}
+    Log To Console    "Running codeflare-sdk test: ${TEST_NAME}"
+    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd codeflare-sdk && poetry env use 3.9 && poetry install --with test,docs && poetry run pytest -v -s ./tests/e2e/${TEST_NAME} --timeout\=600 && deactivate
     ...    shell=true
     ...    stderr=STDOUT
-    ...    cwd=${CODEFLARE-SDK_DIR}
-    ...    env:CODEFLARE_TEST_TIMEOUT_SHORT=5m
-    ...    env:CODEFLARE_TEST_TIMEOUT_MEDIUM=10m
-    ...    env:CODEFLARE_TEST_TIMEOUT_LONG=20m
-    ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/codeflare-sdk-e2e-logs
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
-        FAIL    ${test_name} failed
+        FAIL    ${TEST_NAME} failed
     END


### PR DESCRIPTION
closes [RHOAIENG-3783](https://issues.redhat.com/browse/RHOAIENG-3783) and [RHOAIENG-4754](https://issues.redhat.com/browse/RHOAIENG-4754)
- Added scripts for python 3.9 Virtual environment setup for codeflare-sdk python tests
-  Updated the Go tests to CodeFlare SDK python tests
- Add the SDK authentication test
- Added timeout to maximum 10 minutes and tests running successfully less than 5 min 