### PR TITLE
fix: ODS-1226 Open links

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -545,7 +545,7 @@ Check GPU Resources
     FOR    ${counter}    IN RANGE    ${len}
         Page Should Contain Element    xpath:${RES_CARDS_XP}\[@id=${gpu_re_id}[${counter}]]
         IF    ${gpu_re_link}[${counter}] == '#'
-                ${counter}=    Get WebElements   //a[@href=${gpu_re_link}[${counter}]]
+                ${counter}=    Get WebElements   ${RES_CARDS_XP}//button[text()='Open']
                 ${no_of_open_link}=    Get Length    ${counter}
                 IF   ${no_of_open_link} == ${2}   Log   There are two tile with `Open' link
                 ...        ELSE    Fail     Mismatch on the number of GPU tile present with 'Open' link.Please check the RHODS dashboard.  #robocop disable


### PR DESCRIPTION
Test: 
ODS-1226 - Search and Verify GPU Items Appears In Resources Page

In the 2.8 the "Open" links are "HTML buttons" instead of "HTML a" links
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/7f85f955-fed0-4d66-8a61-c55a32cffd68)


Test results:
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/1a544cce-f730-48fe-928c-3f7ebb44fbc6)
