### PR TITLE
Extend the timeout waiting for component to be enabled

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -384,7 +384,7 @@ Wait Component Ready
     Log To Console    Waiting for ${component} to be ready
 
     # oc wait "${cluster_name}" --for=condition\=${component}Ready\=true --timeout\=3m
-    ${result} =    Run Process    oc wait "${cluster_name}" --for condition\=${component}Ready\=true --timeout\=3m
+    ${result} =    Run Process    oc wait "${cluster_name}" --for condition\=${component}Ready\=true --timeout\=10m
     ...    shell=true    stderr=STDOUT
     IF    $result.rc != 0
         ${suffix} =  Generate Random String  4  [LOWER]


### PR DESCRIPTION
Needed for Kueue component, as it often takes more time to start.