### PR TITLE
Fail fast for `poetry install` command

### DIFF
--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -346,7 +346,10 @@ if [[ ${SKIP_INSTALL} -eq 0 ]]; then
     fi
   fi
 
-  poetry --no-interaction install --sync
+  poetry install --no-interaction --sync || {
+      echo "[ERROR] poetry environment setup failed, aborting the execution!"
+      exit 1
+  }
 fi
 # shellcheck disable=SC1091
 source "$(poetry env info --path)/bin/activate"


### PR DESCRIPTION
In case the `poetry install` command fails, we probably don't want to continue in the execution anymore, so let's have a fail fast check there.

This is a candidate for backport to `releases/2.8.0` branch.

----

Why I want it now? Looks like our pre-created environment against `master` branch may be a bit fragile when running agasint some older branch - this means that packages should be downgraded/update/removed, etc. Don't know the reason and also I'm not sure whether this fail-fast will work since I wasn't able to reproduce the issue, but it shouldn't harm, right? :upside_down_face: 

FYI here is an example of the job run failed poetry environment from our Jenkins:

```
16:17:36  + sh ods_ci/run_robot_test.sh --skip-oclogin true --extra-robot-args '-i Smoke -e AutomationBug -e ProductBug -e ExcludeOnRHOAI'
16:17:36  ods_ci/test-variables.yml
16:17:36  INFO: we found a yq executable
16:17:36  skipping OC login as per parameter --skip-oclogin
16:17:36  Using a pre-created virtual environment in '/home/build/.local/ods-ci/.venv' for poetry to save time.
16:17:39  Python '/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/bin/python' will be used
16:17:42  Installing dependencies from lock file
16:17:43  
16:17:43  Package operations: 19 installs, 121 updates, 7 removals
16:17:43  
16:17:43    - Removing aiohttp (3.9.3)
16:17:44    - Removing aiosignal (1.3.1)
16:17:46    - Removing frozenlist (1.4.1)
16:17:47    - Removing multidict (6.0.5)
16:17:48    - Removing proto-plus (1.23.0)
16:17:49    - Removing robotframework-dependencylibrary (4.0.1)
16:17:51    - Removing yarl (1.9.4)
16:17:52    - Downgrading attrs (23.2.0 -> 23.1.0)
16:17:52    - Downgrading pyasn1 (0.6.0 -> 0.5.0)
16:17:56    - Downgrading cachetools (5.3.3 -> 5.3.1)
16:17:56    - Downgrading certifi (2024.2.2 -> 2023.7.22)
16:17:56    - Downgrading charset-normalizer (3.3.2 -> 3.2.0)
16:17:56    - Downgrading idna (3.6 -> 3.4)
16:17:56    - Downgrading outcome (1.3.0.post0 -> 1.2.0)
16:17:56    - Downgrading protobuf (4.25.3 -> 3.20.3)
16:17:56    - Downgrading pyasn1-modules (0.4.0 -> 0.3.0)
16:17:56    - Downgrading sniffio (1.3.1 -> 1.3.0)
16:17:56    - Downgrading urllib3 (1.26.18 -> 1.26.16)
16:18:18    - Downgrading cffi (1.16.0 -> 1.15.1)
16:18:18    - Installing exceptiongroup (1.1.3)
16:18:18    - Downgrading google-auth (2.29.0 -> 2.23.0)
16:18:18    - Downgrading googleapis-common-protos (1.63.0 -> 1.60.0)
16:18:18    - Downgrading pbr (6.0.0 -> 5.11.1)
16:18:18    - Downgrading pyparsing (3.1.2 -> 3.1.1)
16:18:18    - Downgrading trio (0.25.0 -> 0.22.2)
16:18:18    - Downgrading wrapt (1.16.0 -> 1.15.0)
16:18:18    - Downgrading rpds-py (0.18.0 -> 0.10.3)
16:18:33  
16:18:33    CalledProcessError
16:18:33  
16:18:33    Command '['/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/bin/python', '-m', 'pip', 'uninstall', 'rpds-py', '-y']' returned non-zero exit status 2.
16:18:33  
16:18:33    at /usr/lib64/python3.9/subprocess.py:528 in run
16:18:33         524│             # We don't call process.wait() as .__exit__ does that for us.
16:18:33         525│             raise
16:18:33         526│         retcode = process.poll()
16:18:33         527│         if check and retcode:
16:18:33      →  528│             raise CalledProcessError(retcode, process.args,
16:18:33         529│                                      output=stdout, stderr=stderr)
16:18:33         530│     return CompletedProcess(process.args, retcode, stdout, stderr)
16:18:33         531│ 
16:18:33         532│ 
16:18:33  
16:18:33  The following error occurred when trying to handle this error:
16:18:33  
16:18:33  
16:18:33    EnvCommandError
16:18:33  
16:18:33    Command ['/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/bin/python', '-m', 'pip', 'uninstall', 'rpds-py', '-y'] errored with the following return code 2
16:18:33    
16:18:33    Output:
16:18:33    ERROR: Exception:
16:18:33    Traceback (most recent call last):
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
16:18:33        status = run_func(*args)
16:18:33                 ^^^^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/commands/uninstall.py", line 65, in run
16:18:33        session = self.get_default_session(options)
16:18:33                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 95, in get_default_session
16:18:33        self._session = self.enter_context(self._build_session(options))
16:18:33                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/cli/req_command.py", line 122, in _build_session
16:18:33        session = PipSession(
16:18:33                  ^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/network/session.py", line 342, in __init__
16:18:33        self.headers["User-Agent"] = user_agent()
16:18:33                                     ^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/network/session.py", line 175, in user_agent
16:18:33        setuptools_dist = get_default_environment().get_distribution("setuptools")
16:18:33                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 189, in get_distribution
16:18:33        return next(matches, None)
16:18:33               ^^^^^^^^^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 184, in <genexpr>
16:18:33        matches = (
16:18:33                  ^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/base.py", line 626, in iter_all_distributions
16:18:33        for dist in self._iter_distributions():
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 177, in _iter_distributions
16:18:33        for dist in finder.find_eggs(location):
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 144, in find_eggs
16:18:33        yield from self._find_eggs_in_dir(location)
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_internal/metadata/importlib/_envs.py", line 111, in _find_eggs_in_dir
16:18:33        from pip._vendor.pkg_resources import find_distributions
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3327, in <module>
16:18:33        @_call_aside
16:18:33         ^^^^^^^^^^^
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3302, in _call_aside
16:18:33        f(*args, **kwargs)
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 3360, in _initialize_master_working_set
16:18:33        list(map(working_set.add_entry, sys.path))
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 671, in add_entry
16:18:33        for dist in find_distributions(entry, True):
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2134, in find_on_path
16:18:33        for dist in factory(fullpath):
16:18:33      File "/home/jenkins/workspace/rhods/rhods-smoke/ods-ci/.venv/lib/python3.11/site-packages/pip/_vendor/pkg_resources/__init__.py", line 2192, in distributions_from_metadata
16:18:33        if len(os.listdir(path)) == 0:
16:18:33               ^^^^^^^^^^^^^^^^
16:18:33    FileNotFoundError: [Errno 2] No such file or directory: '/home/build/.local/ods-ci/.venv/lib/python3.11/site-packages/pbr-6.0.0.dist-info'
16:18:33    
16:18:33  
16:18:33    at ~/.local/share/pypoetry/venv/lib64/python3.9/site-packages/poetry/utils/env/base_env.py:342 in _run
16:18:33        338│                 output = subprocess.check_output(
16:18:33        339│                     cmd, stderr=stderr, env=env, text=True, **kwargs
16:18:33        340│                 )
16:18:33        341│         except CalledProcessError as e:
16:18:33      → 342│             raise EnvCommandError(e)
16:18:33        343│ 
16:18:33        344│         return output
16:18:33        345│ 
16:18:33        346│     def execute(self, bin: str, *args: str, **kwargs: Any) -> int:
16:18:33  
16:18:33  Cannot install rpds-py.
```