### PR TITLE
[Fix] Notebook API test

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -1,6 +1,8 @@
 *** Settings ***
 Documentation     Suite for a basic security test of Dashboard APIs. The tests verifies that user
-...               reach endpoints based on their user permissions
+...               reach endpoints based on their user permissions.
+...    Refer to this file https://github.com/opendatahub-io/odh-dashboard/blob/main/frontend/src/types.ts
+...    to read particular API definitions.
 Library           OpenShiftLibrary
 Library           SeleniumLibrary
 Resource          ../../Resources/Common.robot
@@ -72,8 +74,8 @@ ${VALIDATE_ISV_RESULT_ENDPOINT}=         api/validate-isv/results?appName=anacon
 ${NB_ENDPOINT_PT0}=      api/notebooks
 ${NB_ENDPOINT_PT1}=      ${NB_ENDPOINT_PT0}/${NOTEBOOK_NS}/
 ${NB_ENDPOINT_PT2}=      /status
-${NB_ENDPOINT_BODY_A}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started"}
-${NB_ENDPOINT_BODY_B}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","url":"${ODH_DASHBOARD_URL}","gpus":0,"envVars":{"configMap":{},"secrets":{"super-secre":"my new secret 20!"}},"state":"started","username":"<USERNAME>"}
+${NB_ENDPOINT_BODY_A}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","acceleratorProfile": {"count": 0},"envVars":{"configMap":{},"secrets":{"super-secret":"my new secret 20!"}},"state":"started"}  #robocop: disable:line-too-long
+${NB_ENDPOINT_BODY_B}=      {"notebookSizeName":"Small","imageName":"s2i-minimal-notebook","imageTagName":"<IMAGETAGNAME>","acceleratorProfile": {"count": 0},"envVars":{"configMap":{},"secrets":{"super-secret":"my new secret 20!"}},"state":"started","username":"<USERNAME>"}  #robocop: disable:line-too-long
 ${NB_STOP_ENDPOINT_BODY_A}=    {"state":"stopped"}
 ${NB_STOP_ENDPOINT_BODY_B}=    {"state":"stopped","username": "<USERNAME>"}
 


### PR DESCRIPTION
This test was probably failing since the addition of the accelerator profiles. Since I have no idea where is some documentation to the dashboard API which we use here, I grepped my local disk for some keywords and was able to find this file [1] from which I was able to understand what is wrong with this test. As such, please review thoroughly since I could miss something.

[1] https://github.com/opendatahub-io/odh-dashboard/blob/main/frontend/src/types.ts#L670

After merge, I shall backport to `releases/2.8.0` branch too.

---

![Screenshot from 2024-03-15 19-45-42](https://github.com/red-hat-data-services/ods-ci/assets/12250881/f03481aa-cebd-4e20-ac4d-3f01a00e5849)
