### PR TITLE
Another 2.8 backport changes

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/OSP/create_fips.sh
@@ -42,13 +42,6 @@ osp_dashboard="$(openstack catalog show keystone -c endpoints -c name -c type \
 
 echo "Connected to Openstack: ${osp_dashboard}"
 
-echo "Cleaning unused Floating IPs in Openstack Cloud '$OSP_CLOUD' (before creating new IPs in Network '$OSP_NETWORK')"
-openstack floating ip list --status DOWN -c 'Floating IP Address' -f value | xargs -n1 -r --verbose openstack floating ip delete || rc=$?
-if [[ -n "$rc" ]] ; then
-  echo -e "Failure [$rc] cleaning unused floating IPs"
-  exit ${rc:+$rc}
-fi
-
 echo "Allocating a floating IP for cluster's API"
 cmd=(openstack floating ip create --description "$CLUSTER_NAME API" -f value -c floating_ip_address "$OSP_NETWORK")
 echo "${cmd[@]}"

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -183,7 +183,7 @@ Compile Inference Service YAML
             ${mode}=    Set Variable    ${DSC_KSERVE_MODE}
         ELSE
             ${mode}=    Get KServe Default Deployment Mode From DSC
-        END  
+        END
         Log    message=Using defaultDeploymentMode set in the DSC: ${mode}
     END
 
@@ -388,7 +388,8 @@ Compile Deploy And Query LLM model
     ...    namespace=${namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${isvc_name}
     ...    namespace=${namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${namespace}    model_name=${model_name}
+    ${pod_name}=  Get Pod Name    namespace=${namespace}    label_selector=serving.kserve.io/inferenceservice=${isvc_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${namespace}    pod_name=${pod_name}
     Query Model Multiple Times    isvc_name=${isvc_name}    model_name=${model_name}
     ...    n_times=${n_queries}    namespace=${namespace}    query_idx=${query_idx}
     ...    validate_response=${validate_response}    protocol=${protocol}
@@ -755,8 +756,8 @@ Get KServe Default Deployment Mode From DSC
     RETURN    ${mode}
 
 Start Port-forwarding
-    [Arguments]    ${namespace}    ${model_name}    ${process_alias}=llm-query-process
-    ${process}=    Start Process    oc -n ${namespace} port-forward svc/${model_name}-predictor 8033:80
+    [Arguments]    ${namespace}    ${pod_name}    ${process_alias}=llm-query-process
+    ${process}=    Start Process    oc -n ${namespace} port-forward pod/${pod_name} 8033:8033
     ...    alias=${process_alias}    stderr=STDOUT    shell=yes
     Process Should Be Running    ${process}
     sleep  7s

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
+      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -23,7 +23,7 @@ spec:
       ## Note: cannot add readiness/liveness probes to this container because knative will refuse them.
       # multi-container probing will be available after https://github.com/knative/serving/pull/14853 is merged
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
+      image: quay.io/modh/caikit-tgis-serving@sha256:444bca43c99bfc4b961c926f5f10c556488613912f5e333011e98b3407d76d00
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:9f18a63cd84b084c3cbf15534f22d5ba6916d9501298abcc03271d26ebf5cdfb
+      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -21,7 +21,7 @@ spec:
       #     cpu: 8
       #     memory: 16Gi
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:0fd3584362e8780aed922fe124c8829c1c7df9d55590ba2ae76bb6aef0155c1f
+      image: quay.io/modh/caikit-tgis-serving@sha256:444bca43c99bfc4b961c926f5f10c556488613912f5e333011e98b3407d76d00
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
@@ -9,7 +9,7 @@ spec:
       name: pytorch
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:e4d24fd401fd4eb89b49b4ab07e0c08389384d4a672b240e98a03ad7f9ef1c85
+      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
       command: ["text-generation-launcher"]
       args:
         - "--model-name=/mnt/models/"

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -1,0 +1,163 @@
+*** Settings ***
+Documentation    Test Cases to verify Trusted CA Bundle support
+Library    Collections
+Resource    ../../../../Resources/Page/OCPDashboard/OCPDashboard.resource
+Suite Setup    Suite Setup
+Suite Teardown    Suite Teardown
+
+
+*** Variables ***
+${OPERATOR_NS}    ${OPERATOR_NAMESPACE}
+${RHOAI_OPERATOR_DEPLOYMENT_NAME}    rhods-operator
+${TEST_NS}    test-trustedcabundle
+${DSCI_NAME}    default-dsci
+${TRUSTED_CA_BUNDLE_CONFIGMAP}    odh-trusted-ca-bundle
+${CUSTOM_CA_BUNDLE}    test-example-custom-ca-bundle
+${IS_PRESENT}    0
+${IS_NOT_PRESENT}    1
+
+
+*** Test Cases ***
+Validate Trusted CA Bundles State Managed
+    [Documentation]  The purpose of this test case is to validate Trusted CA Bundles when in state Managed
+    ...    With Trusted CA Bundles Managed, ConfigMap odh-trusted-ca-bundle is expected to be created in
+    ...    each non-reserved namespace.
+    [Tags]    Operator    Smoke    ODS-2638    TrustedCABundle-Managed
+
+    Wait Until Keyword Succeeds    2 min    0 sec
+    ...    Is Resource Present    project    ${TEST_NS}    ${TEST_NS}    ${IS_PRESENT}
+
+    Wait Until Keyword Succeeds    3 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_PRESENT}
+
+    # Check that ConfigMap contains key "ca-bundle.crt"
+    Wait Until Keyword Succeeds    3 min    0 sec
+    ...    Check ConfigMap Contains CA Bundle Key    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ca-bundle.crt    ${TEST_NS}
+
+    Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}   ${CUSTOM_CA_BUNDLE}    ${OPERATOR_NS}
+    Wait Until Keyword Succeeds    2 min    0 sec
+    ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${TEST_NS}    ${IS_PRESENT}
+
+    [Teardown]     Restore DSCI Trusted CA Bundle Settings
+
+Validate Trusted CA Bundles State Unmanaged
+    [Documentation]  The purpose of this test case is to validate Trusted CA Bundles when in state Unmanaged
+    ...    With Trusted CA Bundles Unmanaged, ConfigMap odh-trusted-ca-bundle will not be managed by the operator.
+    [Tags]    Operator    Smoke    ODS-2638    TrustedCABundle-Unmanaged
+
+    Set Trusted CA Bundle Management State    ${DSCI_NAME}    Unmanaged    ${OPERATOR_NS}
+
+    # Trusted CA Bundle managementStatus 'Unmanaged' should NOT result in bundle being overwirtten by operator
+    Set Custom CA Bundle Value On ConfigMap
+    ...    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${TEST_NS}    5s
+    Wait Until Keyword Succeeds    1 min    0 sec
+    ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${TEST_NS}    ${IS_PRESENT}
+
+    [Teardown]     Restore DSCI Trusted CA Bundle Settings
+
+Validate Trusted CA Bundles State Removed
+    [Documentation]  The purpose of this test case is to validate Trusted CA Bundles when in state Removed
+    ...    With Trusted CA Bundles Removed, all odh-trusted-ca-bundle ConfigMaps will be removed.
+    [Tags]    Operator    Smoke    ODS-2638    TrustedCABundle-Removed
+
+    Set Trusted CA Bundle Management State    ${DSCI_NAME}    Removed    ${OPERATOR_NS}
+
+    # Check that odh-trusted-ca-bundle has been 'Removed'
+    Wait Until Keyword Succeeds    3 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_NOT_PRESENT}
+
+    [Teardown]     Restore DSCI Trusted CA Bundle Settings
+
+
+*** Keywords ***
+Suite Setup
+    [Documentation]    Suite Setup
+    RHOSi Setup
+    Wait Until Operator Ready    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
+    Wait For DSCI Ready State    ${DSCI_NAME}    ${OPERATOR_NS}
+    Create Namespace In Openshift    ${TEST_NS}
+
+Suite Teardown
+    [Documentation]    Suite Teardown
+    Delete Namespace From Openshift    ${TEST_NS}
+    RHOSi Teardown
+
+Restore DSCI Trusted CA Bundle Settings
+    [Documentation]    Restore DSCI Trusted CA Bundle settings to original tate
+    Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}   ''    ${OPERATOR_NS}
+    Set Trusted CA Bundle Management State    ${DSCI_NAME}    Managed    ${OPERATOR_NS}
+
+Wait Until Operator Ready
+    [Documentation]    Checks if operator is available/ready
+    [Arguments]    ${operator_name}    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc wait --timeout=2m --for condition=available -n ${namespace} deploy/${operator_name}
+    Should Be Equal    "${rc}"    "0"    msg=${output}
+
+Is Resource Present
+    [Documentation]    Check if resource is present in namespace
+    [Arguments]       ${resource}     ${resource_name}    ${namespace}    ${expected_result}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...  oc get ${resource} ${resource_name} -n ${namespace}
+    Should Be Equal    "${rc}"    "${expected_result}"    msg=${output}
+
+Is CA Bundle Value Present
+    [Documentation]    Check if the ConfigtMap contains Custom CA Bundle value
+    [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}        ${expected_result}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${custom_ca_bundle_value}
+    Should Be Equal    "${rc}"    "${expected_result}"    msg=${output}
+
+Wait For DSCI Ready State
+    [Documentation]    Checks that DSCI reconciled succesfully
+    [Arguments]    ${dsci}    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc wait --timeout=3m --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsci ${dsci}
+    Should Be Equal    "${rc}"    "0"     msg=${output}
+
+Check ConfigMap Contains CA Bundle Key
+    [Documentation]    Checks that ConfigMap contains CA Bundle
+    [Arguments]    ${config_map}    ${ca_bundle_name}    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc get configmap ${config_map} -n ${namespace} -o yaml | grep ${ca_bundle_name}
+    Should Be Equal    "${rc}"    "0"     msg=${output}
+
+Create Namespace In Openshift
+    [Documentation]    Create a new namespace if it does not already exist
+    [Arguments]    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output    oc get project ${namespace}
+    IF    ${rc} != 0
+        ${rc}=     Run And Return Rc    oc new-project ${namespace}
+        Should Be Equal    "${rc}"    "0"   msg=${output}
+    END
+
+Delete Namespace From Openshift
+    [Documentation]    Delete namespace from opneshift
+    [Arguments]    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output    oc delete project ${namespace}
+    Should Be Equal    "${rc}"    "0"   msg=${output}
+
+Set Custom CA Bundle Value In DSCI
+    [Documentation]    Set Custom CA Bundle value in DSCI
+    [Arguments]    ${DSCI}    ${custom_ca_bundle_value}    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc patch DSCInitialization/${DSCI} -n ${namespace} -p '{"spec":{"trustedCABundle":{"customCABundle":"${custom_ca_bundle_value}"}}}' --type merge
+    Should Be Equal    "${rc}"    "0"   msg=${output}
+
+Set Custom CA Bundle Value On ConfigMap
+    [Documentation]    Set Custom CA Bundle value in ConfigMap
+    [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}    ${reconsile_wait_time}
+    Log    message=IN Here:${config_map} ${custom_ca_bundle_value} ${namespace}    level=INFO
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc patch ConfigMap/${config_map} -n ${namespace} -p '{"data":{"odh-ca-bundle.crt":"${custom_ca_bundle_value}"}}' --type merge
+    Should Be Equal    "${rc}"    "0"   msg=${output}
+
+    # Allow operator time to reconsile
+    Sleep    ${reconsile_wait_time}
+
+Set Trusted CA Bundle Management State
+    [Documentation]    Change DSCI Management state to one of Managed/Unmanaged/Removed
+    [Arguments]    ${DSCI}    ${management_state}    ${namespace}
+    ${rc}   ${output}=    Run And Return Rc And Output
+    ...    oc patch DSCInitialization/${DSCI} -n ${namespace} -p '{"spec":{"trustedCABundle":{"managementState":"${management_state}"}}}' --type merge
+    Should Be Equal    "${rc}"    "0"   msg=${output}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -38,8 +38,9 @@ Verify User Can Serve And Query A bigscience/mt0-xxl Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=2    validate_response=${TRUE}    # temp
@@ -83,8 +84,9 @@ Verify User Can Serve And Query A google/flan-t5-xl Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=3   validate_response=${TRUE}
@@ -128,8 +130,9 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=3   validate_response=${TRUE}
@@ -172,8 +175,9 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=4    validate_response=${TRUE}    # temp
@@ -217,8 +221,9 @@ Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=0   validate_response=${TRUE}
@@ -262,8 +267,9 @@ Verify User Can Serve And Query A google/flan-ul-2 Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=3   validate_response=${TRUE}
@@ -307,8 +313,9 @@ Verify User Can Serve And Query A codellama/codellama-34b-instruct-hf Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=3000s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=5   validate_response=${TRUE}
@@ -343,8 +350,9 @@ Verify User Can Serve And Query A meta-llama/llama-2-13b-chat Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=900s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc
     ...    namespace=${test_namespace}   query_idx=0   validate_response=${TRUE}    # temp
@@ -393,8 +401,9 @@ Verify User Can Serve And Query A google/flan-t5-xl Prompt Tuned Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    timeout=300s
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
-    ...    Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ${prompt_tuned_params}=    Create Dictionary    prefix_id=flan-t5-xl-tuned
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1    protocol=grpc

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_tgis.robot
@@ -23,7 +23,7 @@ ${TGIS_RUNTIME_NAME}=    tgis-runtime
 @{SEARCH_METRICS}=    tgi_    istio_
 ${USE_GPU}=    ${FALSE}
 
-  
+
 *** Test Cases ***
 Verify User Can Serve And Query A Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
@@ -42,7 +42,8 @@ Verify User Can Serve And Query A Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
@@ -87,14 +88,16 @@ Verify User Can Deploy Multiple Models In The Same Namespace
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_two_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${model_one_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_one_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ...    process_alias=llm-one
     Query Model Multiple Times    model_name=${model_one_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    n_times=5    namespace=${test_namespace}     port_forwarding=${IS_KSERVE_RAW}
     Query Model Multiple Times    model_name=${model_one_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    n_times=5    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
     IF    ${IS_KSERVE_RAW}    Terminate Process    llm-one    kill=true
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${model_two_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_two_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ...    process_alias=llm-two
     Query Model Multiple Times    model_name=${model_two_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    n_times=10    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
@@ -136,12 +139,14 @@ Verify User Can Deploy Multiple Models In Different Namespaces
     ...    namespace=singlemodel-multi1
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_two_name}
     ...    namespace=singlemodel-multi2
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=singlemodel-multi1    model_name=${model_one_name}
+    ${pod_name}=  Get Pod Name    namespace=singlemodel-multi1    label_selector=serving.kserve.io/inferenceservice=${model_one_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ...    process_alias=llm-one
     Query Model Multiple Times    model_name=${model_one_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    n_times=2    namespace=singlemodel-multi1    port_forwarding=${IS_KSERVE_RAW}
     IF    ${IS_KSERVE_RAW}    Terminate Process    llm-one    kill=true
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=singlemodel-multi2    model_name=${model_two_name}
+    ${pod_name}=  Get Pod Name    namespace=singlemodel-multi2    label_selector=serving.kserve.io/inferenceservice=${model_two_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ...    process_alias=llm-two
     Query Model Multiple Times    model_name=${model_two_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    n_times=2    namespace=singlemodel-multi2    port_forwarding=${IS_KSERVE_RAW}
@@ -230,7 +235,7 @@ Verify User Can Change The Minimum Number Of Replicas For A Model
     [Documentation]    Checks if user can change the minimum number of replicas
     ...                of a deployed model.
     ...                Affected by:  https://issues.redhat.com/browse/SRVKS-1175
-    ...                When running on GPUs, it requires 3 GPUs           
+    ...                When running on GPUs, it requires 3 GPUs
     [Tags]    Tier1    ODS-2376
     [Setup]    Set Project And Runtime    runtime=${TGIS_RUNTIME_NAME}     namespace=${TEST_NS}-reps
     ${test_namespace}=    Set Variable     ${TEST_NS}-reps
@@ -246,7 +251,8 @@ Verify User Can Change The Minimum Number Of Replicas For A Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}    exp_replicas=1
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}    n_times=3
     ...    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
     ${rev_id}=    Set Minimum Replicas Number    n_replicas=3    model_name=${model_name}
@@ -344,7 +350,8 @@ Verify User Can Set Requests And Limits For A Model
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     ${rev_id}=    Get Current Revision ID    model_name=${flan_model_name}
     ...    namespace=${test_namespace}
     ${label_selector}=    Get Model Pod Label Selector    model_name=${flan_model_name}
@@ -394,7 +401,8 @@ Verify Model Can Be Served And Query On A GPU Node
     ...    namespace=${test_namespace}    exp_requests=${requests}    exp_limits=${limits}
     Model Pod Should Be Scheduled On A GPU Node    label_selector=serving.kserve.io/inferenceservice=${model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}    n_times=10
     ...    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
     Query Model Multiple Times    model_name=${model_name}    runtime=${TGIS_RUNTIME_NAME}    n_times=5
@@ -427,7 +435,8 @@ Verify Non Admin Can Serve And Query A Model
     ${host}=    Get KServe Inference Host Via CLI    isvc_name=${flan_model_name}   namespace=${test_namespace}
     ${body}=    Set Variable    '{"text": "${EXP_RESPONSES}[queries][0][query_text]"}'
     ${header}=    Set Variable    'mm-model-id: ${flan_model_name}'
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
@@ -456,7 +465,8 @@ Verify User Can Serve And Query Flan-t5 Grammar Syntax Corrector
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    query_idx=1    port_forwarding=${IS_KSERVE_RAW}
@@ -485,7 +495,8 @@ Verify User Can Serve And Query Flan-t5 Large
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    query_idx=${0}    port_forwarding=${IS_KSERVE_RAW}
@@ -517,7 +528,8 @@ Verify Runtime Upgrade Does Not Affect Deployed Models
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    model_name=${flan_model_name}
+    ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
+    IF    ${IS_KSERVE_RAW}     Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
     Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}
     ...    inference_type=all-tokens    n_times=1
     ...    namespace=${test_namespace}    port_forwarding=${IS_KSERVE_RAW}
@@ -560,7 +572,7 @@ Verify User Can Access Model Metrics From UWM
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
-    ...    namespace=${test_namespace}    
+    ...    namespace=${test_namespace}
     Wait Until Keyword Succeeds    30 times    4s
     ...    Metrics Should Exist In UserWorkloadMonitoring
     ...    thanos_url=${thanos_url}    thanos_token=${token}

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
@@ -19,7 +19,7 @@ Run TestMNISTPyTorchMCAD E2E test
     [Documentation]    Run Go E2E test: TestMNISTPyTorchMCAD
     [Tags]  ODS-2543
     ...     Sanity
-    ...     Tier2
+    ...     Tier1
     ...     DistributedWorkloads
     ...     CodeflareOperator
     Run Codeflare E2E Test    TestMNISTPyTorchMCAD
@@ -27,7 +27,7 @@ Run TestMNISTPyTorchMCAD E2E test
 Run TestMNISTRayJobMCADRayCluster E2E test
     [Documentation]    Run Go E2E test: TestMNISTRayJobMCADRayCluster
     [Tags]  ODS-2545
-    ...     Tier2
+    ...     Tier1
     ...     DistributedWorkloads
     ...     CodeflareOperator
     Run Codeflare E2E Test    TestMNISTRayJobMCADRayCluster
@@ -35,7 +35,7 @@ Run TestMNISTRayJobMCADRayCluster E2E test
 Run TestMCADRay ODH test
     [Documentation]    Run Go ODH test: TestMCADRay
     [Tags]  ODS-2514
-    ...     Tier2
+    ...     Tier1
     ...     DistributedWorkloads
     ...     CodeflareOperator
     Skip    "Skip because of https://issues.redhat.com/browse/RHOAIENG-3981"
@@ -44,7 +44,7 @@ Run TestMCADRay ODH test
 Run TestMnistPyTorchMCAD ODH test
     [Documentation]    Run Go ODH test: TestMnistPyTorchMCAD
     [Tags]  ODS-2515
-    ...     Tier2
+    ...     Tier1
     ...     DistributedWorkloads
     ...     CodeflareOperator
     Run Codeflare ODH Test    TestMnistPyTorchMCAD


### PR DESCRIPTION
This bundle contains following changes backported from `master` to `releases/2.8.0`:

* 007b6afd7b7fab0447cc9af6c637044cdd0b3112 (#1326)
* 6b936839fa300551912ac9f08e3f6556f364d72f (#1310)
* 655ac3b5c262ee71b2297a71242963774402dcd0 (#1329)
* e10f8fb6ac5bd3f5d61cc1f0087e3a45538ff434 (#1340)
* 01b755e4279840ae4000ab0dd9fe23434a2e5267 (#1343)

CI: tested smoke run only with `rhods/job/rhods-smoke/5057/` against RHOAI 2.8.1 RC2.

----

I HAVEN'T included following changes yet since these doesn't affect us directly now (but we should probably backport them for the long-term future):

* 389a773d49664eb7518c690ac4795f3a149e8755 (#1336)
* de721a3be1948f6f2599576b85ca3e1992fec2e4 (#1275)
* 24c43cd00d6b08811d96cb2f68a29f9be3ebd8d4 (#1334)