### PR TITLE
Remove workaround for resolved product bugs RHOAIENG-2724, RHOAIENG-2869

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -88,9 +88,6 @@ Serve Model
         Set Folder Path    ${model_path}
     END
     SeleniumLibrary.Wait Until Element Is Enabled   //button[contains(text(),"Deploy")]
-    # Workaround for UI glitch bug RHOAIENG-2724 - Reselect model server and framework
-    Select Model Server    ${model_server}
-    Select Framework    ${framework}
     SeleniumLibrary.Click Button    Deploy
     SeleniumLibrary.Wait Until Page Does Not Contain    xpath://h1[.="Deploy model"]
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/420__model_serving.robot
@@ -144,7 +144,7 @@ Verify Multiple Projects With Same Model
 Verify Editing Existing Model Deployment
     [Documentation]    Tries editing an existing model deployment to see if the underlying deployment is updated
     [Tags]    Sanity    Tier1
-    ...       ProductBug    RHOAIENG-2869
+    ...       RHOAIENG-2869
     Open Data Science Projects Home Page
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
     Recreate S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=model-serving-connection


### PR DESCRIPTION
These RHOAI bugs were recently resolved:
- https://issues.redhat.com/browse/RHOAIENG-2869
- https://issues.redhat.com/browse/RHOAIENG-2724

Thus removing the ProductBug tag and workaround.

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/e9ef0e5a-b653-486e-bfa4-9ec48f6b11b5)
