### PR TITLE
RHOAIENG-5092 - Validate Authorino Resources

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/140__service_mesh.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/140__service_mesh.robot
@@ -27,7 +27,7 @@ Validate Service Mesh State Managed
     [Tags]    Operator    Tier1    ODS-2526    ServiceMesh-Managed
 
     Is Resource Present    ServiceMeshControlPlane    ${SERVICE_MESH_CR_NAME}    ${SERVICE_MESH_CR_NS}    ${IS_PRESENT}
-    Check If Pod Exists    istiod    ${SERVICE_MESH_CR_NS}
+    Check If Pod Exists    ${SERVICE_MESH_CR_NS}    app=istiod    ${FALSE}
 
 Validate Service Mesh State Unmanaged
     [Documentation]    The purpose of this Test Case is to validate Service Mesh state 'Unmanaged'.

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/141__authorino.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/141__authorino.robot
@@ -1,0 +1,49 @@
+*** Settings ***
+Documentation       Test Cases to verify RHOAI operator integration with Authorino operator
+
+Library             Collections
+Resource            ../../../../Resources/OCP.resource
+Resource            ../../../../Resources/ODS.robot
+Suite Setup         Suite Setup
+Suite Teardown      Suite Teardown
+
+
+*** Variables ***
+${OPERATOR_NS}                              ${OPERATOR_NAMESPACE}
+${RHOAI_OPERATOR_DEPLOYMENT_NAME}           rhods-operator
+${DSCI_NAME}                                default-dsci
+${SERVICE_MESH_OPERATOR_NS}                 openshift-operators
+${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
+${AUTHORINO_OPERATOR_NS}                    openshift-operators
+${AUTHORINO_OPERATOR_DEPLOYMENT_NAME}       authorino-operator
+${AUTHORINO_CR_NS}                          redhat-ods-applications-auth-provider
+${AUTHORINO_CR_NAME}                        authorino
+
+${IS_PRESENT}                           0
+${IS_NOT_PRESENT}                       1
+
+
+*** Test Cases ***
+Validate Authorino Resources
+    [Documentation]    The purpose of this Test Case is to validate that Authorino resources have been created.
+    [Tags]    Operator    Tier1    RHOAIENG-5092
+
+    # Validate that Authorino CR has been created
+    Wait Until Keyword Succeeds    2 min    0 sec
+    ...    Is Resource Present    Authorino    ${AUTHORINO_CR_NAME}    ${AUTHORINO_CR_NS}    ${IS_PRESENT}
+
+    Check If Pod Exists    ${AUTHORINO_CR_NS}    authorino-resource    ${FALSE}
+
+
+*** Keywords ***
+Suite Setup
+    [Documentation]    Suite Setup
+    RHOSi Setup
+    Wait Until Operator Ready    ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    ${SERVICE_MESH_OPERATOR_NS}
+    Wait Until Operator Ready    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
+    Wait Until Operator Ready    ${AUTHORINO_OPERATOR_DEPLOYMENT_NAME}    ${AUTHORINO_OPERATOR_NS}
+    Wait For DSCI Ready State    ${DSCI_NAME}    ${OPERATOR_NS}
+
+Suite Teardown
+    [Documentation]    Suite Teardown
+    RHOSi Teardown


### PR DESCRIPTION
Main purpose of this PR is the introduction of a new test case that validates RHOAI operator integration with Authorino. The test case validates that Authorino resources are properly created.

  Note: This is an initial test case, with more test coverage expected.

Secondary inclusion in this PR is a fix to the Service Mesh 'Managed' test case, for checking that the istiod pod is running.
