### PR TITLE
Reuse KW `Wait For Dashboard Page Title` in more tests

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -14,7 +14,7 @@ Library   OpenShiftLibrary
 
 
 *** Variables ***
-${KFNBC_SPAWNER_HEADER_XPATH} =    //h1[.="Start a notebook server"]
+${KFNBC_SPAWNER_HEADER_TITLE} =    Start a notebook server
 ${JUPYTERHUB_DROPDOWN_XPATH} =    //button[@aria-label="Options menu"]
 ${KFNBC_CONTAINER_SIZE_TITLE} =    //div[.="Deployment size"]/..//span[.="Container Size"]
 ${KFNBC_CONTAINER_SIZE_DROPDOWN_XPATH} =  //label[@for="modal-notebook-container-size"]/../..//button[@aria-label="Options menu"]
@@ -39,8 +39,8 @@ ${PREVIOUS_NOTEBOOK_VER} =    2023.2
 *** Keywords ***
 JupyterHub Spawner Is Visible
     [Documentation]  Checks if spawner is visibile and returns the status
-    ${spawner_visible} =  Run Keyword And Return Status  Page Should Contain Element
-    ...    xpath:${KFNBC_SPAWNER_HEADER_XPATH}
+    ${spawner_visible} =  Run Keyword And Return Status
+    ...    Wait For Dashboard Page Title    ${KFNBC_SPAWNER_HEADER_TITLE}
     RETURN  ${spawner_visible}
 
 Wait Until JupyterHub Spawner Is Ready

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsAcceleratorProfiles.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsAcceleratorProfiles.resource
@@ -134,7 +134,7 @@ Edit Accelerator Profile
     ...           ${enabled}=${EMPTY}  ${tolerations}=${EMPTY}  ${tol_operator}=${EMPTY}  ${tol_effect}=${EMPTY}
     ...           ${tol_key}=${EMPTY}  ${tol_value}=${EMPTY}  ${tol_seconds}=${EMPTY}
     Click On Edit Accelerator Profile    ${original_display_name}
-    Wait Until Element Is Visible   //h1[text()="Edit ${original_display_name}"]  timeout=10
+    Wait For Dashboard Page Title    Edit ${original_display_name}
     IF    "${display_name}" != "${EMPTY}"
         Clear Element And Input Text    ${ACCELERATOR_NAME}    ${display_name}
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -256,8 +256,7 @@ Wait Until Page Contains Run Topology Page
     [Documentation]    Waits until the page containing the run details and its topology
     ...                is rendered on the screen
     [Arguments]    ${run_name}
-    Run Keyword And Continue On Failure    Wait Until Page Contains Element
-    ...    xpath://h1[.//text()="${run_name}"]    timeout=10s
+    Run Keyword And Continue On Failure    Wait For Dashboard Page Title    ${run_name}
     Run Keyword And Continue On Failure    Wait Until Page Contains Element
     ...    ${RUN_TOPOLOGY_DETAILS_BTN_XP}
     Run Keyword And Continue On Failure    Wait Until Page Contains Element

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -5,7 +5,7 @@ Resource       ./Workbenches.resource
 
 
 *** Variables ***
-${DS_PROJECT_XP}=     xpath=//h1[text()="Data Science Projects"]
+${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
 ${RESOURCE_INPUT_XP}=    xpath=//input[@id="resource-manage-project-modal-name"]
@@ -29,7 +29,7 @@ Open Data Science Projects Home Page
 Is Data Science Projects Page Open
     [Documentation]    Checks if Data Science Projects home page is open. Returns TRUE or FALSE
     Close Generic Modal If Present
-    ${page_open}=   Run Keyword And Return Status   Page Should Contain Element     ${DS_PROJECT_XP}
+    ${page_open}=   Run Keyword And Return Status    Wait For Dashboard Page Title    ${DS_PROJECT_TITLE}
     RETURN    ${page_open}
 
 Open Data Science Project Details Page
@@ -77,7 +77,7 @@ Project Should Not Exist In Openshift
 Is Data Science Project Details Page Open
     [Arguments]     ${project_title}
     ${page_open}=   Run Keyword And Return Status
-    ...    SeleniumLibrary.Page Should Contain Element     xpath=//h1[contains(text(),"${project_title}")]
+    ...    Wait For Dashboard Page Title    ${project_title}
     RETURN    ${page_open}
 
 Wait Until Project Is Open
@@ -85,7 +85,7 @@ Wait Until Project Is Open
     [Arguments]     ${project_title}    ${timeout-pre-spinner}=3s    ${timeout-spinner}=5s
     Maybe Wait For Dashboard Loading Spinner Page
     ...    timeout-pre=${timeout-pre-spinner}    timeout=${timeout-spinner}
-    Wait Until Page Contains Element    xpath=//h1[contains(text(),"${project_title}")]    timeout=30s
+    Wait For Dashboard Page Title    ${project_title}    timeout=30s
 
 Project Should Be Listed
     [Documentation]    Checks a Project is available in DS Project home page

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -69,7 +69,7 @@ Serve Model
         SeleniumLibrary.Wait Until Page Contains    Deploy model
         SeleniumLibrary.Click Button    Deploy model
     END
-    SeleniumLibrary.Wait Until Page Contains Element    xpath://h1[.="Deploy model"]
+    Wait For Dashboard Page Title    Deploy model
     Select Project    ${project_name}
     Set Model Name    ${model_name}
     Select Model Server    ${model_server}
@@ -197,7 +197,7 @@ Open Model Edit Modal
     [Documentation]    Opens the modal used to edit the details of an already deployed model.
     [Arguments]    ${model_name}
     ODHDashboard.Click Action From Actions Menu    item_title=${model_name}    action=Edit
-    Wait Until Page Contains    xpath://h1[.="Deploy model"]
+    Wait For Dashboard Page Title    Deploy model
 
 Get Model Route Via UI
     [Documentation]    Grabs the serving route (URL) of an already deployed model from the Model Serving page.


### PR DESCRIPTION
This is required to fix many tests that fails due to h1 page title element
that was changed in the new Dashboard UI rework.

Example of using KW `Wait For Dashboard Page Title`:

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/541b4d67-6feb-4950-9f09-c063dc24bbe2)
