### PR TITLE
Enable IBMCloud compatibility for LLM models tests

### DIFF
--- a/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -54,15 +54,17 @@ Delete Pods Using Label Selector
 Check If Pod Exists
     [Documentation]    Check existence of an openshift pod by label selector
     [Arguments]    ${namespace}    ${label_selector}    ${status_only}=${TRUE}
-    ${status}    ${val}=    Run Keyword And Ignore Error    Oc Get    kind=Pod    namespace=${namespace}
-        ...    label_selector=${label_selector}
-    IF    ${status_only} == ${TRUE}
-        RETURN    ${status}
-    ELSE
-        Should Be Equal    ${status}    PASS
+    # The oc library does not correctly use a proxy when needed. Replace with equivalent `oc` calls and robot code.
+    #${status}    ${val}=    Run Keyword And Ignore Error    Oc Get    kind=Pod    namespace=${namespace}
+    #    ...    label_selector=${label_selector}
+    ${rc}    ${out} =  Run And Return Rc And Output  oc get pod -l ${label_selector} -n ${namespace}
+    IF    '''${out}''' != "No resources found in ${namespace} namespace."
+        RETURN    PASS
     END
-
-
+    IF    ${status_only} == ${TRUE}
+        RETURN    FAIL
+    END
+    Fail
 
 Verify Operator Pod Status
     [Documentation]    Verify Pod status

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -50,8 +50,8 @@ RHOSi Setup
     Protect Sensitive Variables In Keywords
     Required Global Variables Should Exist
     Initialize Global Variables
-    #Run Keyword If RHODS Is Managed
-    #...    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
+    Run Keyword If RHODS Is Managed
+    ...    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
     # TO DO: oc login
 
 RHOSi Teardown

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -50,8 +50,8 @@ RHOSi Setup
     Protect Sensitive Variables In Keywords
     Required Global Variables Should Exist
     Initialize Global Variables
-    Run Keyword If RHODS Is Managed
-    ...    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
+    #Run Keyword If RHODS Is Managed
+    #...    Suite Availability Setup    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}
     # TO DO: oc login
 
 RHOSi Teardown

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -15,6 +15,8 @@ ${TGIS_RUNTIME_NAME}=    tgis-runtime
 ${USE_PVC}=    ${TRUE}
 ${DOWNLOAD_IN_PVC}=    ${TRUE}
 ${USE_GPU}=    ${FALSE}
+${IBM_CLOUD_PROXY}=    ${FALSE}
+${PROXY_URL}=    TBD
 ${KSERVE_MODE}=    RawDeployment
 
 
@@ -431,6 +433,10 @@ Verify User Can Serve And Query A google/flan-t5-xl Prompt Tuned Model
 *** Keywords ***
 Suite Setup
     [Documentation]
+    IF    ${IBM_CLOUD_PROXY}
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    export https_proxy=${PROXY_URL}
+    END
     Skip If Component Is Not Enabled    kserve
     RHOSi Setup
     Load Expected Responses

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
@@ -22,8 +22,10 @@ ${TEST_NS}=    tgis-standalone
 ${TGIS_RUNTIME_NAME}=    tgis-runtime
 @{SEARCH_METRICS}=    tgi_    istio_
 ${USE_GPU}=    ${FALSE}
+${IBM_CLOUD_PROXY}=    ${FALSE}
+${PROXY_URL}=    TBD
 
-  
+
 *** Test Cases ***
 Verify User Can Serve And Query A Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
@@ -617,6 +619,10 @@ Verify User Can Query A Model Using HTTP Calls
 *** Keywords ***
 Suite Setup
     [Documentation]
+    IF    ${IBM_CLOUD_PROXY}
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    export https_proxy=${PROXY_URL}
+    END
     Skip If Component Is Not Enabled    kserve
     RHOSi Setup
     Load Expected Responses


### PR DESCRIPTION
Compatibility has to be enabled manually when running the tests in IBM cloud with 
```
--extra-robot-args '--variable IBM_CLOUD_PROXY:True --variable PROXY_URL:my_url'
```