### PR TITLE
[Fix] cleanup for the dashboard api tests

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -835,11 +835,11 @@ Delete Dummy ConfigMaps
 Delete Test Notebooks CRs And PVCs From CLI
     [Documentation]     Stops all the notebook servers spanwed during a test by
     ...                 deleting their CRs. At the end it closes any opened browsers
-    ${CR_1}=   Get User CR Notebook Name    ${TEST_USER_3.USERNAME}
-    ${CR_2}=   Get User CR Notebook Name    ${TEST_USER_4.USERNAME}
-    ${test_crs}=   Create List     ${CR_1}   ${CR_2}
-    FOR   ${nb_cr}    IN  @{test_crs}
-        ${present}=     Run Keyword And Return Status   OpenshiftLibrary.Oc Get    kind=Notebook  namespace=${NOTEBOOK_NS}  name=${nb_cr}
+    ${test_usernames}=   Create List  ${TEST_USER.USERNAME}  ${TEST_USER_3.USERNAME}  ${TEST_USER_4.USERNAME}
+    FOR  ${username}  IN  @{test_usernames}
+        ${nb_cr}=   Get User CR Notebook Name    ${username}
+        ${present}=     Run Keyword And Return Status
+        ...    OpenshiftLibrary.Oc Get    kind=Notebook    namespace=${NOTEBOOK_NS}  name=${nb_cr}
         IF    ${present} == ${FALSE}
             Continue For Loop
         ELSE
@@ -847,9 +847,10 @@ Delete Test Notebooks CRs And PVCs From CLI
         END
     END
     Close All Browsers
+    ${PVC_ADMIN_USER}=   Get User Notebook PVC Name    ${TEST_USER.USERNAME}
     ${PVC_BASIC_USER}=   Get User Notebook PVC Name    ${TEST_USER_3.USERNAME}
     ${PVC_BASIC_USER_2}=   Get User Notebook PVC Name    ${TEST_USER_4.USERNAME}
-    ${test_pvcs}=   Create List     ${PVC_BASIC_USER}   ${PVC_BASIC_USER_2}
+    ${test_pvcs}=   Create List     ${PVC_ADMIN_USER}    ${PVC_BASIC_USER}    ${PVC_BASIC_USER_2}
     Delete Test PVCs     pvc_names=${test_pvcs}
 
 Set Username In Secret Payload


### PR DESCRIPTION
The cleanup only checked for resources of two users but in the tests there are used three different users, so let's clean after all three.

---

Note: I'm not aware that this broke any test, but I think we should clean all relevant Notebooks and PVCs after these tests are executed.

After merge, I shall backport to `releases/2.8.0` branch too.

---

```
./ods_ci/run_robot_test.sh --test-case ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot --extra-robot-args '-e ProductBug' --open-report true
```
(results once #1306 is merged also)

![Screenshot from 2024-03-25 09-53-39](https://github.com/red-hat-data-services/ods-ci/assets/12250881/90865e9e-8434-4f93-8e2f-5732b1062057)
