### PR TITLE
fix: ODS-282 Verify Content In RHODS Explore Section

### DIFF
--- a/ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
+++ b/ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
@@ -317,7 +317,7 @@
                          "matching": ""
                    },
                    "1": {
-                         "text": "Enabling GPU Support in Openshift Data Science",
+                         "text": "Enabling GPU Support in OpenShift AI",
                          "url": "https://access.redhat.com/documentation/en-us/red_hat_openshift_data_science/1/html/managing_users_and_user_resources/enabling-gpu-support-in-openshift-data-science_user-mgmt",
                          "matching": ""
                    }

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -14,7 +14,7 @@ ${ODH_DASHBOARD_PROJECT_NAME}=   Red Hat OpenShift AI
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-v5-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-v5-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-v5-c-card'))]
-${CARD_BUTTON_XP}=  ..//input[@class="pf-v5-c-radio__input"][@name="odh-explore-selectable-card"]
+${CARD_BUTTON_XP}=  //input[@class="pf-v5-c-radio__input"][@name="odh-explore-selectable-card"]
 ${RES_CARDS_XP}=  //div[contains(@data-ouia-component-type, "Card")]
 ${SAMPLE_APP_CARD_XP}=   //*[@id="pachyderm-selectable-card-id"]
 ${HEADER_XP}=  div[@class='pf-v5-c-card__header']
@@ -337,9 +337,9 @@ Check Card Badges And Return Titles
 
 Open Get Started Sidebar And Return Status
     [Arguments]  ${card_locator}
-    Wait Until Element Is Visible    xpath:${card_locator}/${CARD_BUTTON_XP}
-    Wait Until Element Is Enabled     xpath:${card_locator}/${CARD_BUTTON_XP}    timeout=20s     error=Element is not clickbale  #robocop : disable
-    ${element}=    Get WebElement    xpath:${card_locator}/${CARD_BUTTON_XP}
+    Wait Until Element Is Visible    xpath:${card_locator}${CARD_BUTTON_XP}
+    Wait Until Element Is Enabled     xpath:${card_locator}${CARD_BUTTON_XP}    timeout=20s     error=Element is not clickbale  #robocop : disable
+    ${element}=    Get WebElement    xpath:${card_locator}${CARD_BUTTON_XP}
     Execute Javascript    arguments[0].click();     ARGUMENTS    ${element}
     ${status}=  Run Keyword and Return Status  Wait Until Page Contains Element    xpath://div[contains(@class,'pf-v5-c-drawer__panel-main')]
     Sleep  1


### PR DESCRIPTION
Test "fix: ODS-282 Verify Content In RHODS Explore Section" was failing in 2.8 RC2 due to:
1. Wrong xpath for opening the cards (fixed here)

After fixing it we found another 2 issues:
![Screenshot from 2024-03-12 17-46-25](https://github.com/red-hat-data-services/ods-ci/assets/31654558/99925291-e223-4fbb-9fa3-0f751dc76f1d)

2. Wrong Intel links (returning a 403 and redirections)
3. Wrong test data pointing to RHODS instead of RHOAI (fixed here)

Now we just have the wrong Intel links, which has been already [notified](https://issues.redhat.com/browse/RHOAIENG-4442):
![Screenshot from 2024-03-12 17-50-02](https://github.com/red-hat-data-services/ods-ci/assets/31654558/3743d50f-45a9-4e38-b09b-b201b0391aa6)

