### PR TITLE
Install Authorino Operator as a prerequisite for RHOAI 2.9+

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -14,6 +14,9 @@ ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless
 ${SERVICEMESH_OP_NAME}=     servicemeshoperator
 ${SERVICEMESH_SUB_NAME}=    servicemeshoperator
+${AUTHORINO_OP_NAME}=     authorino-operator
+${AUTHORINO_SUB_NAME}=    authorino-operator
+${AUTHORINO_CHANNEL_NAME}=  managed-services
 ${RHODS_CSV_DISPLAY}=    Red Hat OpenShift AI
 ${ODH_CSV_DISPLAY}=    Open Data Hub Operator
 
@@ -306,10 +309,22 @@ Catalog Is Ready
     Should Be Equal As Strings    "READY"    ${output}
 
 Install Kserve Dependencies
-    [Documentation]    Install Dependent Operator For Kserve
+    [Documentation]    Install Dependent Operators For Kserve
     Set Suite Variable   ${FILES_RESOURCES_DIRPATH}    tests/Resources/Files
     Set Suite Variable   ${SUBSCRIPTION_YAML_TEMPLATE_FILEPATH}    ${FILES_RESOURCES_DIRPATH}/isv-operator-subscription.yaml
     Set Suite Variable   ${OPERATORGROUP_YAML_TEMPLATE_FILEPATH}    ${FILES_RESOURCES_DIRPATH}/isv-operator-group.yaml
+    ${is_installed} =   Check If Operator Is Installed Via CLI   ${AUTHORINO_OP_NAME}
+    IF    not ${is_installed}
+          Install ISV Operator From OperatorHub Via CLI    operator_name=${AUTHORINO_OP_NAME}
+          ...    subscription_name=${AUTHORINO_SUB_NAME}
+          ...    channel=${AUTHORINO_CHANNEL_NAME}
+          ...    catalog_source_name=redhat-operators
+          Wait Until Operator Subscription Last Condition Is
+          ...    type=CatalogSourcesUnhealthy    status=False
+          ...    reason=AllCatalogSourcesHealthy    subcription_name=${AUTHORINO_SUB_NAME}
+    ELSE
+          Log To Console    message=Authorino Operator is already installed
+    END
     ${is_installed}=   Check If Operator Is Installed Via CLI   ${SERVICEMESH_OP_NAME}
     IF    not ${is_installed}
           Install ISV Operator From OperatorHub Via CLI    operator_name=${SERVICEMESH_OP_NAME}

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -17,6 +17,7 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ...            ${channel}=stable    ${catalog_source_name}=certified-operators
     ...            ${cs_namespace}=openshift-marketplace    ${operator_group_name}=${NONE}
     ...            ${operator_group_ns}=${NONE}    ${operator_group_target_ns}=${NONE}
+    Log To Console    message=Installing the '${operator_name}' Operator
     IF    "${operator_group_name}" != "${NONE}"
         Create Operator Group    name=${operator_group_name}
         ...    namespace=${operator_group_ns}    target_namespace=${operator_group_target_ns}


### PR DESCRIPTION
This should go for the RHOAI 2.9. Technically it shouldn't do any harm if we merge this also into the RHOAI 2.8 branch, but it's not a clean approach.

@jgarciao when do we plan to release the ods-ci RHOAI 2.8 branch? I suppose just before the release :thinking: 

----

CI: verified with `rhods-smoke/4909` :white_check_mark: 