### PR TITLE
Use cluster id while adding machinepool

### DIFF
--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -378,9 +378,10 @@ class OpenshiftClusterManager:
         if bool(self.reuse_machine_pool) and self.check_if_machine_pool_exists():
             log.info(f"MachinePool with name {self.pool_name} exists in cluster {self.cluster_name}. Hence reusing it")
         else:
+            cluster_id = self.get_osd_cluster_id()
             cmd = "ocm --v={} create machinepool --cluster {} --instance-type {} --replicas {} --taints {} {}".format(
                 self.ocm_verbose_level,
-                self.cluster_name,
+                self.cluster_id,
                 self.pool_instance_type,
                 self.pool_node_count,
                 self.taints,
@@ -508,6 +509,7 @@ class OpenshiftClusterManager:
                     p["value"] = "##hidden##"
         return json.dumps(json_dict)
 
+    # noinspection PyInterpreter
     def install_addon(
         self,
         addon_name="managed-odh",


### PR DESCRIPTION
Observed that we are still using name instead of id while adding machinepool