### PR TITLE
RHOAIENG-4726 - Assign tiers to Kuberay E2E tests

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
@@ -12,10 +12,9 @@ ${KUBERAY_RELEASE_ASSETS}     %{KUBERAY_RELEASE_ASSETS=https://github.com/openda
 *** Test Cases ***
 Run TestRayJob test
     [Documentation]    Run Go E2E test: TestRayJob
-    [Tags]  Tier2
+    [Tags]  Tier1
     ...     DistributedWorkloads
     ...     Kuberay
-    Skip    "Requires Kuberay 1.1"
     Run Kuberay E2E Test    "^TestRayJob$"
 
 Run TestRayJobWithClusterSelector test
@@ -27,10 +26,9 @@ Run TestRayJobWithClusterSelector test
 
 Run TestRayJobSuspend test
     [Documentation]    Run Go E2E test: TestRayJobSuspend
-    [Tags]  Tier2
+    [Tags]  Tier1
     ...     DistributedWorkloads
     ...     Kuberay
-    Skip    "Requires Kuberay 1.1"
     Run Kuberay E2E Test    TestRayJobSuspend
     
 


### PR DESCRIPTION
Tested in https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/distributed-workloads/job/rhods-pipeline-dw-new/7/robot/Tests/Distributed%20Workloads/Test-Run-Kuberay-E2E/