### PR TITLE
fix: Add productBug tag to ODS-282

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -52,8 +52,10 @@ Verify Content In RHODS Explore Section
     ...    It compares the actual data with the one registered in a JSON file. The checks are about:
     ...    - Card's details (text, badges, images)
     ...    - Sidebar (titles, links text, links status)
+    ...    ProducBug: RHOAIENG-935
     [Tags]    Sanity    Tier1
     ...       ODS-488    ODS-993    ODS-749    ODS-352    ODS-282
+    ...       ProductBug
     ${EXP_DATA_DICT}=    Load Expected Data Of RHODS Explore Section
     Click Link    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore


### PR DESCRIPTION
This test was failing during 2.8 QGs
ProductBug: https://issues.redhat.com/browse/RHOAIENG-935 