### PR TITLE
Add openshift_oauth as a workaround for RHOAIENG-3981

### DIFF
--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration.py
@@ -14,11 +14,11 @@ def ray_fn(openshift_server: str, openshift_token: str) -> int:
     auth_return = auth.login()
     print(f'auth_return: "{auth_return}"')
     print("after login")
+    # openshift_oauth is a workaround for RHOAIENG-3981
     cluster = Cluster(
         ClusterConfiguration(
             name="raytest",
-            # namespace must exist, and it is the same from 432__data-science-pipelines-tekton.robot
-            namespace="pipelineskfp1",
+            openshift_oauth=True,
             num_workers=1,
             head_cpus="500m",
             min_memory=1,


### PR DESCRIPTION
namespace was removed because it was fixed in the SDK
openshift_oauth is a workaround for RHOAIENG-3981

```
------------------------------------------------------------------------------
Tests.Ods Dashboard.Data Science Pipelines.Data-Science-Pipelines-... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Data Science Pipelines                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================

```