### PR TITLE
Fix Dashboard Tests for ODH and RHOAI 2.9 

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -67,6 +67,7 @@ Verify RHODS Installation
     Set Global Variable    ${OPERATOR_NAMESPACE}    openshift-operators
     Set Global Variable    ${NOTEBOOKS_NAMESPACE}    opendatahub
   END
+  Set Global Variable    ${DASHBOARD_APP_NAME}    ${PRODUCT.lower()}-dashboard
   Log  Verifying RHODS installation  console=yes
   Log To Console    Waiting for all RHODS resources to be up and running
   IF  "${UPDATE_CHANNEL}" != "odh-nightlies"

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -94,10 +94,10 @@ Verify RHODS Installation
         Add UI Admin Group To Dashboard Admin
 
     ELSE
-        Log To Console    "Waiting for 5 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=rhods-dashboard"
+        Log To Console    "Waiting for 5 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=${DASHBOARD_APP_NAME}"
         Wait For Pods Numbers  5
         ...                   namespace=${APPLICATIONS_NAMESPACE}
-        ...                   label_selector=app=rhods-dashboard
+        ...                   label_selector=app=${DASHBOARD_APP_NAME}
         ...                   timeout=1200
     END
   END

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -28,7 +28,7 @@ Begin Web Test
     RHOSi Setup
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${username}  ${password}  ${auth_type}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub  ${username}  ${password}  ${auth_type}
     ${authorization_required} =  Is Service Account Authorization Required
@@ -50,7 +50,7 @@ End Non JupyterLab Web Test
     [Documentation]  Stops running workbench that was started by logged-in user via the
     ...              JupyterHub launcher space.
     Go To  ${ODH_DASHBOARD_URL}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Handle Control Panel
     Capture Page Screenshot
@@ -308,8 +308,8 @@ Run Keyword If RHODS Is Self-Managed
     ${is_self_managed}=    Is RHODS Self-Managed
     IF    ${is_self_managed} == True    Run Keyword    ${name}    @{arguments}
 
-Get Domain From Current URL
-    [Documentation]    Gets the lowest level domain from the current URL (i.e. everything before the first dot in the URL)
+Get Sub Domain Of Current URL
+    [Documentation]    Gets the sub-domain of the current URL (i.e. everything before the first dot in the URL)
     ...    e.g. https://console-openshift-console.apps.<cluster>.rhods.ccitredhat.com -> https://console-openshift-console
     ...    e.g. https://rhods-dashboard-redhat-ods-applications.apps.<cluster>.rhods.ccitredhat.com/ -> https://rhods-dashboard-redhat-ods-applications
     ${current_url} =    Get Location
@@ -320,9 +320,9 @@ Does Current Sub Domain Start With
     [Documentation]    Check if current sub-domain start with the given String
     ...   and returns True/False
     [Arguments]    ${url}
-    ${domain} =    Get Domain From Current URL
-    ${comparison} =    Run Keyword And Return Status    Should Be Equal As Strings
-    ...    ${domain}    ${url}
+    ${subdomain} =    Get Sub Domain Of Current URL
+    ${comparison} =    Run Keyword And Return Status    Should Start With
+    ...    ${subdomain}    ${url}
     RETURN    ${comparison}
 
 Get OAuth Cookie

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -316,8 +316,8 @@ Get Domain From Current URL
     ${domain} =    Fetch From Left    string=${current_url}    marker=.
     RETURN    ${domain}
 
-Is Current Domain Equal To
-    [Documentation]    Compare the lowest level domain to a given string
+Does Current Sub Domain Start With
+    [Documentation]    Check if current sub-domain start with the given String
     ...   and returns True/False
     [Arguments]    ${url}
     ${domain} =    Get Domain From Current URL

--- a/ods_ci/tests/Resources/Page/LoginPage.robot
+++ b/ods_ci/tests/Resources/Page/LoginPage.robot
@@ -44,7 +44,7 @@ Login To Openshift
     Wait Until Page Contains A String In List    ${expected_text_list}
 
     # Return if page is not the Login page (no login required)
-    ${should_login} =    Is Current Domain Equal To    https://oauth-openshift
+    ${should_login} =    Does Current Sub Domain Start With    https://oauth
     IF  not ${should_login}    RETURN
 
     # If here we need to login

--- a/ods_ci/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/Builds/Builds.robot
@@ -138,7 +138,7 @@ Provoke Image Build Failure
     Delete Build    namespace=${namespace}    build_name=${build}
     ${failed_build_name} =    Start New Build    namespace=${namespace}
     ...    buildconfig=${build_config_name}
-    ${pod_name} =    Find First Pod By Name    namespace=${namespace}    pod_start_with=${failed_build_name}
+    ${pod_name} =    Find First Pod By Name    namespace=${namespace}    pod_regex=${failed_build_name}
     Wait Until Build Status Is    namespace=${namespace}    build_name=${failed_build_name}
     ...    expected_status=Running
     Wait Until Container Exist  namespace=${namespace}  pod_name=${pod_name}  container_to_check=${container_to_kill}

--- a/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
@@ -49,7 +49,7 @@ Switch To Developer Perspective
 Maybe Skip Tour
     [Documentation]    If we are in the openshift web console, maybe skip the first time
     ...    tour popup given to users, otherwise RETURN.
-    ${should_cont} =    Is Current Domain Equal To    https://console-openshift-console
+    ${should_cont} =    Does Current Sub Domain Start With    https://console-openshift-console
     IF  ${should_cont}==False
         RETURN
     END

--- a/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -142,11 +142,17 @@ Container Image Url Should Contain
     ...    msg=Unexpected container image url
 
 Search Pod
-    [Documentation]   Returns list pod  ${pod_start_with} = here ypu have to provide starting of pod name
-    [Arguments]   ${namespace}  ${pod_start_with}
-    ${pod} =  Run  oc get pods -n ${namespace} -o json | jq '.items[] | select(.metadata.name | startswith("${pod_start_with}")) | .metadata.name'    #robocop:disable
+    [Documentation]   Returns a list of pods that match the regular expression '${pod_regex}'
+    [Arguments]   ${namespace}  ${pod_regex}
+    ${pod} =  Run  oc get pods -n ${namespace} -o json | jq '.items[] | select(.metadata.name | test("${pod_regex}")) | .metadata.name'    #robocop:disable
     @{list_pods} =  Split String  ${pod}  \n
     RETURN  ${list_pods}
+
+Find First Pod By Name
+    [Documentation]   Returns first occurred of pod that starts with '${pod_regex}'
+    [Arguments]   ${namespace}  ${pod_regex}
+    ${list_pods} =  Search Pod  namespace=${namespace}  pod_regex=^${pod_regex}
+    RETURN  ${list_pods}[0]
 
 Run Command In Container
     [Documentation]    Executes a command in a container.
@@ -170,12 +176,6 @@ Check Is Container Exist
     [Arguments]     ${namespace}    ${pod_name}    ${container_to_check}
     ${container_name} =  Run  oc get pod ${pod_name} -n ${namespace} -o json | jq '.spec.containers[] | select(.name == "${container_to_check}") | .name'
     Should Be Equal    "${container_to_check}"    ${container_name}
-
-Find First Pod By Name
-    [Documentation]   Returns first occurred pod  ${pod_start_with} = here ypu have to provide starting of pod name
-    [Arguments]   ${namespace}  ${pod_start_with}
-    ${list_pods} =  Search Pod  namespace=${namespace}  pod_start_with=${pod_start_with}
-    RETURN  ${list_pods}[0]
 
 Get Containers
     [Documentation]    Returns list of containers

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -675,7 +675,7 @@ Log In N Users To JupyterLab And Launch A Notebook For Each Of Them
     FOR    ${username}    IN    @{list_of_usernames}
         Open Browser    ${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}    options=${BROWSER.OPTIONS}    alias=${username}
         Login To RHODS Dashboard    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-        Wait for RHODS Dashboard to Load
+        Wait For RHODS Dashboard To Load
         Launch Jupyter From RHODS Dashboard Link
         Login To Jupyterhub    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
         Page Should Not Contain    403 : Forbidden
@@ -693,7 +693,7 @@ CleanUp JupyterHub For N Users
     FOR    ${username}    IN    @{list_of_usernames}
         Open Browser    ${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}    options=${BROWSER.OPTIONS}    alias=${username}
         Login To RHODS Dashboard    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-        Wait for RHODS Dashboard to Load
+        Wait For RHODS Dashboard To Load
         Launch Jupyter From RHODS Dashboard Link
         Login To Jupyterhub    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
         Page Should Not Contain    403 : Forbidden

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -32,8 +32,8 @@ ${KFNBC_CONTROL_PANEL_HEADER_XPATH} =    //h1[.="Notebook server control panel"]
 ${KFNBC_ENV_VAR_NAME_PRE} =    //span[.="Variable name"]/../../../div[@class="pf-v5-c-form__group-control"]
 ${DEFAULT_PYTHON_VER} =    3.9
 ${PREVIOUS_PYTHON_VER} =    3.9
-${DEFAULT_NOTEBOOK_VER} =    2023.2
-${PREVIOUS_NOTEBOOK_VER} =    2023.1
+${DEFAULT_NOTEBOOK_VER} =    2024.1
+${PREVIOUS_NOTEBOOK_VER} =    2023.2
 
 
 *** Keywords ***

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -16,7 +16,9 @@ ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-v5-c-drawe
 ${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-v5-c-card'))]
 ${CARD_BUTTON_XP}=  //input[@class="pf-v5-c-radio__input"][@name="odh-explore-selectable-card"]
 ${RES_CARDS_XP}=  //div[contains(@data-ouia-component-type, "Card")]
-${SAMPLE_APP_CARD_XP}=   //*[@id="pachyderm-selectable-card-id"]
+${SAMPLE_APP_CARD_XP}=    //div[contains(@data-testid,"explore-card")]
+${JUPYTER_CARD_XP}=    //div[@data-testid="explore-card jupyter"]
+${EXPLORE_PANEL_XP}=    //div[@data-testid="explore-drawer-panel"]
 ${HEADER_XP}=  div[@class='pf-v5-c-card__header']
 ${TITLE_XP}=   div[@class='pf-v5-c-card__title']//span
 ${TITLE_XP_OLD}=  div[@class='pf-v5-c-card__title']//div/div[1]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -750,7 +750,7 @@ Clear Dashboard Notifications
 
 Get Dashboard Pods Names
     [Documentation]     Retrieves the names of dashboard pods
-    ${dash_pods}=    Oc Get    kind=Pod    namespace=${APPLICATIONS_NAMESPACE}     label_selector=app=rhods-dashboard
+    ${dash_pods}=    Oc Get    kind=Pod    namespace=${APPLICATIONS_NAMESPACE}     label_selector=app=${DASHBOARD_APP_NAME}
     ...                        fields=['metadata.name']
     ${names}=   Create List
     FOR    ${pod_name}    IN    @{dash_pods}
@@ -761,7 +761,7 @@ Get Dashboard Pods Names
 Get Dashboard Pod Logs
     [Documentation]     Fetches the logs from one dashboard pod
     [Arguments]     ${pod_name}
-    ${pod_logs}=    Oc Get Pod Logs  name=${pod_name}  namespace=${APPLICATIONS_NAMESPACE}  container=rhods-dashboard
+    ${pod_logs}=    Oc Get Pod Logs  name=${pod_name}  namespace=${APPLICATIONS_NAMESPACE}  container=${DASHBOARD_APP_NAME}
     ${pod_logs_lines}=    Split String    string=${pod_logs}  separator=\n
     ${n_lines}=    Get Length    ${pod_logs_lines}
     Log     ${pod_logs_lines}[${n_lines-3}:]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -144,18 +144,18 @@ Launch ${dashboard_app} From RHODS Dashboard Dropdown
 
 Verify Service Is Enabled
   [Documentation]   Verify the service appears in Applications > Enabled
-  [Arguments]  ${app_name}
+  [Arguments]  ${app_name}    ${timeout}=180s
   Menu.Navigate To Page    Applications    Enabled
-  Wait Until Page Contains    Jupyter  timeout=30
-  Wait Until Page Contains    ${app_name}  timeout=180
+  # Jupyter App should always be listed
+  Wait Until Page Contains    Jupyter    timeout=30s
+  Wait Until Page Contains    ${app_name}    timeout=${timeout}
   Page Should Contain Element    xpath://div//*[.='${app_name}']/../..   message=${app_name} should be enabled in ODS Dashboard
   Page Should Not Contain Element    xpath://div//*[.='${app_name}']/..//div[contains(@class,'enabled-controls')]/span[contains(@class,'disabled-text')]  message=${app_name} is marked as Disabled. Check the license
-
 
 Verify Service Is Not Enabled
   [Documentation]   Verify the service is not present in Applications > Enabled
   [Arguments]  ${app_name}
-  ${app_is_enabled}=  Run Keyword And Return Status   Verify Service Is Enabled    ${app_name}
+  ${app_is_enabled}=  Run Keyword And Return Status   Verify Service Is Enabled    ${app_name}    timeout=10s
   Should Be True   not ${app_is_enabled}   msg=${app_name} should not be enabled in ODS Dashboard
 
 Verify Service Is Available In The Explore Page

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -734,7 +734,7 @@ RHODS Notification Drawer Should Not Contain
 Sort Resources By
     [Documentation]    Changes the sort of items in resource page
     [Arguments]    ${sort_type}
-    Click Element    //div[@class="pf-v5-c-toolbar__content-section"]/div[2]/div/button
+    Click Button    //*[contains(., "Sort by")]
     Click Button    //button[@data-key="${sort_type}"]
     Sleep    1s
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -114,7 +114,7 @@ Wait for QuickStart to Load
     RETURN    ${quickStartElements}
 
 Wait Until Resource Page Is Loaded
-    Wait Until Page Contains Element    xpath://div[contains(@class,'odh-learning-paths__gallery')]
+    Wait Until Page Contains Element    xpath://div[@aria-label="Favoritable card container"]
 
 Get Link Web Elements From Resource Page
     [Documentation]    Returns the link web elements from Resources page which redirects users to

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -16,43 +16,42 @@ ${EDITOR_RUNTIME_BTN_XP}=    //div[contains(@class, "odh-dashboard__code-editor"
 
 *** Keywords ***
 Click Add Serving Runtime Template Button
-    SeleniumLibrary.Wait Until Page Contains Element    ${ADD_RUNTIME_BTN_XP}
-    SeleniumLibrary.Click Element    ${ADD_RUNTIME_BTN_XP}
-    Run Keyword And Continue On Failure    SeleniumLibrary.Page Should Contain    Add a serving runtime
-    Run Keyword And Continue On Failure    SeleniumLibrary.Page Should Contain    Drag a file here, upload files, or start from scratch.
-    Run Keyword And Continue On Failure    SeleniumLibrary.Page Should Contain Element    ${UPLOAD_RUNTIME_BTN_XP}
-    Run Keyword And Continue On Failure    SeleniumLibrary.Page Should Contain Element    ${SCRATCH_RUNTIME_BTN_XP}
-    Run Keyword And Continue On Failure    SeleniumLibrary.Page Should Contain Element    ${EDITOR_RUNTIME_BTN_XP}
+    Wait Until Page Contains Element    ${ADD_RUNTIME_BTN_XP}
+    Click Element    ${ADD_RUNTIME_BTN_XP}
+    Run Keyword And Continue On Failure    Page Should Contain    Add a serving runtime
+    Run Keyword And Continue On Failure    Page Should Contain    Drag a file here, upload files, or start from scratch.
+    Run Keyword And Continue On Failure    Page Should Contain Element    ${UPLOAD_RUNTIME_BTN_XP}
+    Run Keyword And Continue On Failure    Page Should Contain Element    ${SCRATCH_RUNTIME_BTN_XP}
+    Run Keyword And Continue On Failure    Page Should Contain Element    ${EDITOR_RUNTIME_BTN_XP}
 
 Upload Serving Runtime Template
     [Documentation]    Uploads via UI a YAML file containing a custom Serving Runtime definition
     [Arguments]    ${runtime_filepath}    ${serving_platform}
     Click Add Serving Runtime Template Button
-    SeleniumLibrary.Click Element   ${UPLOAD_RUNTIME_BTN_XP}
+    Element Should Be Enabled   ${UPLOAD_RUNTIME_BTN_XP}
     ${rc}    ${pwd}=    Run And Return Rc And Output    echo $PWD
     Should Be Equal As Integers    ${rc}    ${0}
-    SeleniumLibrary.Choose File    ${EDITOR_RUNTIME_BTN_XP}//input[@type="file"]    ${pwd}/${runtime_filepath}
-    Run Keyword And Continue On Failure    SeleniumLibrary.Wait Until Page Contains Element    //span[text()="kind"]
-    Run Keyword And Continue On Failure    SeleniumLibrary.Wait Until Page Contains Element    //span[text()="ServingRuntime"]
+    Choose File    ${EDITOR_RUNTIME_BTN_XP}//input[@type="file"]    ${pwd}/${runtime_filepath}
+    Wait For Dashboard Page Title    Add serving runtime
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element    //span[text()="kind"]
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element    //span[text()="ServingRuntime"]
     Select Model Serving Platform    platform=${serving_platform}
     IF    '${serving_platform}'=='single'    Select Runtime API Protocol
-    Submit Serving Runtime Template
-
-Submit Serving Runtime Template
-    SeleniumLibrary.Click Element    ${SUBMIT_RUNTIME_BTN_XP}
+    Click Element    ${SUBMIT_RUNTIME_BTN_XP}
+    Wait Until Element Is Not Visible   ${SUBMIT_RUNTIME_BTN_XP}
     Wait For RHODS Dashboard To Load    expected_page=Serving runtimes
     ...    wait_for_cards=${FALSE}
 
 Serving Runtime Template Should Be Listed
     [Arguments]    ${displayed_name}    ${serving_platform}
     Run Keyword And Continue On Failure
-    ...    SeleniumLibrary.Wait Until Page Contains Element
+    ...    Wait Until Page Contains Element
     ...    //table//tr/td[@data-label="Name"]//div[text()="${displayed_name}"]
     ...    timeout=10s
     Run Keyword And Continue On Failure
-    ...    SeleniumLibrary.Wait Until Page Contains Element
+    ...    Wait Until Page Contains Element
     ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]    # robocop: disable
-    ${actual_platform_labels_str}=    SeleniumLibrary.Get Text
+    ${actual_platform_labels_str}=    Get Text
     ...    xpath=//table//tr[td[@data-label="Name"]//div[text()="${displayed_name}"]]/td[@data-label="Serving platforms supported"]    # robocop: disable
     ${actual_platform_labels}=    Split To Lines    ${actual_platform_labels_str}
     IF    "${serving_platform}" == "both"
@@ -93,13 +92,13 @@ Select Model Serving Platform
     [Documentation]    Selects which model serving platform the serving runtime could be executed on
     [Arguments]    ${platform}="both"
     ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
-    SeleniumLibrary.Click Element    xpath://div[@data-testid="custom-serving-runtime-selection"]//button
-    SeleniumLibrary.Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]
-    SeleniumLibrary.Click Link    ${platform_link_name}
+    Click Element    xpath://div[@data-testid="custom-serving-runtime-selection"]//button
+    Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]
+    Click Link    ${platform_link_name}
 
 Select Runtime API Protocol
     [Documentation]    Selects which API protocol for the runtime
     [Arguments]    ${protocol}=gRPC
-    SeleniumLibrary.Click Element    xpath://div[@data-testid="custom-serving-api-protocol-selection"]//button
-    SeleniumLibrary.Wait Until Page Contains Element    xpath://a[text()="${protocol}"]
-    SeleniumLibrary.Click Link    ${protocol}
+    Click Element    xpath://div[@data-testid="custom-serving-api-protocol-selection"]//button
+    Wait Until Page Contains Element    xpath://a[text()="${protocol}"]
+    Click Link    ${protocol}

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -73,6 +73,7 @@ Initialize Global Variables
     ${RHODS_VERSION}=    Get RHODS Version    ${force_fetch}
     Set Global Variable   ${RHODS_VERSION}
     Set Prometheus Variables
+    Set Global Variable    ${DASHBOARD_APP_NAME}    ${PRODUCT.lower()}-dashboard
 
 Required Global Variables Should Exist
     [Documentation]   Fails if new required global variables are not set

--- a/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -267,7 +267,6 @@ Verify RHODS Display Name and Version
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-1862
-        
     IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
         ${CSV_DISPLAY} =    Set Variable     Red Hat OpenShift AI
     ELSE

--- a/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -274,8 +274,8 @@ Verify RHODS Display Name and Version
     END
     ${csv_name} =    Run    oc get csv -n ${OPERATOR_NAMESPACE} --no-headers | awk '/${CSV_DISPLAY}/ {print \$1}'
     ${csv_version} =    Run    oc get csv -n ${OPERATOR_NAMESPACE} --no-headers ${csv_name} -o custom-columns=":spec.version"
-    ${csv_version_t} =    Split String   ${csv_name}    .v    1
-    Should Be Equal       ${csv_version_t[1]}   ${csv_version}
+    ${csv_version_t} =    Split String   ${csv_name}    .    1
+    Should Be Equal       ${csv_version_t[1].replace('v','')}   ${csv_version}
     ...    msg='${csv_name}' name and '${csv_version}' vesrion are not consistent
 
 Verify RHODS Notebooks Network Policies

--- a/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -16,7 +16,6 @@ Resource            ../../../Resources/Common.robot
 Suite Setup         RHOSi Setup
 Suite Teardown      RHOSi Teardown
 
-
 *** Test Cases ***
 Verify Dashbord has no message with NO Component Found
     [Tags]  Tier3
@@ -83,7 +82,7 @@ Verify That Prometheus Image Is A CPaaS Built Image
     Skip If RHODS Is Self-Managed
     Wait For Pods To Be Ready    label_selector=deployment=prometheus
     ...    namespace=${MONITORING_NAMESPACE}    timeout=60s
-    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_start_with=prometheus-
+    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_regex=prometheus-
     Container Image Url Should Contain    ${MONITORING_NAMESPACE}    ${pod}    prometheus
     ...    registry.redhat.io/openshift4/ose-prometheus
     Container Image Url Should Contain    ${MONITORING_NAMESPACE}    ${pod}    oauth-proxy
@@ -97,7 +96,7 @@ Verify That Blackbox-exporter Image Is A CPaaS Built Image
     Skip If RHODS Is Self-Managed
     Wait For Pods To Be Ready    label_selector=deployment=blackbox-exporter
     ...    namespace=${MONITORING_NAMESPACE}    timeout=60s
-    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_start_with=blackbox-exporter-
+    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_regex=blackbox-exporter-
     Container Image Url Should Contain    ${MONITORING_NAMESPACE}    ${pod}    blackbox-exporter
     ...    quay.io/integreatly/prometheus-blackbox-exporter
 
@@ -109,7 +108,7 @@ Verify That Alert Manager Image Is A CPaaS Built Image
     Skip If RHODS Is Self-Managed
     Wait For Pods To Be Ready    label_selector=deployment=prometheus
     ...    namespace=${MONITORING_NAMESPACE}    timeout=60s
-    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_start_with=prometheus-
+    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_regex=prometheus-
     Container Image Url Should Contain    ${MONITORING_NAMESPACE}    ${pod}    alertmanager
     ...    registry.redhat.io/openshift4/ose-prometheus-alertmanager
 
@@ -118,9 +117,9 @@ Verify Oath-Proxy Image Is A CPaaS Built Image
     [Tags]      Sanity
     ...         Tier1
     ...         ODS-666
-    Wait For Pods To Be Ready    label_selector=app=rhods-dashboard
+    Wait For Pods To Be Ready    label_selector=app=${DASHBOARD_APP_NAME}
     ...    namespace=${APPLICATIONS_NAMESPACE}    timeout=60s
-    ${pod} =    Find First Pod By Name  namespace=${APPLICATIONS_NAMESPACE}   pod_start_with=rhods-dashboard-
+    ${pod} =    Find First Pod By Name  namespace=${APPLICATIONS_NAMESPACE}   pod_regex=${DASHBOARD_APP_NAME}-
     Container Image Url Should Contain      ${APPLICATIONS_NAMESPACE}     ${pod}      oauth-proxy
     ...     registry.redhat.io/openshift4/ose-oauth-proxy
 
@@ -268,13 +267,17 @@ Verify RHODS Display Name and Version
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-1862
-    ${rhods_csv_detail}   Oc Get    kind=ClusterServiceVersion    label_selector=olm.copiedFrom=${OPERATOR_NAMESPACE}
-    ${rhods_csv_name}     Set Variable     ${rhods_csv_detail[0]['metadata']['name']}
-    ${rhods_version}      Set Variable       ${rhods_csv_detail[0]['spec']['version']}
-    ${rhods_displayname}  Set Variable       ${rhods_csv_detail[0]['spec']['displayName']}
-    ${rhods_version_t}    Split String   ${rhods_csv_name}    .    1
-    Should Be Equal       ${rhods_version_t[1]}   ${rhods_version}   msg=RHODS vesrion and label is not consistent
-    Should Be Equal       ${rhods_displayname}   Red Hat OpenShift AI  msg=Dieplay name doesn't match
+        
+    IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
+        ${CSV_DISPLAY} =    Set Variable     Red Hat OpenShift AI
+    ELSE
+        ${CSV_DISPLAY} =    Set Variable     Open Data Hub Operator
+    END
+    ${csv_name} =    Run    oc get csv -n ${OPERATOR_NAMESPACE} --no-headers | awk '/${CSV_DISPLAY}/ {print \$1}'
+    ${csv_version} =    Run    oc get csv -n ${OPERATOR_NAMESPACE} --no-headers ${csv_name} -o custom-columns=":spec.version"
+    ${csv_version_t} =    Split String   ${csv_name}    .v    1
+    Should Be Equal       ${csv_version_t[1]}   ${csv_version}
+    ...    msg='${csv_name}' name and '${csv_version}' vesrion are not consistent
 
 Verify RHODS Notebooks Network Policies
     [Documentation]    Verifies that the network policies for RHODS Notebooks are present on the cluster
@@ -311,8 +314,8 @@ Verify All The Pods Are Using Image Digest Instead Of Tags
 *** Keywords ***
 Delete Dashboard Pods And Wait Them To Be Back
     [Documentation]    Delete Dashboard Pods And Wait Them To Be Back
-    Oc Delete    kind=Pod     namespace=${APPLICATIONS_NAMESPACE}    label_selector=app=rhods-dashboard
-    OpenShiftLibrary.Wait For Pods Status    namespace=${APPLICATIONS_NAMESPACE}  label_selector=app=rhods-dashboard  timeout=120
+    Oc Delete    kind=Pod     namespace=${APPLICATIONS_NAMESPACE}    label_selector=app=${DASHBOARD_APP_NAME}
+    OpenShiftLibrary.Wait For Pods Status    namespace=${APPLICATIONS_NAMESPACE}  label_selector=app=${DASHBOARD_APP_NAME}  timeout=120
 
 Test Setup For Rhods Dashboard
     [Documentation]    Test Setup for Rhods Dashboard
@@ -341,7 +344,7 @@ Verify Authentication Is Required To Access BlackboxExporter Target
     Length Should Be    ${links}    ${expected_endpoint_count}
     ...    msg=Unexpected number of endpoints in blackbox-exporter target (target_name:${target_name})
 
-    ${pod_name} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_start_with=prometheus-
+    ${pod_name} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_regex=prometheus-
     FOR    ${link}    IN    @{links}
         Log    link:${link}
         ${command} =    Set Variable    curl --silent --insecure ${link}
@@ -354,7 +357,7 @@ Verify Authentication Is Required To Access BlackboxExporter Target
 Verify BlackboxExporter Includes Oauth Proxy
     [Documentation]     Verifies the blackbok-exporter inludes 2 containers one for
     ...                 application and second for oauth proxy
-    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_start_with=blackbox-exporter-
+    ${pod} =    Find First Pod By Name    namespace=${MONITORING_NAMESPACE}    pod_regex=blackbox-exporter-
     @{containers} =    Get Containers    pod_name=${pod}    namespace=${MONITORING_NAMESPACE}
     List Should Contain Value    ${containers}    oauth-proxy
     List Should Contain Value    ${containers}    blackbox-exporter

--- a/ods_ci/tests/Tests/100__deploy/100__installation/104__dashboard.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/104__dashboard.robot
@@ -133,7 +133,7 @@ Fetch Dashboard Pods
     ...        None
     ...    Returns:
     ...        dashboard_pods_info(list(dict)): Dashboard pods selected by label and namespace
-    @{dashboard_pods_info} =    Oc Get    kind=Pod    api_version=v1    namespace=${APPLICATIONS_NAMESPACE}    label_selector=app=rhods-dashboard
+    @{dashboard_pods_info} =    Oc Get    kind=Pod    api_version=v1    namespace=${APPLICATIONS_NAMESPACE}    label_selector=app=${DASHBOARD_APP_NAME}
     RETURN    @{dashboard_pods_info}
 
 Fetch Dashboard Deployments
@@ -143,7 +143,7 @@ Fetch Dashboard Deployments
     ...    Returns:
     ...        dashboard_deployments_info(list(dict)): Dashboard deployments selected by label and namespace
     @{dashboard_deployments_info} =    Oc Get    kind=Deployment    api_version=v1    namespace=${APPLICATIONS_NAMESPACE}
-    ...    label_selector=app=rhods-dashboard
+    ...    label_selector=app=${DASHBOARD_APP_NAME}
     RETURN    @{dashboard_deployments_info}
 
 Fetch Dashboard Services
@@ -152,7 +152,7 @@ Fetch Dashboard Services
     ...        None
     ...    Returns:
     ...        dashboard_services_info(list(dict)): Dashboard services selected by name and namespace
-    @{dashboard_services_info} =    Oc Get    kind=Service    api_version=v1    name=rhods-dashboard    namespace=${APPLICATIONS_NAMESPACE}
+    @{dashboard_services_info} =    Oc Get    kind=Service    api_version=v1    name=${DASHBOARD_APP_NAME}    namespace=${APPLICATIONS_NAMESPACE}
     RETURN    @{dashboard_services_info}
 
 Fetch Dashboard Routes
@@ -161,14 +161,14 @@ Fetch Dashboard Routes
     ...        None
     ...    Returns:
     ...        dashboard_routes_info(list(dict)): Dashboard routes selected by name and namespace
-    @{dashboard_routes_info} =    Oc Get    kind=Route    api_version=route.openshift.io/v1    name=rhods-dashboard
+    @{dashboard_routes_info} =    Oc Get    kind=Route    api_version=route.openshift.io/v1    name=${DASHBOARD_APP_NAME}
     ...    namespace=${APPLICATIONS_NAMESPACE}
     RETURN    @{dashboard_routes_info}
 
 Verify Dashboard ReplicaSets Info
     [Documentation]    Fetchs and verifies information from Dashboard replicasets
     @{dashboard_replicasets_info} =    Oc Get    kind=ReplicaSet    api_version=v1    namespace=${APPLICATIONS_NAMESPACE}
-    ...    label_selector=app=rhods-dashboard
+    ...    label_selector=app=${DASHBOARD_APP_NAME}
     OpenShift Resource Field Value Should Be Equal As Strings    status.readyReplicas
     ...    ${EXP_DASHBOARD_REPLICAS}    @{dashboard_replicasets_info}
     OpenShift Resource Field Value Should Be Equal As Strings    status.replicas
@@ -200,6 +200,6 @@ Fetch rhods-dashboard ClusterRole Info
     ...        None
     ...    Returns:
     ...        rhodsdashboard_clusterrole_info(dict): Dictionary containing rhods-dashboard ClusterRole Information
-    @{resources_info_list}=    Oc Get    kind=ClusterRole    api_version=rbac.authorization.k8s.io/v1    name=rhods-dashboard
+    @{resources_info_list}=    Oc Get    kind=ClusterRole    api_version=rbac.authorization.k8s.io/v1    name=${DASHBOARD_APP_NAME}
     &{rhodsdashboard_clusterrole_info} =    Set Variable    ${resources_info_list}[0]
     RETURN    &{rhodsdashboard_clusterrole_info}

--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -34,7 +34,7 @@ Verify OpenShift Monitoring Results Are Correct When Running Undefined Queries
 
 Test Billing Metric (Notebook Cpu Usage) On OpenShift Monitoring
     [Documentation]     Run notebook for 5 min and checks CPU usage is greater than zero
-    [Tags]    Smoke
+    [Tags]    Sanity
     ...       Tier1
     ...       ODS-175
     Run Jupyter Notebook For 5 Minutes

--- a/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
+++ b/ods_ci/tests/Tests/200__monitor_and_manage/200__metrics/201__billing_metrics.robot
@@ -184,7 +184,7 @@ Run Jupyter Notebook For 5 Minutes
     [Documentation]     Opens jupyter notebook and run for 5 min
     Open Browser    ${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}    options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Iterative Image Test
     ...    science-notebook
     ...    https://github.com/lugi0/minimal-nb-image-test
@@ -215,7 +215,7 @@ CleanUp JupyterHub
     [Documentation]     Cleans JupyterHub
     Open Browser    ${ODH_DASHBOARD_URL}    browser=${BROWSER.NAME}    options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
     Page Should Not Contain    403 : Forbidden

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -191,7 +191,7 @@ Verify Notifications Appears When Notebook Builds Finish And Atleast One Failed
 
 Verify Favorite Resource Cards
     [Tags]    ODS-389    ODS-384
-    ...       Tier1
+    ...       Sanity
     [Documentation]    Verifies the item in Resource page can be marked se favorite.
     ...                It checks if favorite items are always listed as first regardless
     ...                the view type or sorting
@@ -201,16 +201,16 @@ Verify Favorite Resource Cards
     ${list_of_tile_ids} =    Get List Of Ids Of Tiles
     Verify Star Icons Are Clickable    ${list_of_tile_ids}
 
-    ${favorite_ids} =    Get Slice From List    ${list_of_tile_ids}    ${27}    ${48}
+    ${favorite_ids} =    Get Slice From List    ${list_of_tile_ids}    ${2}    ${7}
     Add The Items In Favorites    @{favorite_ids}
 
     ${list_of_tile_ids} =    Get List Of Ids Of Tiles
-    Favorite Items Should Be Listed First    ${favorite_ids}    ${list_of_tile_ids}    ${21}
+    Favorite Items Should Be Listed First    ${favorite_ids}    ${list_of_tile_ids}    ${5}
 
     Click Button    //*[@id="list-view"]
     Sleep    0.5s
     ${list_view_tiles} =    Get The List Of Ids of Tiles In List View
-    Favorite Items Should Be Listed First    ${favorite_ids}    ${list_view_tiles}    ${21}
+    Favorite Items Should Be Listed First    ${favorite_ids}    ${list_view_tiles}    ${5}
 
     Click Button    //*[@id="card-view"]
     Sleep    0.5s
@@ -441,22 +441,24 @@ Verify Star Icons Are Clickable
 Get List Of Ids Of Tiles
     [Documentation]    Returns the list of ids of tiles present in resources page
     ${list_of_ids}=    Get List Of Atrributes
-    ...    xpath=//div[@class="pf-v5-c-card pf-m-selectable odh-card odh-tourable-card"]    attribute=id
+    ...    xpath=//div[contains(@class, "odh-tourable-card")]    attribute=id
     RETURN    ${list_of_ids}
 
 Set Item As Favorite
     [Documentation]    Add the tiles in favorite
     [Arguments]    ${id}
-    ${not_clicked} =    Get Element Attribute    //*[@id="${id}"]/div[1]/span    class
-    Should Be Equal    ${not_clicked}    odh-dashboard__favorite
-    Click Element    //*[@id="${id}"]/div[1]/span
+    ${card_star_button}=    Set Variable    //*[@id="${id}" and contains(@class, "odh-tourable-card")]//button
+    ${not_clicked} =    Get Element Attribute    ${card_star_button}    aria-label
+    Should Be Equal    ${not_clicked}    not starred
+    Click Element    ${card_star_button}
 
 Remove An Item From Favorite
     [Documentation]    Removes the tiles from favorite
     [Arguments]    ${id}
-    ${clicked} =    Get Element Attribute    //*[@id="${id}"]/div[1]/span    class
-    Should Be Equal    ${clicked}    odh-dashboard__favorite m-is-favorite
-    Click Element    //*[@id="${id}"]/div[1]/span
+    ${card_star_button}=    Set Variable    //*[@id="${id}" and contains(@class, "odh-tourable-card")]//button
+    ${clicked} =    Get Element Attribute    ${card_star_button}    aria-label
+    Should Be Equal    ${clicked}    starred
+    Click Element    ${card_star_button}
 
 Add The Items In Favorites
     [Documentation]    Add the tiles in the favorites
@@ -471,7 +473,7 @@ Favorite Items Should Be Listed First When Sorted By
     [Arguments]    ${list_of_ids_of_favorite}    ${sort_type}
     Sort Resources By    ${sort_type}
     ${new_list_of_tile} =    Get List Of Ids Of Tiles
-    Favorite Items Should Be Listed First    ${list_of_ids_of_favorite}    ${new_list_of_tile}    ${21}
+    Favorite Items Should Be Listed First    ${list_of_ids_of_favorite}    ${new_list_of_tile}    ${5}
 
 Get The List Of Ids of Tiles In List View
     [Documentation]    Returns the list of ids of tiles in list view

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -56,6 +56,9 @@ Verify Content In RHODS Explore Section
     [Tags]    Sanity    Tier1
     ...       ODS-488    ODS-993    ODS-749    ODS-352    ODS-282
     ...       ProductBug
+    ...       AutomationBugOnODH
+    # TODO: In ODH there are only 2 Apps, we excpect 7 Apps according to:
+    # ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
     ${EXP_DATA_DICT}=    Load Expected Data Of RHODS Explore Section
     Click Link    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
@@ -67,6 +70,9 @@ Verify RHODS Explore Section Contains Only Expected ISVs
     [Tags]    Smoke
     ...       Tier1
     ...       ODS-1890
+    ...       AutomationBugOnODH
+    # TODO: In ODH there are only 2 Apps, we excpect 7 Apps according to:
+    # ods_ci/tests/Resources/Files/AppsInfoDictionary_latest.json
     ${EXP_DATA_DICT}=    Load Expected Data Of RHODS Explore Section
     Click Link    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
@@ -128,6 +134,10 @@ Verify Documentation Link HTTP Status Code
     ...    also checks the RHODS dcoumentation link present in resource page.
     [Tags]    Sanity    Tier1
     ...       ODS-327    ODS-492
+    ...       AutomationBugOnODH
+    # TODO: In ODH the expected Docs links are:
+    # https://opendatahub.io/community
+    # https://opendatahub.io/docs
     ${links}=  Get RHODS Documentation Links From Dashboard
     Documentation Links Should Be Equal To The Expected Ones   actual_links=${links}  expected_links=${DOC_LINKS_EXP}
     Check External Links Status     links=${links}
@@ -145,6 +155,7 @@ Search and Verify GPU Items Appears In Resources Page
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-1226
+    ...       ExcludeOnODH
     Search Items In Resources Section    GPU
     Check GPU Resources
 
@@ -163,6 +174,7 @@ Verify Notifications Appears When Notebook Builds Finish And Atleast One Failed
     ...       ODS-470  ODS-718
     ...       Execution-Time-Over-30m
     ...       FlakyTest
+    ${failed_build_name}=    Set Variable    ${NONE}
     Skip If RHODS Version Greater Or Equal Than    1.20.0    CUDA build chain removed in v1.20
     Clear Dashboard Notifications
     ${build_name}=  Search Last Build  namespace=${APPLICATIONS_NAMESPACE}    build_name_includes=pytorch
@@ -184,7 +196,7 @@ Verify Favorite Resource Cards
     ...                It checks if favorite items are always listed as first regardless
     ...                the view type or sorting
     Click Link    Resources
-    Wait Until Element Is Visible    //div[@class="pf-v5-l-gallery pf-m-gutter odh-learning-paths__gallery"]
+    Wait Until Resource Page Is Loaded
     Sort Resources By    name
     ${list_of_tile_ids} =    Get List Of Ids Of Tiles
     Verify Star Icons Are Clickable    ${list_of_tile_ids}

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -299,7 +299,7 @@ Verify Dashboard Pod Is Not Getting Restarted
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-374
-    ${pod_names}    Get POD Names    ${APPLICATIONS_NAMESPACE}    app=rhods-dashboard
+    ${pod_names}    Get POD Names    ${APPLICATIONS_NAMESPACE}    app=${DASHBOARD_APP_NAME}
     Verify Containers Have Zero Restarts    ${pod_names}    ${APPLICATIONS_NAMESPACE}
 
 Verify Switcher to Masterhead
@@ -480,7 +480,7 @@ Remove Items From Favorites
     Close Browser
 
 RHODS Dahsboard Pod Should Contain OauthProxy Container
-    ${list_of_pods} =    Search Pod    namespace=${APPLICATIONS_NAMESPACE}    pod_start_with=rhods-dashboard
+    ${list_of_pods} =    Search Pod    namespace=${APPLICATIONS_NAMESPACE}    pod_regex=${DASHBOARD_APP_NAME}
     FOR    ${pod_name}    IN   @{list_of_pods}
         ${container_name} =    Get Containers    pod_name=${pod_name}    namespace=${APPLICATIONS_NAMESPACE}
         List Should Contain Value    ${container_name}    oauth-proxy

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -4,6 +4,7 @@ Resource          ../../Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
 Resource          ../../Resources/RHOSi.resource
 Resource          ../../Resources/ODS.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
+Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
 Resource          ../../Resources/Page/ODH/AiApps/Anaconda.resource
 Resource          ../../Resources/Page/LoginPage.robot
@@ -125,7 +126,8 @@ Verify CSS Style Of Getting Started Descriptions
     ...       ODS-1165
     Click Link    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
-    Open Get Started Sidebar And Return Status    card_locator=${SAMPLE_APP_CARD_XP}
+    ${status}=    Open Get Started Sidebar And Return Status    card_locator=${JUPYTER_CARD_XP}
+    Should Be Equal    ${status}    ${TRUE}
     Capture Page Screenshot    get_started_sidebar.png
     Verify Jupyter Card CSS Style
 
@@ -501,10 +503,9 @@ RHODS Dahsboard Pod Should Contain OauthProxy Container
     END
 
 Verify Jupyter Card CSS Style
-    [Documentation]    Compare the some CSS properties of the Explore page
-    ...    with the expected ones. The expected values change based
-    ...    on the RHODS version
-    CSS Property Value Should Be    locator=//pre
+    [Documentation]    Compare the some CSS properties of the Explore page with the expected ones
+    # Verify that the color of the Jupyter code is gray
+    CSS Property Value Should Be    locator=${EXPLORE_PANEL_XP}//code
     ...    property=background-color    exp_value=rgba(240, 240, 240, 1)
     CSS Property Value Should Be    locator=${SIDEBAR_TEXT_CONTAINER_XP}//p
     ...    property=margin-bottom    exp_value=8px

--- a/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
@@ -65,12 +65,12 @@ Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook
     AllowedGroups In OdhDashboardConfig CRD Should Be      rhods-admins
     Logout From RHODS Dashboard
     Login To RHODS Dashboard    ${TEST_USER_4.USERNAME}    ${TEST_USER_4.PASSWORD}    ${TEST_USER_4.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Wait For RHODS Dashboard To Load    expected_page=${NONE}    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
     Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
     # Let's check that we're not allowed to also access the spawner page directly navigating the browser there
     Go To    ${ODH_DASHBOARD_URL}/notebookController/spawner
-    Wait for RHODS Dashboard to Load    expected_page=${NONE}    wait_for_cards=${FALSE}
+    Wait For RHODS Dashboard To Load    expected_page=${NONE}    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure    Page Should Contain    Access permissions needed
     Run Keyword And Continue On Failure    Page Should Contain    ask your administrator to adjust your permissions.
     [Teardown]  Revert Changes To Access Configuration

--- a/ods_ci/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -22,7 +22,7 @@ ${python_dict}  {'classifiers':[${generic-1}, ${minimal-1}], 'clustering':[${gen
 Open RHODS Dashboard
   [Tags]  Sanity    Tier1
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
 
 Iterative Testing Classifiers
   [Tags]  Sanity  POLARION-ID-Classifiers    Tier1

--- a/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -120,13 +120,13 @@ Check New Access Configuration Works As Expected
     Capture Page Screenshot    perm_denied_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_2.USERNAME}  ${TEST_USER_2.PASSWORD}  ${TEST_USER_2.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Run Keyword And Continue On Failure   Verify Jupyter Access Level    expected_result=admin
     Capture Page Screenshot    perm_admin_custom.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load    expected_page=Start a notebook server
+    Wait For RHODS Dashboard To Load    expected_page=Start a notebook server
     ...    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure   Verify Jupyter Access Level     expected_result=user
     Capture Page Screenshot    perm_user_custom.png
@@ -142,7 +142,7 @@ Check Standard Access Configuration Works As Expected
     Capture Page Screenshot    perm_admin_std.png
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${TEST_USER_4.USERNAME}  ${TEST_USER_4.PASSWORD}  ${TEST_USER_4.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load    expected_page=Start a notebook server
+    Wait For RHODS Dashboard To Load    expected_page=Start a notebook server
     ...    wait_for_cards=${FALSE}
     Run Keyword And Continue On Failure   Verify Jupyter Access Level   expected_result=user
     Capture Page Screenshot    perm_user_std.png

--- a/ods_ci/tests/Tests/500__jupyterhub/multiple-gpus.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/multiple-gpus.robot
@@ -41,7 +41,7 @@ Verify Two Servers Can Be Spawned
     Sleep    60s
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER_2.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch JupyterHub Spawner From Dashboard    username=${TEST_USER_2.USERNAME}
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small  gpus=1
     ${serial_second} =    Get GPU Serial Number
@@ -66,6 +66,6 @@ Double User Teardown
     Close Browser
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch JupyterHub Spawner From Dashboard
     End Web Test

--- a/ods_ci/tests/Tests/500__jupyterhub/special-user-testing.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/special-user-testing.robot
@@ -23,7 +23,7 @@ Test Special Usernames
     ...     ODS-257  ODS-532
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     FOR  ${char}  IN  @{CHARS}
         Login Verify Logout  ldap-special${char}  ${TEST_USER.PASSWORD}  ldap-provider-qe

--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-flask-notebook.robot
@@ -14,7 +14,7 @@ Test Tags       JupyterHub
 *** Test Cases ***
 Open RHODS Dashboard
   [Tags]  Tier2
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
   [Tags]  Tier2

--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
@@ -14,7 +14,7 @@ Test Tags       JupyterHub
 *** Test Cases ***
 Open RHODS Dashboard
   [Tags]  Sanity    Tier1
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity    Tier1

--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-notebook.robot
@@ -17,7 +17,7 @@ Test Tags       JupyterHub
 *** Test Cases ***
 Open RHODS Dashboard
   [Tags]  Sanity    Tier1
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity    Tier1

--- a/ods_ci/tests/Tests/500__jupyterhub/test-minimal-image.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-minimal-image.robot
@@ -20,7 +20,7 @@ ${RequirementsFilePath}=    ods-ci-notebooks-main/notebooks/500__jupyterhub/test
 
 *** Test Cases ***
 Open RHODS Dashboard
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
     Launch Jupyter From RHODS Dashboard Link

--- a/ods_ci/tests/Tests/500__jupyterhub/test-pipChanges-not-permanent.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-pipChanges-not-permanent.robot
@@ -30,6 +30,6 @@ Verify pip Changes not permanent
 Test Setup
     [Documentation]  Added customized Setup
     Begin Web Test
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook With Arguments    image=minimal-notebook

--- a/ods_ci/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-s3-cc-fraud.robot
@@ -14,7 +14,7 @@ Test Tags       JupyterHub
 *** Test Cases ***
 Open RHODS Dashboard
   [Tags]  Sanity    Tier1
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
   [Tags]  Sanity    Tier1

--- a/ods_ci/tests/Tests/500__jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test.robot
@@ -30,7 +30,7 @@ Can Launch Jupyterhub
     #This keyword will work with accounts that are not cluster admins.
     Launch RHODS Via OCP Application Launcher
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    Wait for RHODS Dashboard to Load
+    Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
 
 Can Login To Jupyterhub

--- a/ods_ci/tests/Tests/600__ai_apps/610__ibm_watson_studio/610__ibm_watson_studio.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/610__ibm_watson_studio/610__ibm_watson_studio.robot
@@ -13,7 +13,7 @@ Verify IBM Watson Studio Is Available In RHODS Dashboard Explore Page
   ...     ODS-267
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
   Verify Service Is Available In The Explore Page    IBM Watson Studio
   Verify Service Provides "Get Started" Button In The Explore Page    IBM Watson Studio
 

--- a/ods_ci/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/620__intel_aikit/620__intel_aikit.robot
@@ -22,7 +22,7 @@ Verify Intel AIKIT Is Available In RHODS Dashboard Explore Page
   ...     ODS-1017
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
   Verify Service Is Available In The Explore Page     ${intel_aikit_container_name}
   Verify Service Provides "Get Started" Button In The Explore Page     ${intel_aikit_container_name}
 

--- a/ods_ci/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/640__rhoam/640__rhoam.robot
@@ -14,7 +14,7 @@ Verify RHOAM Is Available In RHODS Dashboard Explore Page
   ...       ODS-271
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
   Verify RHOAM Availability Based On RHODS Installation Type
 
 Verify RHOAM Is Enabled In RHODS After Installation

--- a/ods_ci/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/660__openvino/660__openvino.robot
@@ -21,7 +21,7 @@ Verify OpenVino Is Available In RHODS Dashboard Explore Page
   ...     ODS-493
   Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  Wait for RHODS Dashboard to Load
+  Wait For RHODS Dashboard To Load
   Verify Service Is Available In The Explore Page    OpenVINO
   Verify Service Provides "Get Started" Button In The Explore Page    OpenVINO
 


### PR DESCRIPTION
Including fixing dependent KW and tests:
- Fix `Verify RHODS Display Name and Version` for ODH
- Set $DASHBOARD_APP_NAME according to RHODS / ODH
- Fix `Verify Favorite Resource Cards` test 
- Fix `Sort Resources By` KW
- Fix `Verify Jupyter Card CSS Style` KW
- Fix `Upload Serving Runtime Template` in ODHDashboard Settings
- Update DEFAULT_NOTEBOOK_VER=2024.1 and PREVIOUS_NOTEBOOK_VER=2023.2
- Search Pod KW returns a list of pods that match regular expression
- Verify Jupiter Service Is Not Enabled should not wait long (app isn't present)
- Remove Test Billing Metric test (5+ minutes) from Smoke

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/45d49105-4855-4d92-80c8-6dc5ccb17f95)

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/c5ca12e2-7a79-4e74-8f1c-097fbdeda1de)

