### PR TITLE
Add support to open also ODH via application list

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
@@ -26,10 +26,10 @@ Launch Jupyterhub via Routes
    Sleep  10s
    Switch Window  JupyterHub
 
-Launch RHODS Via OCP Application Launcher
-    [Documentation]    Uses the Application Launcher in the OCP Web UI to open the
-    ...    RHODS Dashboard page.
-    Click Element    xpath://button[@aria-label="Application launcher"]
-    Wait Until Page Contains Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]
-    Click Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]/..
-    Switch Window    NEW
+Launch RHOAI Via OCP Application Launcher
+   [Documentation]    Uses the Application Launcher in the OCP Web UI to open the
+   ...    RHOAI Dashboard page.
+   Click Element    xpath://button[@aria-label="Application launcher"]
+   Wait Until Page Contains Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]
+   Click Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]/..
+   Switch Window    NEW

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/LaunchJupyterHub.robot
@@ -1,6 +1,12 @@
 *** Settings ***
 Library  JupyterLibrary
 
+
+*** Variables ***
+# This variable is overriden for ODH runs via 'ods_ci/test-variables-odh-overwrite.yml'
+${ODH_DASHBOARD_PROJECT_NAME}=   Red Hat OpenShift AI
+
+
 *** Keywords ***
 Launch Jupyterhub via Routes
    [Documentation]  This keyword only works with kubeadmin or accounts that are
@@ -24,6 +30,6 @@ Launch RHODS Via OCP Application Launcher
     [Documentation]    Uses the Application Launcher in the OCP Web UI to open the
     ...    RHODS Dashboard page.
     Click Element    xpath://button[@aria-label="Application launcher"]
-    Wait Until Page Contains Element    xpath://span[.="Red Hat OpenShift AI"]
-    Click Element    xpath://span[.="Red Hat OpenShift AI"]/..
+    Wait Until Page Contains Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]
+    Click Element    xpath://span[.="${ODH_DASHBOARD_PROJECT_NAME}"]/..
     Switch Window    NEW

--- a/ods_ci/tests/Tests/500__jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test.robot
@@ -28,7 +28,7 @@ Can Launch Jupyterhub
     ...      Tier1
     ...      ODS-935
     #This keyword will work with accounts that are not cluster admins.
-    Launch RHODS Via OCP Application Launcher
+    Launch RHOAI Via OCP Application Launcher
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link


### PR DESCRIPTION
+ some small refactoring in a separate commit (will squash after approved)

---

CI: tested locally

RHOAI:

```
./ods_ci/run_robot_test.sh --test-case ods_ci/tests/Tests/500__jupyterhub/test.robot --open-report true
```

![Screenshot from 2024-03-25 18-38-09](https://github.com/red-hat-data-services/ods-ci/assets/12250881/fee12b09-2fd1-41d0-bfd7-ab1ce8ba7d89)

ODH (we don't have a fully functional build so the tests cannot pass completely) but passed the point of changes in this PR just fine:

```
./ods_ci/run_robot_test.sh --test-case ods_ci/tests/Tests/500__jupyterhub/test.robot --extra-robot-args '--variablefile ./ods_ci/test-variables-odh-overwrite.yml' --open-report true
```