### PR TITLE
RHOAIENG-3425_Validate_Trusted_CA_Bundle

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -100,8 +100,7 @@ Is DSCI In Ready State
     [Documentation]    Checks that DSCI Reconciled Succesfully
     [Arguments]    ${dsci}    ${namespace}
     ${rc}=    Run And Return Rc 
-    ...    oc wait --timeout=3m
-    ... --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted-n ${namespace} dsci ${dsci}
+    ...    oc wait --timeout=3m --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsci ${dsci}
     Should Be Equal As Integers    ${rc}     ${0}    msg=${dsci} not in Ready state
 
 Check ConfigMap Contains CA Bundle
@@ -122,22 +121,19 @@ Set Custom CA Bundle Value In DSCI
     [Documentation]    Set Custom CA Bundle Value in DSCI
     [Arguments]    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch DSCInitialization/default-dsci
-    ... -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set DSCI Custom CA Bundle value to ${custom_ca_bundle_value}
 
 Set Custom CA Bundle Value On ConfigMap
     [Documentation]    Set Custom CA Bundle Value in ConfigMap
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch ConfigMap/${config_map}
-    ... -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
+    ...    oc patch ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set ${config_map} value ${custom_ca_bundle_value} ${namespace}
 
 Set Trusted CA Bundle Management State
     [Documentation]    Change DSCI Management State to one of Managed/Unmanaged/Removed
     [Arguments]    ${management_state}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch DSCInitialization/default-dsci
-    ... -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed update DSCI trustedCABundle managementState to ${management_state}

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -99,7 +99,7 @@ Is Resource Present
 Is DSCI In Ready State
     [Documentation]    Checks that DSCI Reconciled Succesfully
     [Arguments]    ${dsci}    ${namespace}
-    ${rc}=    Run And Return Rc 
+    ${rc}=    Run And Return Rc
     ...    oc wait --timeout=3m --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsci ${dsci}
     Should Be Equal As Integers    ${rc}     ${0}    msg=${dsci} not in Ready state
 

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -5,6 +5,7 @@ Resource    ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
 Suite Setup    Suite Setup
 Suite Teardown    Suite Teardown
 
+
 *** Variables ***
 ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    rhods-operator
 ${SERVICE_MESH_OPERATOR_NS}    openshift-operators
@@ -41,28 +42,28 @@ Validate Trusted CA Bundles ConfigMaps
     Check ConfigMap Contains CA Bundle   ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ca-bundle.crt    ${SERVICE_MESH_CR_NS}
 
     Set Custom CA Bundle Value In DSCI   ${CUSTOM_CA_BUNDLE}    ${RHOAI_OPERATOR_NS}
-    Wait Until Keyword Succeeds    
-    ...    3 min    0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+    Wait Until Keyword Succeeds    3 min    0 sec    
+    ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
 
     Log    message=Validate Trusted CA Bundle Management State Unmanaged    level=INFO
 
     Set Trusted CA Bundle Management State    Unmanaged    ${RHOAI_OPERATOR_NS}
 
-    #Trusted CA BUndle managementStatus 'Unmanaged' should NOT result in bundle being overwirtten by operator
+    # Trusted CA BUndle managementStatus 'Unmanaged' should NOT result in bundle being overwirtten by operator
     Set Custom CA Bundle Value On ConfigMap
     ...    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}
     # Allow operator time to reconsile
     Sleep    5
-    Wait Until Keyword Succeeds
-    ...    3 min    0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+    Wait Until Keyword Succeeds    3 min    0 sec
+    ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
 
     Log    message=Validate Trusted CA Bundle Management State Removed    level=INFO
 
     Set Trusted CA Bundle Management State    Removed    ${RHOAI_OPERATOR_NS}
 
     # Check that odh-trusted-ca-bundle has been 'Removed'
-    Wait Until Keyword Succeeds
-    ...    3 min    0 sec    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_NOT_PRESENT}
+    Wait Until Keyword Succeeds    3 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_NOT_PRESENT}
 
     Log    message=Restore DSCI to original state    level=INFO
     Set Custom CA Bundle Value In DSCI   ''    ${RHOAI_OPERATOR_NS}
@@ -133,22 +134,22 @@ Set Custom CA Bundle Value In DSCI
     [Documentation]    Set Custom CA Bundle Value in DSCI
     [Arguments]    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch
-    ...    DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    ...    oc patch DSCInitialization/default-dsci
+    ...    -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set DSCI Custom CA Bundle value to ${custom_ca_bundle_value}
 
 Set Custom CA Bundle Value On ConfigMap
     [Documentation]    Set Custom CA Bundle Value in ConfigMap
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch
-    ...    ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
+    ...    oc patch ConfigMap/${config_map}
+    ...    -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set ${config_map} value ${custom_ca_bundle_value} ${namespace}
 
 Set Trusted CA Bundle Management State
     [Documentation]    Change DSCI Management State to one of Managed/Unmanaged/Removed
     [Arguments]    ${management_state}    ${namespace}
     ${rc}=     Run And Return Rc
-    ...    oc patch
-    ...    DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    ...    oc patch DSCInitialization/default-dsci
+    ...    -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed update DSCI trustedCABundle managementState to ${management_state}

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -7,6 +7,9 @@ Suite Teardown    Suite Teardown
 
 
 *** Variables ***
+${RHOAI_APPNAME}     Red Hat OpenShift AI
+${RHOAI_OPERATOR_NAME}    Red Hat OpenShift AI
+${RHOAI_OPERATOR_NS}    redhat-ods-operator
 ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    rhods-operator
 ${SERVICE_MESH_OPERATOR_NS}    openshift-operators
 ${SERVICE_MESH_CR_NS}    istio-system
@@ -25,8 +28,6 @@ Validate Trusted CA Bundles ConfigMaps
     ...    odh-trusted-ca-bundle ConfigMaps
     [Tags]    Operator
     ...       ODS-2638
-
-    Assign Vars According To Product    ${PRODUCT}
 
     Log    message=Check that operators are available    level=INFO
 
@@ -81,19 +82,6 @@ Suite Teardown
     Log    message=Suite Teardown.    level=INFO
     RHOSi Teardown
 
-Assign Vars According To Product
-    [Documentation]    Assign variables related to product
-    [Arguments]    ${product}
-    IF    "${product}" == "RHODS"
-        VAR    ${RHOAI_APPNAME}     Red Hat OpenShift AI
-        VAR    ${RHOAI_OPERATOR_NAME}    Red Hat OpenShift AI
-        VAR    ${RHOAI_OPERATOR_NS}    redhat-ods-operator
-    ELSE IF    "${product}" == "ODH"
-        VAR    ${RHOAI_APPNAME}  Open Data Hub Operator
-        VAR    ${RHOAI_OPERATOR_NAME}    Open Data Hub Operator
-        VAR    ${RHOAI_OPERATOR_NS}    openshift-operators
-    END
-
 Is Operator Available
     [Documentation]    Checks if operator is available
     [Arguments]    ${operator_name}    ${namespace}
@@ -111,9 +99,9 @@ Is Resource Present
 Is DSCI In Ready State
     [Documentation]    Checks that DSCI Reconciled Succesfully
     [Arguments]    ${dsci}    ${namespace}
-    ${rc}=    Run And Return Rc
+    ${rc}=    Run And Return Rc 
     ...    oc wait --timeout=3m
-    ...    --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted-n ${namespace} dsci ${dsci}
+    ... --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted-n ${namespace} dsci ${dsci}
     Should Be Equal As Integers    ${rc}     ${0}    msg=${dsci} not in Ready state
 
 Check ConfigMap Contains CA Bundle
@@ -135,7 +123,7 @@ Set Custom CA Bundle Value In DSCI
     [Arguments]    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
     ...    oc patch DSCInitialization/default-dsci
-    ...    -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    ... -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set DSCI Custom CA Bundle value to ${custom_ca_bundle_value}
 
 Set Custom CA Bundle Value On ConfigMap
@@ -143,7 +131,7 @@ Set Custom CA Bundle Value On ConfigMap
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}
     ${rc}=     Run And Return Rc
     ...    oc patch ConfigMap/${config_map}
-    ...    -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
+    ... -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set ${config_map} value ${custom_ca_bundle_value} ${namespace}
 
 Set Trusted CA Bundle Management State
@@ -151,5 +139,5 @@ Set Trusted CA Bundle Management State
     [Arguments]    ${management_state}    ${namespace}
     ${rc}=     Run And Return Rc
     ...    oc patch DSCInitialization/default-dsci
-    ...    -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    ... -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed update DSCI trustedCABundle managementState to ${management_state}

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -1,0 +1,149 @@
+*** Settings ***
+Documentation    Test Cases to verify Serverless installation
+Library         Collections
+Resource        ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
+Suite Setup      Suite Setup
+Suite Teardown   Suite Teardown
+
+
+*** Variables ***
+${RHOAI_OPERATOR_DEPLOYMENT_NAME}    rhods-operator
+${SERVICE_MESH_APPNAME}    Red Hat OpenShift Service Mesh
+${SERVICE_MESH_OPERATOR_NAME}    Red Hat OpenShift Service Mesh
+${SERVICE_MESH_OPERATOR_NS}    openshift-operators
+${SERVICE_MESH_CR_NS}    istio-system
+${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
+${DSCI_NAME}    default-dsci
+${TRUSTED_CA_BUNDLE_CONFIGMAP}    odh-trusted-ca-bundle
+${CUSTOM_CA_BUNDLE}    test-example-custom-ca-bundle
+
+${IS_PRESENT}    0
+${IS_NOT_PRESENT}    1
+
+
+*** Test Cases ***
+Validate DSCI creates Trusted CA Bundles ConfigMaps
+    [Documentation]  The purpose of this Test Case is to validate the creation of
+    ...    odh-trusted-ca-bundle ConfigMaps
+    [Tags]    Operator
+    ...       ODS-2638
+
+    Assign Vars According To Product    ${PRODUCT}
+
+    Log    message=Check that operator are available    level=INFO
+
+    Is Operator Available    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${RHOAI_OPERATOR_NS}
+    Is Operator Available    ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    ${SERVICE_MESH_OPERATOR_NS}
+
+    Log    message=Validate Trusted CA Bundle Management state Managed    level=INFO
+
+    Is DSCI In Ready State    ${DSCI_NAME}    ${SERVICE_MESH_OPERATOR_NS}
+    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+
+    # Check that ConfigMap contains "ca-bundle.crt"
+    Check ConfigMap Contains CA Bundle   ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ca-bundle.crt    ${SERVICE_MESH_CR_NS}
+
+    Set Custom CA Bundle Value In DSCI   ${CUSTOM_CA_BUNDLE}    ${RHOAI_OPERATOR_NS}
+    Wait Until Keyword Succeeds    3 min	0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+
+    Log    message=Validate Trusted CA Bundle Management State Unmanaged    level=INFO
+
+    Set Trusted CA Bundle Management State    Unmanaged    ${RHOAI_OPERATOR_NS}
+
+    # Setting the Custom CA Bundle in ConfigMap with managementStatus to 'Unmanaged' should NOT result in bundle being overwirtten by operator
+    Set Custom CA Bundle Value On ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    
+    # Allow operator time to reconsile
+    Sleep    5
+    Wait Until Keyword Succeeds    3 min	0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+
+    Log    message=Validate Trusted CA Bundle Management State Removed    level=INFO
+
+    Set Trusted CA Bundle Management State    Removed    ${RHOAI_OPERATOR_NS}
+
+    # Check that odh-trusted-ca-bundle has been 'Removed'
+    Wait Until Keyword Succeeds    3 min	0 sec    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_NOT_PRESENT}
+
+    Log    message=Restore DSCI to original state    level=INFO
+    Set Custom CA Bundle Value In DSCI   ''    ${RHOAI_OPERATOR_NS}
+    Set Trusted CA Bundle Management State    Managed    ${RHOAI_OPERATOR_NS}
+
+
+*** Keywords ***
+Suite Setup
+    [Documentation]    Suite Setup
+    Log    message=Suite Setup.    level=INFO
+    RHOSi Setup
+
+Suite Teardown
+    [Documentation]    Suite Teardown
+    Log    message=Suite Teardown.    level=INFO
+    RHOSi Teardown
+
+Assign Vars According To Product
+    [Documentation]    Assign variables related to product
+    [Arguments]    ${product}
+    IF    "${product}" == "RHODS"
+        Set Suite Variable    ${RHOAI_APPNAME}     Red Hat OpenShift AI
+        Set Suite Variable    ${RHOAI_OPERATOR_NAME}    Red Hat OpenShift AI
+        Set Suite Variable    ${RHOAI_OPERATOR_NS}    redhat-ods-operator
+    ELSE IF    "${product}" == "ODH"
+        Set Suite Variable    ${RHOAI_APPNAME}  Open Data Hub Operator
+        Set Suite Variable    ${RHOAI_OPERATOR_NAME}    Open Data Hub Operator
+        Set Suite Variable    ${RHOAI_OPERATOR_NS}    openshift-operators
+    END
+
+Is Operator Available
+    [Documentation]    Checks if operator is available
+    [Arguments]    ${operator_name}    ${namespace} 
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    oc wait --timeout=2m --for condition=available -n ${namespace} deploy/${operator_name}
+    Should Be Equal As Integers    ${rc}     ${0}    msg=${operator_name} Not Available
+
+Is Resource Present
+    [Documentation]    Check If Resource Is Present In Namespace
+    [Arguments]       ${resource}     ${resource_name}    ${namespace}    ${expected_result}
+    ${rc}=     Run and Return Rc
+    ...  oc get ${resource} ${resource_name} -n ${namespace}
+    Should Be Equal    "${rc}"    "${expected_result}"    msg=${resource} does not exist in ${namespace}
+
+Is DSCI In Ready State
+    [Documentation]    Checks that DSCI Reconciled Succesfully
+    [Arguments]    ${dsci}    ${namespace}
+    ${rc}    ${out}=    Run And Return Rc And Output
+    ...    oc wait --timeout=3m --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsci ${dsci}
+    Should Be Equal As Integers    ${rc}     ${0}    msg=${DSCI} not in Ready state
+
+Check ConfigMap Contains CA Bundle
+    [Documentation]    Checks that ConfigMap contains CA Bundle
+    [Arguments]    ${config_map}    ${ca_bundle_name}    ${namespace}
+    ${rc}=     Run and Return Rc
+    ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${ca_bundle_name}
+    Should Be Equal    "${rc}"    "0"    msg=${TRUSTED_CA_BUNDLE_CONFIGMAP} does not contain CA bundle ${ca_bundle_name}
+
+Is CA Bundle Value Present
+    [Documentation]    Check if the ConfigtMap contains Custom CA Bundle value
+    [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}        ${expected_result}
+    ${rc}=     Run and Return Rc
+    ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${custom_ca_bundle_value}
+    Should Be Equal As Integers    ${rc}    ${expected_result}
+
+Set Custom CA Bundle Value In DSCI
+    [Documentation]    Set Custom CA Bundle Value in DSCI
+    [Arguments]    ${custom_ca_bundle_value}    ${namespace}
+    ${rc}=     Run and Return Rc
+    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    Should Be Equal    "${rc}"    "0"    msg=Failed to set DSCI Custom CA Bundle value to ${custom_ca_bundle_value}
+
+Set Custom CA Bundle Value On ConfigMap
+    [Documentation]    Set Custom CA Bundle Value in ConfigMap
+    [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}
+    ${rc}=     Run and Return Rc
+    ...    oc patch ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge 
+    Should Be Equal    "${rc}"    "0"    msg=Failed to set ConfigMap Custom CA Bundle value to ${config_map} ${custom_ca_bundle_value} ${namespace}
+
+Set Trusted CA Bundle Management State
+    [Documentation]    Change DSCI Management State to one of Managed/Unmanaged/Removed
+    [Arguments]    ${management_state}    ${namespace}
+    ${rc}=     Run and Return Rc
+    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    Should Be Equal    "${rc}"    "0"    msg=Failed to update DSCI trustedCABundle managementState to ${management_state}

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -1,15 +1,12 @@
 *** Settings ***
 Documentation    Test Cases to verify Serverless installation
-Library         Collections
-Resource        ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
-Suite Setup      Suite Setup
-Suite Teardown   Suite Teardown
-
+Library    Collections
+Resource    ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
+Suite Setup    Suite Setup
+Suite Teardown    Suite Teardown
 
 *** Variables ***
 ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    rhods-operator
-${SERVICE_MESH_APPNAME}    Red Hat OpenShift Service Mesh
-${SERVICE_MESH_OPERATOR_NAME}    Red Hat OpenShift Service Mesh
 ${SERVICE_MESH_OPERATOR_NS}    openshift-operators
 ${SERVICE_MESH_CR_NS}    istio-system
 ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
@@ -22,7 +19,7 @@ ${IS_NOT_PRESENT}    1
 
 
 *** Test Cases ***
-Validate DSCI creates Trusted CA Bundles ConfigMaps
+Validate Trusted CA Bundles ConfigMaps
     [Documentation]  The purpose of this Test Case is to validate the creation of
     ...    odh-trusted-ca-bundle ConfigMaps
     [Tags]    Operator
@@ -30,7 +27,7 @@ Validate DSCI creates Trusted CA Bundles ConfigMaps
 
     Assign Vars According To Product    ${PRODUCT}
 
-    Log    message=Check that operator are available    level=INFO
+    Log    message=Check that operators are available    level=INFO
 
     Is Operator Available    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${RHOAI_OPERATOR_NS}
     Is Operator Available    ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    ${SERVICE_MESH_OPERATOR_NS}
@@ -44,24 +41,28 @@ Validate DSCI creates Trusted CA Bundles ConfigMaps
     Check ConfigMap Contains CA Bundle   ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ca-bundle.crt    ${SERVICE_MESH_CR_NS}
 
     Set Custom CA Bundle Value In DSCI   ${CUSTOM_CA_BUNDLE}    ${RHOAI_OPERATOR_NS}
-    Wait Until Keyword Succeeds    3 min	0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+    Wait Until Keyword Succeeds    
+    ...    3 min    0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
 
     Log    message=Validate Trusted CA Bundle Management State Unmanaged    level=INFO
 
     Set Trusted CA Bundle Management State    Unmanaged    ${RHOAI_OPERATOR_NS}
 
-    # Setting the Custom CA Bundle in ConfigMap with managementStatus to 'Unmanaged' should NOT result in bundle being overwirtten by operator
-    Set Custom CA Bundle Value On ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    
+    #Trusted CA BUndle managementStatus 'Unmanaged' should NOT result in bundle being overwirtten by operator
+    Set Custom CA Bundle Value On ConfigMap
+    ...    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}
     # Allow operator time to reconsile
     Sleep    5
-    Wait Until Keyword Succeeds    3 min	0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
+    Wait Until Keyword Succeeds
+    ...    3 min    0 sec    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
 
     Log    message=Validate Trusted CA Bundle Management State Removed    level=INFO
 
     Set Trusted CA Bundle Management State    Removed    ${RHOAI_OPERATOR_NS}
 
     # Check that odh-trusted-ca-bundle has been 'Removed'
-    Wait Until Keyword Succeeds    3 min	0 sec    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_NOT_PRESENT}
+    Wait Until Keyword Succeeds
+    ...    3 min    0 sec    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${SERVICE_MESH_CR_NS}    ${IS_NOT_PRESENT}
 
     Log    message=Restore DSCI to original state    level=INFO
     Set Custom CA Bundle Value In DSCI   ''    ${RHOAI_OPERATOR_NS}
@@ -83,67 +84,71 @@ Assign Vars According To Product
     [Documentation]    Assign variables related to product
     [Arguments]    ${product}
     IF    "${product}" == "RHODS"
-        Set Suite Variable    ${RHOAI_APPNAME}     Red Hat OpenShift AI
-        Set Suite Variable    ${RHOAI_OPERATOR_NAME}    Red Hat OpenShift AI
-        Set Suite Variable    ${RHOAI_OPERATOR_NS}    redhat-ods-operator
+        VAR    ${RHOAI_APPNAME}     Red Hat OpenShift AI
+        VAR    ${RHOAI_OPERATOR_NAME}    Red Hat OpenShift AI
+        VAR    ${RHOAI_OPERATOR_NS}    redhat-ods-operator
     ELSE IF    "${product}" == "ODH"
-        Set Suite Variable    ${RHOAI_APPNAME}  Open Data Hub Operator
-        Set Suite Variable    ${RHOAI_OPERATOR_NAME}    Open Data Hub Operator
-        Set Suite Variable    ${RHOAI_OPERATOR_NS}    openshift-operators
+        VAR    ${RHOAI_APPNAME}  Open Data Hub Operator
+        VAR    ${RHOAI_OPERATOR_NAME}    Open Data Hub Operator
+        VAR    ${RHOAI_OPERATOR_NS}    openshift-operators
     END
 
 Is Operator Available
     [Documentation]    Checks if operator is available
-    [Arguments]    ${operator_name}    ${namespace} 
-    ${rc}    ${out}=    Run And Return Rc And Output
+    [Arguments]    ${operator_name}    ${namespace}
+    ${rc}=    Run And Return Rc
     ...    oc wait --timeout=2m --for condition=available -n ${namespace} deploy/${operator_name}
     Should Be Equal As Integers    ${rc}     ${0}    msg=${operator_name} Not Available
 
 Is Resource Present
     [Documentation]    Check If Resource Is Present In Namespace
     [Arguments]       ${resource}     ${resource_name}    ${namespace}    ${expected_result}
-    ${rc}=     Run and Return Rc
+    ${rc}=     Run And Return Rc
     ...  oc get ${resource} ${resource_name} -n ${namespace}
     Should Be Equal    "${rc}"    "${expected_result}"    msg=${resource} does not exist in ${namespace}
 
 Is DSCI In Ready State
     [Documentation]    Checks that DSCI Reconciled Succesfully
     [Arguments]    ${dsci}    ${namespace}
-    ${rc}    ${out}=    Run And Return Rc And Output
-    ...    oc wait --timeout=3m --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsci ${dsci}
-    Should Be Equal As Integers    ${rc}     ${0}    msg=${DSCI} not in Ready state
+    ${rc}=    Run And Return Rc
+    ...    oc wait --timeout=3m
+    ...    --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted-n ${namespace} dsci ${dsci}
+    Should Be Equal As Integers    ${rc}     ${0}    msg=${dsci} not in Ready state
 
 Check ConfigMap Contains CA Bundle
     [Documentation]    Checks that ConfigMap contains CA Bundle
     [Arguments]    ${config_map}    ${ca_bundle_name}    ${namespace}
-    ${rc}=     Run and Return Rc
+    ${rc}=     Run And Return Rc
     ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${ca_bundle_name}
     Should Be Equal    "${rc}"    "0"    msg=${TRUSTED_CA_BUNDLE_CONFIGMAP} does not contain CA bundle ${ca_bundle_name}
 
 Is CA Bundle Value Present
     [Documentation]    Check if the ConfigtMap contains Custom CA Bundle value
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}        ${expected_result}
-    ${rc}=     Run and Return Rc
+    ${rc}=     Run And Return Rc
     ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${custom_ca_bundle_value}
     Should Be Equal As Integers    ${rc}    ${expected_result}
 
 Set Custom CA Bundle Value In DSCI
     [Documentation]    Set Custom CA Bundle Value in DSCI
     [Arguments]    ${custom_ca_bundle_value}    ${namespace}
-    ${rc}=     Run and Return Rc
-    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    ${rc}=     Run And Return Rc
+    ...    oc patch
+    ...    DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
     Should Be Equal    "${rc}"    "0"    msg=Failed to set DSCI Custom CA Bundle value to ${custom_ca_bundle_value}
 
 Set Custom CA Bundle Value On ConfigMap
     [Documentation]    Set Custom CA Bundle Value in ConfigMap
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}
-    ${rc}=     Run and Return Rc
-    ...    oc patch ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge 
-    Should Be Equal    "${rc}"    "0"    msg=Failed to set ConfigMap Custom CA Bundle value to ${config_map} ${custom_ca_bundle_value} ${namespace}
+    ${rc}=     Run And Return Rc
+    ...    oc patch
+    ...    ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
+    Should Be Equal    "${rc}"    "0"    msg=Failed to set ${config_map} value ${custom_ca_bundle_value} ${namespace}
 
 Set Trusted CA Bundle Management State
     [Documentation]    Change DSCI Management State to one of Managed/Unmanaged/Removed
     [Arguments]    ${management_state}    ${namespace}
-    ${rc}=     Run and Return Rc
-    ...    oc patch DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
-    Should Be Equal    "${rc}"    "0"    msg=Failed to update DSCI trustedCABundle managementState to ${management_state}
+    ${rc}=     Run And Return Rc
+    ...    oc patch
+    ...    DSCInitialization/default-dsci -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    Should Be Equal    "${rc}"    "0"    msg=Failed update DSCI trustedCABundle managementState to ${management_state}


### PR DESCRIPTION
The purpose of this new test case is to validate the operator DSCI support of Trusted CA Bundles.

