### PR TITLE
Update dashboard tests "415"

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -262,7 +262,7 @@ Stop Workbench From Projects Home Page
 
 Wait Until Workbench Is Started From Projects Home Page
     [Documentation]    Waits until the workbench status is "RUNNING", from the DS Project home page
-    [Arguments]     ${workbench_title}   ${project_title}   ${timeout}=60s
+    [Arguments]     ${workbench_title}   ${project_title}   ${timeout}=30s
     Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be From Projects Home Page
     ...     workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_RUNNING}   project_title=${project_title}
 
@@ -386,20 +386,20 @@ Permissions Tab Should Not Be Accessible
 Wait Until Permissions Tab Is Open
     [Documentation]    Wait until "Permissions" tab is rendered
     Run Keyword And Continue On Failure
-    ...    Wait Until Page Contains Element    id:user-permission-User
+    ...    Wait Until Page Contains Element    id:permissions
 
-Wait Until Components Tab Is Open
-    [Documentation]    Wait until "Components" tab is rendered
+Wait Until Overview Tab Is Open
+    [Documentation]    Wait until "Overview" tab is rendered
     Run Keyword And Continue On Failure
-    ...    Wait Until Page Contains Element    id:workbenches-title
+    ...    Wait Until Page Contains Element    id:overview
 
-Components Tab Should Be Accessible
-    [Documentation]    Verify user can access the "Permissions" tab of a DS project
+Overview Tab Should Be Accessible
+    [Documentation]    Verify user can access the "Overview" tab of a DS project
     Run Keyword And Continue On Failure
     ...    Page Should Contain Element
-    ...    xpath://span[text()="Components"]
-    Move To Tab    tab_title=Components
-    Wait Until Components Tab Is Open
+    ...    xpath://span[text()="Overview"]
+    Move To Tab    tab_title=Overview
+    Wait Until Overview Tab Is Open
 
 Move To Tab
     [Documentation]    Open one of the tabs in a DS Project details page (e.g., Permissions)

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -262,7 +262,7 @@ Stop Workbench From Projects Home Page
 
 Wait Until Workbench Is Started From Projects Home Page
     [Documentation]    Waits until the workbench status is "RUNNING", from the DS Project home page
-    [Arguments]     ${workbench_title}   ${project_title}   ${timeout}=30s
+    [Arguments]     ${workbench_title}   ${project_title}   ${timeout}=60s
     Wait Until Keyword Succeeds    ${timeout}    5s      Workbench Status Should Be From Projects Home Page
     ...     workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_RUNNING}   project_title=${project_title}
 
@@ -280,7 +280,7 @@ Launch And Access Workbench From Projects Home Page
     ${is_started}=      Run Keyword And Return Status   Workbench Status Should Be From Projects Home Page
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_RUNNING}    project_title=${project_title}
     IF    ${is_started} == ${TRUE}
-        Click Element       xpath=//tr//a[text()="${project_title}"]/ancestor::tr/td[@data-label="Workbench"]//a[text()="${workbench_title}"]
+        Click Element       xpath=//tr//a[text()="${project_title}"]/ancestor::tr/td[@data-label="workbenchName"]//a[text()="${workbench_title}"]
         Switch Window   NEW
         Access To Workbench    username=${username}    password=${password}
         ...    auth_type=${auth_type}    expected_ide=${expected_ide}
@@ -292,7 +292,7 @@ Workbench Launch Link Should Be Disabled
     [Documentation]    Checks the workbench launch link is disabled from DS Projects home page.
     [Arguments]     ${workbench_title}    ${project_title}
     ${link_status}=    Get Element Attribute
-    ...    xpath=//tr//a[text()="${project_title}"]/ancestor::tr/td[@data-label="Workbench"]//a[text()="${workbench_title}"]    aria-disabled
+    ...    xpath=//tr//a[text()="${project_title}"]/ancestor::tr/td[@data-label="workbenchName"]//a[text()="${workbench_title}"]    aria-disabled
     Should Be Equal As Strings    ${link_status}    true
     ...    msg=Workbench launch link should be disabled for workbench ${workbench_title} in project ${project_title}
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Storages.resource
@@ -6,7 +6,7 @@ Resource       Projects.resource
 
 
 *** Variables ***
-${STORAGE_SECTION_XP}=             xpath=//div[@id="cluster-storages"]
+${STORAGE_SECTION_XP}=             xpath=//div[@data-testid="section-cluster-storages"]
 ${STORAGE_NAME_INPUT_XP}=          xpath=//input[@name="create-new-storage-name"]
 ${STORAGE_DESCR_INPUT_XP}=         xpath=//textarea[@name="create-new-storage-description"]
 ${STORAGE_SIZE_INPUT_XP}=         xpath=//input[@aria-label="Input"]
@@ -24,12 +24,12 @@ Storage Should Be Listed
     [Arguments]     ${name}   ${description}   ${type}   ${connected_workbench}
     Run Keyword And Continue On Failure     Wait Until Page Contains Element    ${STORAGE_SECTION_XP}//td[@data-label="Name"]//*/div[text()="${name}"]
     Run Keyword And Continue On Failure     Wait Until Page Contains Element    ${STORAGE_SECTION_XP}//td[@data-label="Name"]/p[text()="${description}"]
-    Run Keyword And Continue On Failure     Wait Until Page Contains Element    ${STORAGE_SECTION_XP}//tr[td[@data-label="Name"]//*/div[text()="${name}"]]/td[@data-label="Type"]/p[contains(text(),"${type}")]
+    Run Keyword And Continue On Failure     Wait Until Page Contains Element    ${STORAGE_SECTION_XP}//tr[td[@data-label="Name"]//div[text()="${name}"]]/td[@data-label="Type"]//*[contains(text(),"${type}")]
     IF    "${connected_workbench}" == "${NONE}"
         Run Keyword And Continue On Failure    Page Should Contain Element    ${STORAGE_SECTION_XP}//tr[td[@data-label="Name"]//*/div[text()="${name}"]]/td[text()="No connections"]
     ELSE
         FOR    ${index}    ${workbench_title}    IN ENUMERATE    @{connected_workbench}
-            Run Keyword And Continue On Failure    Page Should Contain Element    ${STORAGE_SECTION_XP}//tr[td[@data-label="Name"]//*/div[text()="${name}"]]/td[@data-label="Connected workbenches"]/ul/li[text()="${workbench_title}"]
+            Run Keyword And Continue On Failure    Page Should Contain Element    ${STORAGE_SECTION_XP}//tr[td[@data-label="Name"]//div[text()="${name}"]]/td[@data-label="Connected workbenches"]//*[contains(text(),"${workbench_title}")]
         END
     END
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -51,7 +51,7 @@ Create Workbench
     ...             ${storage}  ${pv_existent}   ${pv_name}  ${pv_description}  ${pv_size}    ${gpus}=${NONE}
     ...             ${press_cancel}=${FALSE}  ${version}=default  ${envs}=${NONE}
     ...             ${data_connection}=${NONE}
-    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=workbenches
+    Open Data Science Project Details Page       project_title=${prj_title}    tab_id=workbenches
     Click Element    ${WORKBENCH_CREATE_BTN_XP}
     Wait Until Page Contains Element    ${WORKBENCH_NAME_INPUT_XP}
     Run Keyword And Continue On Failure     Element Should Be Disabled    ${WORKBENCH_CREATE_BTN_2_XP}
@@ -97,7 +97,7 @@ Create Workbench
         Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
     END
     Wait Until Generic Modal Disappears  timeout=1 minute
-    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=workbenches
+    Open Data Science Project Details Page       project_title=${prj_title}    tab_id=workbenches
 
 #robocop: disable: line-too-long
 Add Environment Variables In Workbench

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -7,7 +7,7 @@ Resource       Projects.resource
 
 
 *** Variables ***
-${WORKBENCH_SECTION_XP}=             xpath=//div[@id="workbenches"]
+${WORKBENCH_SECTION_XP}=             xpath=//div[@data-testid="section-workbenches"]
 ${WORKBENCH_CREATE_BTN_XP}=           xpath=//button[text()="Create workbench"]
 ${WORKBENCH_CREATE_BTN_2_XP}=         xpath=//button[@id="create-button"]
 ${WORKBENCH_NAME_INPUT_XP}=               xpath=//input[@name="workbench-name"]
@@ -51,6 +51,7 @@ Create Workbench
     ...             ${storage}  ${pv_existent}   ${pv_name}  ${pv_description}  ${pv_size}    ${gpus}=${NONE}
     ...             ${press_cancel}=${FALSE}  ${version}=default  ${envs}=${NONE}
     ...             ${data_connection}=${NONE}
+    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=workbenches
     Click Element    ${WORKBENCH_CREATE_BTN_XP}
     Wait Until Page Contains Element    ${WORKBENCH_NAME_INPUT_XP}
     Run Keyword And Continue On Failure     Element Should Be Disabled    ${WORKBENCH_CREATE_BTN_2_XP}
@@ -96,7 +97,7 @@ Create Workbench
         Click Button    ${WORKBENCH_CREATE_BTN_2_XP}
     END
     Wait Until Generic Modal Disappears  timeout=1 minute
-    Wait Until Project Is Open    project_title=${prj_title}
+    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=workbenches
 
 #robocop: disable: line-too-long
 Add Environment Variables In Workbench

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -179,6 +179,7 @@ Verify User Can Create And Start A Workbench Adding A New PV Storage
     #SeleniumLibrary.Reload Page
     #Wait Until Project Is Open    project_title=${PRJ_TITLE}
     ${connected_woksps}=    Create List    ${WORKBENCH_3_TITLE}
+    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=cluster-storages
     Storage Should Be Listed    name=${pv_name}    description=${PV_DESCRIPTION}
     ...                         type=Persistent storage    connected_workbench=${connected_woksps}
     Storage Size Should Be    name=${pv_name}    namespace=${ns_name}  size=${PV_SIZE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -488,11 +488,10 @@ Verify Users Can Start, Stop, Launch And Delete A Workbench
 Verify Users Can Start, Stop And Launch A Workbench From DS Projects Home Page
     [Tags]     Smoke    Sanity    Tier1
     ...        ODS-1818    ODS-1823
+    ...        ProductBug    RHOAIENG-5084
     [Documentation]    Verifies users can start, stop, launch and delete a running workbench from project details page
     [Setup]        Run Keywords
     ...    Launch Data Science Project Main Page
-    ...    AND
-    ...    Open Data Science Project Details Page       project_title=${PRJ_TITLE}    tab_id=workbenches
     ...    AND
     ...    Create Workbench    workbench_title=${WORKBENCH_TITLE}  workbench_description=${WORKBENCH_DESCRIPTION}
     ...        prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE}   deployment_size=Small

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -158,7 +158,7 @@ Launch RHODS Dashboard Session And Create A DS Project With User B
     Create Data Science Project    title=${PRJ_USER_B_TITLE}
     ...    description=${PRJ_DESCRIPTION}
     Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
+    Overview Tab Should Be Accessible
 
 Launch RHODS Dashboard Session With User C
     Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_USER_C_TITLE}
@@ -169,7 +169,7 @@ Launch RHODS Dashboard Session With User C
     Create Data Science Project    title=${PRJ_USER_C_TITLE}
     ...    description=${PRJ_DESCRIPTION}
     Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
+    Overview Tab Should Be Accessible
 
 Set User Groups For Testing
     Create Group    ${USER_GROUP_1}
@@ -259,7 +259,7 @@ ${username} Should Have Admin Access To ${project_title}
     Wait Until Project Is Listed    project_title=${project_title}
     Open Data Science Project Details Page    ${project_title}    tab_id=permissions
     Permissions Tab Should Be Accessible
-    Components Tab Should Be Accessible
+    Overview Tab Should Be Accessible
 
 ${username} Should Not Have Access To ${project_title}
     Switch To User    ${username}


### PR DESCRIPTION
This is to update Smoke tests in `415__ods_dashboard_projects.robot`.
It includes minor changes for elements and KW according to the new UI of RHOAI 2.9.

In addition, a tag of ProductBug for [RHOAIENG-5084](https://issues.redhat.com/browse/RHOAIENG-5084) was added, for the following test failure:

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/71415814-8520-41e2-9f0d-54837060d889)
