### PR TITLE
Enhance Pipelines UI tests for DSPv2 and add some example pipelines

### DIFF
--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test.py
@@ -1,0 +1,28 @@
+from kfp import components, dsl
+
+
+def print_message(message: str):
+    """Prints a message"""
+    print(message)
+
+
+print_message_op = components.create_component_from_func(
+    print_message,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+
+
+@dsl.pipeline(
+    name="version-test-pipeline",
+    description="Pipeline that prints a hello message",
+)
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message_op(message)
+
+
+if __name__ == "__main__":
+    from kfp_tekton.compiler import TektonCompiler
+
+    TektonCompiler().compile(
+        version_test_pipeline, package_path=__file__.replace(".py", "_compiled.yaml")
+    )

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_compiled.yaml
@@ -7,7 +7,7 @@ metadata:
     tekton.dev/input_artifacts: '{}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
-    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_endpoint_scheme: https://
     tekton.dev/artifact_items: '{"print-message": []}'
     sidecar.istio.io/inject: "false"
     tekton.dev/template: ''

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_compiled.yaml
@@ -1,0 +1,66 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: version-test-pipeline
+  annotations:
+    tekton.dev/output_artifacts: '{}'
+    tekton.dev/input_artifacts: '{}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"print-message": []}'
+    sidecar.istio.io/inject: "false"
+    tekton.dev/template: ''
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that prints a
+      hello message", "inputs": [{"default": "Hello world", "name": "message", "optional":
+      true, "type": "String"}], "name": "version-test-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
+spec:
+  params:
+  - name: message
+    value: Hello world
+  pipelineSpec:
+    params:
+    - name: message
+      default: Hello world
+    tasks:
+    - name: print-message
+      params:
+      - name: message
+        value: $(params.message)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.message)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message(message):
+                """Prints a message"""
+                print(message)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = print_message(**_parsed_args)
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: message
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message",
+              "outputs": [], "version": "Print message@sha256=e90da6a7a29b1ffac71258294056f94b8202ea8f7e34f65ee74a8fa0fbe167ee"}'

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2.py
@@ -1,0 +1,40 @@
+from kfp import components, dsl
+
+
+def print_message(message: str) -> str:
+    """Prints a message"""
+    print(message)
+    return message
+
+
+def print_message_2(message: str):
+    """Prints a message"""
+    print(message)
+
+
+print_message_op = components.create_component_from_func(
+    print_message,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+
+print_message_2_op = components.create_component_from_func(
+    print_message_2,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+
+
+@dsl.pipeline(
+    name="version-test-pipeline",
+    description="Pipeline that prints a hello message",
+)
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message_op(message)
+    print_message_2_task = print_message_2_op(message=print_message_task.output)
+
+
+if __name__ == "__main__":
+    from kfp_tekton.compiler import TektonCompiler
+
+    TektonCompiler().compile(
+        version_test_pipeline, package_path=__file__.replace(".py", "_compiled.yaml")
+    )

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2_compiled.yaml
@@ -1,0 +1,138 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: version-test-pipeline
+  annotations:
+    tekton.dev/output_artifacts: '{"print-message": [{"key": "artifacts/$PIPELINERUN/print-message/Output.tgz",
+      "name": "print-message-Output", "path": "/tmp/outputs/Output/data"}]}'
+    tekton.dev/input_artifacts: '{"print-message-2": [{"name": "print-message-Output",
+      "parent_task": "print-message"}]}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"print-message": [["Output", "$(results.Output.path)"]],
+      "print-message-2": []}'
+    sidecar.istio.io/inject: "false"
+    tekton.dev/template: ''
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that prints a
+      hello message", "inputs": [{"default": "Hello world", "name": "message", "optional":
+      true, "type": "String"}], "name": "version-test-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
+spec:
+  params:
+  - name: message
+    value: Hello world
+  pipelineSpec:
+    params:
+    - name: message
+      default: Hello world
+    tasks:
+    - name: print-message
+      params:
+      - name: message
+        value: $(params.message)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.message)
+          - '----output-paths'
+          - $(results.Output.path)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message(message):
+                """Prints a message"""
+                print(message)
+                return message
+
+            def _serialize_str(str_value: str) -> str:
+                if not isinstance(str_value, str):
+                    raise TypeError('Value "{}" has type "{}" instead of str.'.format(
+                        str(str_value), str(type(str_value))))
+                return str_value
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+            _parsed_args = vars(_parser.parse_args())
+            _output_files = _parsed_args.pop("_output_paths", [])
+
+            _outputs = print_message(**_parsed_args)
+
+            _outputs = [_outputs]
+
+            _output_serializers = [
+                _serialize_str,
+
+            ]
+
+            import os
+            for idx, output_file in enumerate(_output_files):
+                try:
+                    os.makedirs(os.path.dirname(output_file))
+                except OSError:
+                    pass
+                with open(output_file, 'w') as f:
+                    f.write(_output_serializers[idx](_outputs[idx]))
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: message
+        results:
+        - name: Output
+          type: string
+          description: /tmp/outputs/Output/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message",
+              "outputs": [{"name": "Output", "type": "String"}], "version": "Print
+              message@sha256=fc7ffc1b623e533a9816b909fb25a9e755cd17934910cb4a584db727d394a18d"}'
+    - name: print-message-2
+      params:
+      - name: print-message-Output
+        value: $(tasks.print-message.results.Output)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.print-message-Output)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message_2(message):
+                """Prints a message"""
+                print(message)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message 2', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = print_message_2(**_parsed_args)
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: print-message-Output
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message
+              2", "outputs": [], "version": "Print message 2@sha256=9f92667edcb4cf9023a4faf372c980e8c53d821b18271bb25cfdaec0ce9943e2"}'

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v2_compiled.yaml
@@ -9,7 +9,7 @@ metadata:
       "parent_task": "print-message"}]}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
-    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_endpoint_scheme: https://
     tekton.dev/artifact_items: '{"print-message": [["Output", "$(results.Output.path)"]],
       "print-message-2": []}'
     sidecar.istio.io/inject: "false"

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3.py
@@ -1,0 +1,50 @@
+from kfp import components, dsl
+
+
+def print_message(message: str) -> str:
+    """Prints a message"""
+    print(message)
+    return message
+
+
+def print_message_2(message: str) -> str:
+    """Prints a message"""
+    print(message)
+    return message
+
+
+def print_message_3(message: str):
+    """Prints a message"""
+    print(message)
+
+
+print_message_op = components.create_component_from_func(
+    print_message,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+
+print_message_2_op = components.create_component_from_func(
+    print_message_2,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+
+print_message_3_op = components.create_component_from_func(
+    print_message_3,
+    base_image="registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61",
+)
+@dsl.pipeline(
+    name="version-test-pipeline",
+    description="Pipeline that prints a hello message",
+)
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message_op(message)
+    print_message_2_task = print_message_2_op(message=print_message_task.output)
+    print_message_3_task = print_message_3_op(message=print_message_2_task.output)
+
+
+if __name__ == "__main__":
+    from kfp_tekton.compiler import TektonCompiler
+
+    TektonCompiler().compile(
+        version_test_pipeline, package_path=__file__.replace(".py", "_compiled.yaml")
+    )

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3_compiled.yaml
@@ -1,0 +1,211 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: version-test-pipeline
+  annotations:
+    tekton.dev/output_artifacts: '{"print-message": [{"key": "artifacts/$PIPELINERUN/print-message/Output.tgz",
+      "name": "print-message-Output", "path": "/tmp/outputs/Output/data"}], "print-message-2":
+      [{"key": "artifacts/$PIPELINERUN/print-message-2/Output.tgz", "name": "print-message-2-Output",
+      "path": "/tmp/outputs/Output/data"}]}'
+    tekton.dev/input_artifacts: '{"print-message-2": [{"name": "print-message-Output",
+      "parent_task": "print-message"}], "print-message-3": [{"name": "print-message-2-Output",
+      "parent_task": "print-message-2"}]}'
+    tekton.dev/artifact_bucket: mlpipeline
+    tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
+    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_items: '{"print-message": [["Output", "$(results.Output.path)"]],
+      "print-message-2": [["Output", "$(results.Output.path)"]], "print-message-3":
+      []}'
+    sidecar.istio.io/inject: "false"
+    tekton.dev/template: ''
+    pipelines.kubeflow.org/big_data_passing_format: $(workspaces.$TASK_NAME.path)/artifacts/$ORIG_PR_NAME/$TASKRUN_NAME/$TASK_PARAM_NAME
+    pipelines.kubeflow.org/pipeline_spec: '{"description": "Pipeline that prints a
+      hello message", "inputs": [{"default": "Hello world", "name": "message", "optional":
+      true, "type": "String"}], "name": "version-test-pipeline"}'
+  labels:
+    pipelines.kubeflow.org/pipelinename: ''
+    pipelines.kubeflow.org/generation: ''
+spec:
+  params:
+  - name: message
+    value: Hello world
+  pipelineSpec:
+    params:
+    - name: message
+      default: Hello world
+    tasks:
+    - name: print-message
+      params:
+      - name: message
+        value: $(params.message)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.message)
+          - '----output-paths'
+          - $(results.Output.path)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message(message):
+                """Prints a message"""
+                print(message)
+                return message
+
+            def _serialize_str(str_value: str) -> str:
+                if not isinstance(str_value, str):
+                    raise TypeError('Value "{}" has type "{}" instead of str.'.format(
+                        str(str_value), str(type(str_value))))
+                return str_value
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+            _parsed_args = vars(_parser.parse_args())
+            _output_files = _parsed_args.pop("_output_paths", [])
+
+            _outputs = print_message(**_parsed_args)
+
+            _outputs = [_outputs]
+
+            _output_serializers = [
+                _serialize_str,
+
+            ]
+
+            import os
+            for idx, output_file in enumerate(_output_files):
+                try:
+                    os.makedirs(os.path.dirname(output_file))
+                except OSError:
+                    pass
+                with open(output_file, 'w') as f:
+                    f.write(_output_serializers[idx](_outputs[idx]))
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: message
+        results:
+        - name: Output
+          type: string
+          description: /tmp/outputs/Output/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message",
+              "outputs": [{"name": "Output", "type": "String"}], "version": "Print
+              message@sha256=fc7ffc1b623e533a9816b909fb25a9e755cd17934910cb4a584db727d394a18d"}'
+    - name: print-message-2
+      params:
+      - name: print-message-Output
+        value: $(tasks.print-message.results.Output)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.print-message-Output)
+          - '----output-paths'
+          - $(results.Output.path)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message_2(message):
+                """Prints a message"""
+                print(message)
+                return message
+
+            def _serialize_str(str_value: str) -> str:
+                if not isinstance(str_value, str):
+                    raise TypeError('Value "{}" has type "{}" instead of str.'.format(
+                        str(str_value), str(type(str_value))))
+                return str_value
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message 2', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parser.add_argument("----output-paths", dest="_output_paths", type=str, nargs=1)
+            _parsed_args = vars(_parser.parse_args())
+            _output_files = _parsed_args.pop("_output_paths", [])
+
+            _outputs = print_message_2(**_parsed_args)
+
+            _outputs = [_outputs]
+
+            _output_serializers = [
+                _serialize_str,
+
+            ]
+
+            import os
+            for idx, output_file in enumerate(_output_files):
+                try:
+                    os.makedirs(os.path.dirname(output_file))
+                except OSError:
+                    pass
+                with open(output_file, 'w') as f:
+                    f.write(_output_serializers[idx](_outputs[idx]))
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: print-message-Output
+        results:
+        - name: Output
+          type: string
+          description: /tmp/outputs/Output/data
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message
+              2", "outputs": [{"name": "Output", "type": "String"}], "version": "Print
+              message 2@sha256=8958b6241f037b2931ee8830253221e35070fd81c89d2e8a99606e9d4ac7486a"}'
+    - name: print-message-3
+      params:
+      - name: print-message-2-Output
+        value: $(tasks.print-message-2.results.Output)
+      taskSpec:
+        steps:
+        - name: main
+          args:
+          - --message
+          - $(inputs.params.print-message-2-Output)
+          command:
+          - sh
+          - -ec
+          - |
+            program_path=$(mktemp)
+            printf "%s" "$0" > "$program_path"
+            python3 -u "$program_path" "$@"
+          - |
+            def print_message_3(message):
+                """Prints a message"""
+                print(message)
+
+            import argparse
+            _parser = argparse.ArgumentParser(prog='Print message 3', description='Prints a message')
+            _parser.add_argument("--message", dest="message", type=str, required=True, default=argparse.SUPPRESS)
+            _parsed_args = vars(_parser.parse_args())
+
+            _outputs = print_message_3(**_parsed_args)
+          image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+        params:
+        - name: print-message-2-Output
+        metadata:
+          labels:
+            pipelines.kubeflow.org/cache_enabled: "true"
+          annotations:
+            pipelines.kubeflow.org/component_spec_digest: '{"name": "Print message
+              3", "outputs": [], "version": "Print message 3@sha256=dacfe624f5773863129f61dd5a0786298e1305fd8832fe9b560efd194fc0f007"}'

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/pipeline-versions/version_test_v3_compiled.yaml
@@ -12,7 +12,7 @@ metadata:
       "parent_task": "print-message-2"}]}'
     tekton.dev/artifact_bucket: mlpipeline
     tekton.dev/artifact_endpoint: minio-service.kubeflow:9000
-    tekton.dev/artifact_endpoint_scheme: http://
+    tekton.dev/artifact_endpoint_scheme: https://
     tekton.dev/artifact_items: '{"print-message": [["Output", "$(results.Output.path)"]],
       "print-message-2": [["Output", "$(results.Output.path)"]], "print-message-3":
       []}'

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline.py
@@ -2,8 +2,10 @@ import kfp
 from kfp import Client, compiler, dsl
 from kfp.dsl import ClassificationMetrics, Dataset, Input, Model, Output
 
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+# common_base_image = "quay.io/opendatahub/ds-pipelines-sample-base:v1.0"
 
-@dsl.component(base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0", packages_to_install=["pandas==2.2.0"])
+@dsl.component(base_image=common_base_image, packages_to_install=["pandas==2.2.0"])
 def create_dataset(iris_dataset: Output[Dataset]):
     import pandas as pd
 
@@ -16,7 +18,7 @@ def create_dataset(iris_dataset: Output[Dataset]):
 
 
 @dsl.component(
-    base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0",
+    base_image=common_base_image,
     packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
 )
 def normalize_dataset(
@@ -41,7 +43,7 @@ def normalize_dataset(
 
 
 @dsl.component(
-    base_image="quay.io/opendatahub/ds-pipelines-sample-base:v1.0",
+    base_image=common_base_image,
     packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
 )
 def train_model(
@@ -95,6 +97,4 @@ def my_pipeline(
     )
 
 
-endpoint = "http://ml-pipeline-ui-kubeflow.apps.rmartine.dev.datahub.redhat.com/"
-
-compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "-v2.yaml"))
+compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_compiled.yaml
@@ -82,11 +82,11 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef create_dataset(iris_dataset: Output[Dataset]):\n    import pandas\
-          \ as pd\n\n    csv_url = 'https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data'\n\
-          \    col_names = [\n        'Sepal_Length', 'Sepal_Width', 'Petal_Length',\
-          \ 'Petal_Width', 'Labels'\n    ]\n    df = pd.read_csv(csv_url, names=col_names)\n\
-          \n    with open(iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+          \ as pd\n\n    csv_url = \"https://archive.ics.uci.edu/ml/machine-learning-databases/iris/iris.data\"\
+          \n    col_names = [\"Sepal_Length\", \"Sepal_Width\", \"Petal_Length\",\
+          \ \"Petal_Width\", \"Labels\"]\n    df = pd.read_csv(csv_url, names=col_names)\n\
+          \n    with open(iris_dataset.path, \"w\") as f:\n        df.to_csv(f)\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
     exec-normalize-dataset:
       container:
         args:
@@ -116,14 +116,14 @@ deploymentSpec:
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef normalize_dataset(\n    input_iris_dataset: Input[Dataset],\n\
           \    normalized_iris_dataset: Output[Dataset],\n    standard_scaler: bool,\n\
-          ):\n\n    import pandas as pd\n    from sklearn.preprocessing import MinMaxScaler\n\
-          \    from sklearn.preprocessing import StandardScaler\n\n    with open(input_iris_dataset.path)\
-          \ as f:\n        df = pd.read_csv(f)\n    labels = df.pop('Labels')\n\n\
-          \    scaler = StandardScaler() if standard_scaler else MinMaxScaler()\n\n\
-          \    df = pd.DataFrame(scaler.fit_transform(df))\n    df['Labels'] = labels\n\
-          \    normalized_iris_dataset.metadata['state'] = \"Normalized\"\n    with\
-          \ open(normalized_iris_dataset.path, 'w') as f:\n        df.to_csv(f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+          ):\n    import pandas as pd\n    from sklearn.preprocessing import MinMaxScaler,\
+          \ StandardScaler\n\n    with open(input_iris_dataset.path) as f:\n     \
+          \   df = pd.read_csv(f)\n    labels = df.pop(\"Labels\")\n\n    scaler =\
+          \ StandardScaler() if standard_scaler else MinMaxScaler()\n\n    df = pd.DataFrame(scaler.fit_transform(df))\n\
+          \    df[\"Labels\"] = labels\n    normalized_iris_dataset.metadata[\"state\"\
+          ] = \"Normalized\"\n    with open(normalized_iris_dataset.path, \"w\") as\
+          \ f:\n        df.to_csv(f)\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
     exec-train-model:
       container:
         args:
@@ -154,21 +154,19 @@ deploymentSpec:
           \ *\n\ndef train_model(\n    normalized_iris_dataset: Input[Dataset],\n\
           \    model: Output[Model],\n    metrics: Output[ClassificationMetrics],\n\
           \    n_neighbors: int,\n):\n    import pickle\n\n    import pandas as pd\n\
-          \    from sklearn.model_selection import train_test_split\n    from sklearn.neighbors\
-          \ import KNeighborsClassifier\n\n    from sklearn.metrics import roc_curve\n\
-          \    from sklearn.model_selection import train_test_split, cross_val_predict\n\
-          \    from sklearn.metrics import confusion_matrix\n\n\n    with open(normalized_iris_dataset.path)\
-          \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop('Labels')\n    X\
-          \ = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
+          \    from sklearn.metrics import confusion_matrix, roc_curve\n    from sklearn.model_selection\
+          \ import cross_val_predict, train_test_split\n    from sklearn.neighbors\
+          \ import KNeighborsClassifier\n\n    with open(normalized_iris_dataset.path)\
+          \ as f:\n        df = pd.read_csv(f)\n\n    y = df.pop(\"Labels\")\n   \
+          \ X = df\n\n    X_train, X_test, y_train, y_test = train_test_split(X, y,\
           \ random_state=0)\n\n    clf = KNeighborsClassifier(n_neighbors=n_neighbors)\n\
-          \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(\n\
-          \        clf, X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n\
-          \        ['Iris-Setosa', 'Iris-Versicolour', 'Iris-Virginica'],\n      \
-          \  confusion_matrix(\n            y_train,\n            predictions).tolist()\
-          \  # .tolist() to convert np array to list.\n    )\n\n    model.metadata['framework']\
-          \ = 'scikit-learn'\n    with open(model.path, 'wb') as f:\n        pickle.dump(clf,\
-          \ f)\n\n"
-        image: quay.io/opendatahub/ds-pipelines-sample-base:v1.0
+          \    clf.fit(X_train, y_train)\n\n    predictions = cross_val_predict(clf,\
+          \ X_train, y_train, cv=3)\n    metrics.log_confusion_matrix(\n        [\"\
+          Iris-Setosa\", \"Iris-Versicolour\", \"Iris-Virginica\"],\n        confusion_matrix(y_train,\
+          \ predictions).tolist(),  # .tolist() to convert np array to list.\n   \
+          \ )\n\n    model.metadata[\"framework\"] = \"scikit-learn\"\n    with open(model.path,\
+          \ \"wb\") as f:\n        pickle.dump(clf, f)\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
 pipelineInfo:
   name: iris-training-pipeline
 root:

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test.py
@@ -1,0 +1,19 @@
+from kfp import compiler, dsl
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
+def print_message(message: str):
+    """Prints a message"""
+    print(message + " (step 1)")
+
+
+@dsl.pipeline(name="version-test-pipeline", description="Pipeline that prints a hello message")
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message(message=message)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(version_test_pipeline,
+                                package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_compiled.yaml
@@ -1,0 +1,68 @@
+# PIPELINE DEFINITION
+# Name: version-test-pipeline
+# Description: Pipeline that prints a hello message
+# Inputs:
+#    message: str [Default: 'Hello world']
+components:
+  comp-print-message:
+    executorLabel: exec-print-message
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-print-message:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message(message: str):\n    \"\"\"Prints a message\"\"\"\
+          \n    print(message)\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+pipelineInfo:
+  description: Pipeline that prints a hello message
+  name: version-test-pipeline
+root:
+  dag:
+    tasks:
+      print-message:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message
+        inputs:
+          parameters:
+            message:
+              componentInputParameter: message
+        taskInfo:
+          name: print-message
+  inputDefinitions:
+    parameters:
+      message:
+        defaultValue: Hello world
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.7.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2.py
@@ -1,0 +1,25 @@
+from kfp import compiler, dsl
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
+def print_message(message: str) -> str:
+    """Prints a message"""
+    print(message + " (step 1)")
+    return message
+
+
+@dsl.component(base_image=common_base_image)
+def print_message_2(message: str):
+    """Prints a message"""
+    print(message + " (step 2)")
+@dsl.pipeline(name="version-test-pipeline", description="Pipeline that prints a hello message")
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message(message=message)
+    print_message_2(message=print_message_task.output)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(version_test_pipeline,
+                                package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2_compiled.yaml
@@ -1,0 +1,122 @@
+# PIPELINE DEFINITION
+# Name: version-test-pipeline
+# Description: Pipeline that prints a hello message
+# Inputs:
+#    message: str [Default: 'Hello world']
+components:
+  comp-print-message:
+    executorLabel: exec-print-message
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-message-2:
+    executorLabel: exec-print-message-2
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-print-message:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message(message: str) -> str:\n    \"\"\"Prints a message\"\
+          \"\"\n    print(message + \" (step 1)\")\n    return message\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+    exec-print-message-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message_2
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message_2(message: str):\n    \"\"\"Prints a message\"\"\
+          \"\n    print(message + \" (step 2)\")\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+pipelineInfo:
+  description: Pipeline that prints a hello message
+  name: version-test-pipeline
+root:
+  dag:
+    tasks:
+      print-message:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message
+        inputs:
+          parameters:
+            message:
+              componentInputParameter: message
+        taskInfo:
+          name: print-message
+      print-message-2:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message-2
+        dependentTasks:
+        - print-message
+        inputs:
+          parameters:
+            message:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: print-message
+        taskInfo:
+          name: print-message-2
+  inputDefinitions:
+    parameters:
+      message:
+        defaultValue: Hello world
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.7.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3.py
@@ -1,0 +1,34 @@
+from kfp import compiler, dsl
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
+def print_message(message: str) -> str:
+    """Prints a message"""
+    print(message + " (step 1)")
+    return message
+
+
+@dsl.component(base_image=common_base_image)
+def print_message_2(message: str) -> str:
+    """Prints a message"""
+    print(message + " (step 2)")
+    return message
+
+@dsl.component(base_image=common_base_image)
+def print_message_3(message: str):
+    """Prints a message"""
+    print(message + " (step 3)")
+
+
+@dsl.pipeline(name="version-test-pipeline", description="Pipeline that prints a hello message")
+def version_test_pipeline(message: str = "Hello world"):
+    print_message_task = print_message(message=message)
+    print_message_2_task = print_message_2(message=print_message_task.output)
+    print_message_3(message=print_message_2_task.output)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(version_test_pipeline,
+                                package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3_compiled.yaml
@@ -1,0 +1,176 @@
+# PIPELINE DEFINITION
+# Name: version-test-pipeline
+# Description: Pipeline that prints a hello message
+# Inputs:
+#    message: str [Default: 'Hello world']
+components:
+  comp-print-message:
+    executorLabel: exec-print-message
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-message-2:
+    executorLabel: exec-print-message-2
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-print-message-3:
+    executorLabel: exec-print-message-3
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-print-message:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message(message: str) -> str:\n    \"\"\"Prints a message\"\
+          \"\"\n    print(message + \" (step 1)\")\n    return message\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+    exec-print-message-2:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message_2
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message_2(message: str) -> str:\n    \"\"\"Prints a message\"\
+          \"\"\n    print(message + \" (step 2)\")\n    return message\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+    exec-print-message-3:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - print_message_3
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef print_message_3(message: str):\n    \"\"\"Prints a message\"\"\
+          \"\n    print(message + \" (step 3)\")\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+pipelineInfo:
+  description: Pipeline that prints a hello message
+  name: version-test-pipeline
+root:
+  dag:
+    tasks:
+      print-message:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message
+        inputs:
+          parameters:
+            message:
+              componentInputParameter: message
+        taskInfo:
+          name: print-message
+      print-message-2:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message-2
+        dependentTasks:
+        - print-message
+        inputs:
+          parameters:
+            message:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: print-message
+        taskInfo:
+          name: print-message-2
+      print-message-3:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-print-message-3
+        dependentTasks:
+        - print-message-2
+        inputs:
+          parameters:
+            message:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: print-message-2
+        taskInfo:
+          name: print-message-3
+  inputDefinitions:
+    parameters:
+      message:
+        defaultValue: Hello world
+        isOptional: true
+        parameterType: STRING
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.7.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap.py
@@ -1,0 +1,30 @@
+from kfp import compiler, dsl
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
+def take_nap(naptime_secs: int) -> str:
+    """Sleeps for secs"""
+    from time import sleep
+
+    print(f"Sleeping for {naptime_secs} seconds: Zzzzzz ...")
+    sleep(naptime_secs)
+    return "I'm awake now. Did I snore?"
+
+
+@dsl.component(base_image=common_base_image)
+def wake_up(message: str):
+    """Wakes up from nap printing a message"""
+    print(message)
+
+
+@dsl.pipeline(name="take-nap-pipeline", description="Pipeline that sleeps for 15 mins (900 secs)")
+def take_nap_pipeline(naptime_secs: int = 900):
+    take_nap_task = take_nap(naptime_secs=naptime_secs)
+    wake_up_task = wake_up(message=take_nap_task.output)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(take_nap_pipeline,
+                                package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_compiled.yaml
@@ -1,0 +1,124 @@
+# PIPELINE DEFINITION
+# Name: take-nap-pipeline
+# Description: Pipeline that sleeps for 15 mins (900 secs)
+# Inputs:
+#    naptime_secs: int [Default: 900.0]
+components:
+  comp-take-nap:
+    executorLabel: exec-take-nap
+    inputDefinitions:
+      parameters:
+        naptime_secs:
+          parameterType: NUMBER_INTEGER
+    outputDefinitions:
+      parameters:
+        Output:
+          parameterType: STRING
+  comp-wake-up:
+    executorLabel: exec-wake-up
+    inputDefinitions:
+      parameters:
+        message:
+          parameterType: STRING
+deploymentSpec:
+  executors:
+    exec-take-nap:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - take_nap
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef take_nap(naptime_secs: int) -> str:\n    \"\"\"Sleeps for secs\"\
+          \"\"\n    from time import sleep\n\n    print(f\"Sleeping for {naptime_secs}\
+          \ seconds: Zzzzzz ...\")\n    sleep(naptime_secs)\n    return \"I'm awake\
+          \ now. Did I snore?\"\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+    exec-wake-up:
+      container:
+        args:
+        - --executor_input
+        - '{{$}}'
+        - --function_to_execute
+        - wake_up
+        command:
+        - sh
+        - -c
+        - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
+          \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
+          $0\" \"$@\"\n"
+        - sh
+        - -ec
+        - 'program_path=$(mktemp -d)
+
+
+          printf "%s" "$0" > "$program_path/ephemeral_component.py"
+
+          _KFP_RUNTIME=true python3 -m kfp.dsl.executor_main                         --component_module_path                         "$program_path/ephemeral_component.py"                         "$@"
+
+          '
+        - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
+          \ *\n\ndef wake_up(message: str):\n    \"\"\"Wakes up from nap printing\
+          \ a message\"\"\"\n    print(message)\n\n"
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
+pipelineInfo:
+  description: Pipeline that sleeps for 15 mins (900 secs)
+  name: take-nap-pipeline
+root:
+  dag:
+    tasks:
+      take-nap:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-take-nap
+        inputs:
+          parameters:
+            naptime_secs:
+              componentInputParameter: naptime_secs
+        taskInfo:
+          name: take-nap
+      wake-up:
+        cachingOptions:
+          enableCache: true
+        componentRef:
+          name: comp-wake-up
+        dependentTasks:
+        - take-nap
+        inputs:
+          parameters:
+            message:
+              taskOutputParameter:
+                outputParameterKey: Output
+                producerTask: take-nap
+        taskInfo:
+          name: wake-up
+  inputDefinitions:
+    parameters:
+      naptime_secs:
+        defaultValue: 900.0
+        isOptional: true
+        parameterType: NUMBER_INTEGER
+schemaVersion: 2.1.0
+sdkVersion: kfp-2.7.0

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -130,7 +130,7 @@ Delete Pipeline Server
     Click Element    //li[contains(a/text(), 'Delete pipeline server')]
     Handle Deletion Confirmation Modal    ${data_science_project_name} pipeline server    pipeline server
     Wait Until Page Contains     text=Configure pipeline server    timeout=120s
-    Pipelines.Wait Until Pipeline Server Is Deleted
+    Pipelines.Wait Until Pipeline Server Is Deleted    ${data_science_project_name}
 
 Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
     [Documentation]    Verify me message "Error displaying Pipelines" after creating pipeline server

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -55,12 +55,6 @@ Fill In Run Creation Form    # robocop: disable
     Input Text    ${PIPELINE_RUN_DESC_INPUT_XP}    ${name}
     Run Keyword And Warn On Failure    Element Should Be Disabled    ${PIPELINE_RUN_CREATE_BTN_XP}
 
-    # FIXME: temporally harcoding parameters for iris-pipeline.
-    # This is a dirty workaround for RHOAIENG-4738 (dashboard not loading default pipeline parameters)
-    Wait Until Element is Visible    //*[@data-testid="neighbors"]/*/*/*/input
-    Input Text                       //*[@data-testid="neighbors"]/*/*/*/input   3
-    Click Element                    //*[@data-testid="radio-standard_scaler-true"]
-
 #    TODO: by fix it to select latest version of ${pipeline_name}
 #    IF    "${pipeline_name}" != "${NONE}"
 #        Select Pipeline For The Run    pipeline_name=${pipeline_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -103,31 +103,34 @@ Archive Pipeline Run
     Wait Until Page Contains Element    xpath://h2[contains(text(), 'No triggered runs yet')]
 
 Delete Pipeline
-    [Documentation]    Delete a pipeline. From the left menu select "Data Science Pipelines" -> Pipelines.
-    ...                The "Delete Pipeline" will search for a line in the grid that match the pipeline name.
-    ...                Based on that, hit the ... Menu in the row and hit Delete drop down menu.
+    [Documentation]    Navigates to "Data Science Pipelines" -> Pipelines, deletes the latest pipeline version
+    ...    available and deletes the pipeline using the pipelines actions menu.
+    ...    TODO: improve keyword to delete multiple pipeline versions
     [Arguments]    ${pipeline_name}
     Navigate To Page    Data Science Pipelines    Pipelines
-    Wait Until Page Contains Element    xpath://h2[text()='${pipeline_name}']
-    Pipelines.Click Action From Actions Menu    ${pipeline_name}    Delete
+    ODHDashboard.Maybe Wait For Dashboard Loading Spinner Page
+
+    Pipelines.Expand Pipeline Details    ${pipeline_name}
+    Pipelines.Click Action From Pipeline Version Actions Menu    ${pipeline_name}    Delete pipeline version
     Handle Deletion Confirmation Modal    ${pipeline_name}    pipeline
-    Wait Until Page Contains Element    xpath://h4[contains(text(), 'No pipelines yet')]
+
+    Pipelines.Click Action From Pipeline Actions Menu    ${pipeline_name}    Delete
+    Handle Deletion Confirmation Modal    ${pipeline_name}    pipeline
+    Wait Until Pipeline Is Not Listed    ${pipeline_name}
 
 Delete Pipeline Server
-    [Documentation]    Delete a pipeline server. From the top right menu inside "Data Science Pipelines" -> Pipelines
+    [Documentation]    Navigates to "Data Science Pipelines" -> Pipelines and deletes the pipeline server
     [Arguments]    ${data_science_project_name}
+    Navigate To Page    Data Science Pipelines    Pipelines
+    ODHDashboard.Maybe Wait For Dashboard Loading Spinner Page
     Wait Until Page Contains Element    xpath://button[contains(span/text(), 'Pipeline server actions')]
-    Click Element    //button[contains(span/text(), 'Pipeline server actions')]
+    Wait Until Element Is Enabled       xpath://button[contains(span/text(), 'Pipeline server actions')]
+    Click Element                       xpath://button[contains(span/text(), 'Pipeline server actions')]
     Wait Until Page Contains Element    xpath://li[contains(a/text(), 'Delete pipeline server')]
     Click Element    //li[contains(a/text(), 'Delete pipeline server')]
     Handle Deletion Confirmation Modal    ${data_science_project_name} pipeline server    pipeline server
-    Wait Until Page Contains Element    xpath://h3[text()="Enable pipelines"]    timeout=120s
-    FOR  ${index}  IN RANGE  0  30
-        ${pod_count}    Run    oc get pods -n ${data_science_project_name} -l component=data-science-pipelines | wc -l
-        IF  ${pod_count}==0  BREAK
-        Sleep  1s
-    END
-    Should Be True    ${pod_count} == 0    Pods weren't removed
+    Wait Until Page Contains     text=Configure pipeline server    timeout=120s
+    Pipelines.Wait Until Pipeline Server Is Deleted
 
 Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
     [Documentation]    Verify me message "Error displaying Pipelines" after creating pipeline server

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -70,13 +70,18 @@ Select Data Connection
     Wait Until Page Contains Element    xpath://button//*[text()="${dc_name}"]
     Click Element    xpath://button//*[text()="${dc_name}"]
 
+Wait Until Pipeline Is Not Listed
+    [Documentation]    Waits until pipeline is no longer listed in the pipelines table
+    [Arguments]    ${pipeline_name}    ${timeout}=60s
+    Maybe Wait For Dashboard Loading Spinner Page
+    ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    Wait Until Page Does Not Contain Element    ${PIPELINES_TABLE_XP}    timeout=${timeout}
+
 Import Pipeline
     [Documentation]    Import a pipeline definition from DS Project details page.
     ...                It expects to receive the relative path starting from ods_ci/
     [Arguments]    ${name}    ${filepath}    ${project_title}    ${description}=${NONE}    ${press_cancel}=${FALSE}
     Projects.Move To Tab    Pipelines
-    Wait Until Element Is Enabled       ${PIPELINES_IMPORT_BTN_XP}  timeout=120
-    Element Should Be Enabled    ${PIPELINES_IMPORT_BTN_XP}
     Click Button    ${PIPELINES_IMPORT_BTN_XP}
     Wait Until Generic Modal Appears
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
@@ -99,7 +104,7 @@ Create Pipeline Run    # robocop: disable
     ...            ${trigger_type}=Periodic    ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
     ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}    ${press_cancel}=${FALSE}    &{model_param}
     Projects.Move To Tab    Pipelines
-    Pipelines.Click Action From Actions Menu    pipeline_name=${pipeline_name}    action=Create run
+    Pipelines.Click Action From Pipeline Actions Menu    pipeline_name=${pipeline_name}    action=Create run
     Wait For RHODS Dashboard To Load    expected_page=Create run
     ...    wait_for_cards=${FALSE}
     Fill In Run Creation Form    name=${name}    pipeline_name=${pipeline_name}
@@ -118,12 +123,52 @@ Create Pipeline Run    # robocop: disable
     END
     RETURN    ${workflow_name}
 
-# robocop: disable=too-many-calls-in-keyword,line-too-long
-Click Action From Actions Menu
-    [Documentation]    Click an action from Actions menu (3-dots menu on the right)
+Expand Pipeline Details
+    [Documentation]    Expands a pipeline row in the dashboard UI
+    [Arguments]    ${pipeline_name}
+
+    ${pipeline_row_xp}=                 Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    ${pipeline_details_xp}=             Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Details"]
+    ${expanded_pipeline_details_xp}=    Set Variable    ${pipeline_row_xp}/td/button[@aria-expanded="true"]
+
+    ${is_expanded}=  Run Keyword And Return Status
+    ...  Page Should Contain Element  xpath:${expanded_pipeline_details_xp}
+    IF  ${is_expanded}==False
+        Click Button  xpath:${pipeline_details_xp}
+    END
+
+Collapse Pipeline Details
+    [Documentation]    Collapses a pipeline row in the dashboard UI
+    [Arguments]    ${pipeline_name}
+    ${pipeline_row_xp}=                 Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    ${pipeline_details_xp}=             Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Details"]
+    ${expanded_pipeline_details_xp}=    Set Variable    ${pipeline_row_xp}/td/button[@aria-expanded="true"]
+
+    ${is_expanded}=  Run Keyword And Return Status
+    ...  Page Should Contain Element  xpath:${expanded_pipeline_details_xp}
+    IF  ${is_expanded}==True
+        Click Button  xpath:${pipeline_details_xp}
+    END
+
+# robocop: line-too-long
+Click Action From Pipeline Actions Menu
+    [Documentation]    Click an action from Pipeline Actions menu (3-dots menu on the right)
     [Arguments]    ${pipeline_name}    ${action}
 
-    ${pipeline_row_xp}=    Set Variable    //*[@data-testid="table-row-title-${pipeline_name}"]/../..
+    ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    ${kebab_xp}=           Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Kebab toggle"]
+    ${kebap_action_xp}=    Set Variable    ${pipeline_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
+    Wait Until Page Contains Element    ${kebab_xp}
+    Click Element                       ${kebab_xp}
+    Wait Until Page Contains Element    ${kebap_action_xp}
+    Click Element                       ${kebap_action_xp}
+
+# robocop: line-too-long
+Click Action From Pipeline Version Actions Menu
+    [Documentation]    Click an action from Pipeline Version Actions menu (3-dots menu on the right)
+    [Arguments]    ${pipeline_version_name_contains}    ${action}
+
+    ${pipeline_row_xp}=    Set Variable    (//*[contains(@data-testid,"table-row-title-${pipeline_version_name_contains}")])[2]/../..
     ${kebab_xp}=           Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Kebab toggle"]
     ${kebap_action_xp}=    Set Variable    ${pipeline_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
     Wait Until Page Contains Element    ${kebab_xp}
@@ -314,6 +359,15 @@ Wait Until Pipeline Server Is Deployed
     [Arguments]    ${project_title}
     Wait Until Keyword Succeeds    10 times    10s
     ...    Verify Pipeline Server Deployments    project_title=${project_title}
+
+Wait Until Pipeline Server Is Deleted
+    [Documentation]    Waits until all pipeline server pods are deleted
+
+    FOR  ${index}  IN RANGE  0  30
+        ${pod_count}    Run    oc get pods -n ${data_science_project_name} -l component=data-science-pipelines | wc -l
+        IF  ${pod_count}==0  BREAK
+        Sleep  1s
+    END
 
 # TODO: we need to replace this keyword for a similar one checking in Data Science Pipelines > Runs
 #Verify Successful Pipeline Run Via Project UI

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -217,21 +217,21 @@ Pipeline Should Be Listed
     [Arguments]     ${pipeline_name}    ${pipeline_description}=${EMPTY}
 
     Projects.Move To Tab    Pipelines
-    ${pipeline_row_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
-    Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_row_xp}
+    ${pipeline_title_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_title_xp}
 
     IF    "${pipeline_description}" != "${EMPTY}"
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
-        ...        ${pipeline_row_xp}/following-sibling::*[p[text()="${pipeline_description}"]]
+        ...        ${pipeline_title_xp}/following-sibling::*[p[text()="${pipeline_description}"]]
     END
 
 Pipeline Should Not Be Listed
     [Documentation]    Verifies a pipeline not listed in Data Science Project > Pipelines
     [Arguments]     ${pipeline_name}
     Projects.Move To Tab    Pipelines
-    ${pipeline_row_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
-    Run Keyword And Continue On Failure    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}
+    ${pipeline_title_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]
+    Run Keyword And Continue On Failure    Wait Until Page Does Not Contain Element    ${pipeline_title_xp}
 
 Pipeline Last Run Should Be
     [Documentation]    Checks the pipeline last run which is reported is the expected one

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -1,3 +1,4 @@
+# robocop: off=line-too-long,unnecessary-string-conversion,file-too-long,too-many-arguments,too-many-calls-in-keyword
 *** Settings ***
 Documentation    Collection of keywords to interact with DS Pipelines
 Resource       Projects.resource
@@ -16,8 +17,9 @@ ${RUN_TOPOLOGY_OUTPUT_BTN_XP}=        xpath://*[@data-testid="bottom-drawer-tab-
 ${RUN_TOPOLOGY_XP}=                   xpath://*[@data-test-id="topology"]
 ${PIPELINES_DISABLED_EXC_MARK}=       xpath=//*[@id="page-sidebar"]/div/nav/ul/li[3]/a/div/div[2]
 
+
 *** Keywords ***
-Create Pipeline Server
+Create Pipeline Server    # robocop: off=too-many-calls-in-keyword
     [Documentation]    Creates the DS Pipeline server from DS Project details page
     ...                It assumes the Data Connection is aleady created
     ...                and you wants to use defaul DB configurations [TEMPORARY]
@@ -65,6 +67,7 @@ Select Data Connection
     [Documentation]    Selects an existing data connection from the dropdown
     ...                in the modal for Pipeline Server creation
     [Arguments]    ${dc_name}
+    # robocop: off=line-too-long
     Wait Until Page Contains Element    xpath://div[@class="pf-v5-c-form__group"][.//label//*[text()="Access key"]]//div[@data-ouia-component-type="PF5/Dropdown"]
     Click Element                       xpath://div[@class="pf-v5-c-form__group"][.//label//*[text()="Access key"]]//div[@data-ouia-component-type="PF5/Dropdown"]
     Wait Until Page Contains Element    xpath://button//*[text()="${dc_name}"]
@@ -75,7 +78,7 @@ Wait Until Pipeline Is Not Listed
     [Arguments]    ${pipeline_name}    ${timeout}=60s
     Maybe Wait For Dashboard Loading Spinner Page
     ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
-    Wait Until Page Does Not Contain Element    ${PIPELINES_TABLE_XP}    timeout=${timeout}
+    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}    timeout=${timeout}
 
 Import Pipeline
     [Documentation]    Import a pipeline definition from DS Project details page.
@@ -86,7 +89,7 @@ Import Pipeline
     Wait Until Generic Modal Appears
     Run Keyword And Continue On Failure    Element Should Be Disabled    ${PIPELINES_IMPORT_BTN_FORM_XP}
     Fill In Pipeline Import Form    ${name}    ${filepath}    ${project_title}    ${description}
-    IF    ${press_cancel} == ${TRUE}
+    IF    ${press_cancel}
         Click Button    ${GENERIC_CANCEL_BTN_XP}
     ELSE
         Click Button    ${PIPELINES_IMPORT_BTN_FORM_XP}
@@ -94,14 +97,14 @@ Import Pipeline
     Wait Until Generic Modal Disappears
     Wait Until Project Is Open    project_title=${project_title}
 
-Create Pipeline Run    # robocop: disable
+Create Pipeline Run
     [Documentation]    Create a pipeline run from DS Project details page.
     ...                Note that the ${type} arguments can accept:
     ...                - immediate
     ...                - schedule -> this requires to insert additional arguments
     ...                TEMPORARILY SUPPORTING ONLY IMMEDIATE RUNS AND DEFAULT MODEL PARAMS
     [Arguments]    ${name}    ${pipeline_name}=${NONE}    ${run_type}=Immediate
-    ...            ${trigger_type}=Periodic    ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
+    ...            ${start_date}=${NONE}    ${start_time}=${NONE}    ${end_date}=${NONE}
     ...            ${end_time}=${NONE}    ${cron_expr}=${NONE}    ${press_cancel}=${FALSE}    &{model_param}
     Projects.Move To Tab    Pipelines
     Pipelines.Click Action From Pipeline Actions Menu    pipeline_name=${pipeline_name}    action=Create run
@@ -111,7 +114,7 @@ Create Pipeline Run    # robocop: disable
     ...    run_type=${run_type}    trigger_type=Periodic    start_date=${start_date}
     ...    start_time=${start_time}    end_date=${end_date}    end_time=${end_time}
     ...    cron_expr=${cron_expr}    &{model_param}
-    IF    ${press_cancel} == ${TRUE}
+    IF    ${press_cancel}
         Click Button    ${GENERIC_CANCEL_BTN_XP}
         Wait For RHODS Dashboard To Load    expected_page=Pipelines
         ...    wait_for_cards=${FALSE}
@@ -133,9 +136,7 @@ Expand Pipeline Details
 
     ${is_expanded}=  Run Keyword And Return Status
     ...  Page Should Contain Element  xpath:${expanded_pipeline_details_xp}
-    IF  ${is_expanded}==False
-        Click Button  xpath:${pipeline_details_xp}
-    END
+    IF  not ${is_expanded}    Click Button  xpath:${pipeline_details_xp}
 
 Collapse Pipeline Details
     [Documentation]    Collapses a pipeline row in the dashboard UI
@@ -146,15 +147,12 @@ Collapse Pipeline Details
 
     ${is_expanded}=  Run Keyword And Return Status
     ...  Page Should Contain Element  xpath:${expanded_pipeline_details_xp}
-    IF  ${is_expanded}==True
-        Click Button  xpath:${pipeline_details_xp}
-    END
+    IF  ${is_expanded}    Click Button  xpath:${pipeline_details_xp}
 
-# robocop: line-too-long
 Click Action From Pipeline Actions Menu
     [Documentation]    Click an action from Pipeline Actions menu (3-dots menu on the right)
     [Arguments]    ${pipeline_name}    ${action}
-
+    # robocop: off=line-too-long
     ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
     ${kebab_xp}=           Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Kebab toggle"]
     ${kebap_action_xp}=    Set Variable    ${pipeline_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
@@ -163,11 +161,10 @@ Click Action From Pipeline Actions Menu
     Wait Until Page Contains Element    ${kebap_action_xp}
     Click Element                       ${kebap_action_xp}
 
-# robocop: line-too-long
 Click Action From Pipeline Version Actions Menu
     [Documentation]    Click an action from Pipeline Version Actions menu (3-dots menu on the right)
     [Arguments]    ${pipeline_version_name_contains}    ${action}
-
+    # robocop: off=line-too-long
     ${pipeline_row_xp}=    Set Variable    (//*[contains(@data-testid,"table-row-title-${pipeline_version_name_contains}")])[2]/../..
     ${kebab_xp}=           Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Kebab toggle"]
     ${kebap_action_xp}=    Set Variable    ${pipeline_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
@@ -175,7 +172,6 @@ Click Action From Pipeline Version Actions Menu
     Click Element                       ${kebab_xp}
     Wait Until Page Contains Element    ${kebap_action_xp}
     Click Element                       ${kebap_action_xp}
-
 
 Click Action From Pipeline Run Actions Menu
     [Documentation]    In Data Science Pipelines > Runs, click an action from Actions menu (3-dots menu on the right)
@@ -189,13 +185,12 @@ Click Action From Pipeline Run Actions Menu
     Wait Until Page Contains Element    ${kebap_action_xp}
     Click Element                       ${kebap_action_xp}
 
-
 Pipeline Context Menu Should Be Working
     [Documentation]   Test Pipeline YAML context menu works with mouse right-click and with keyboard
     [Arguments]    ${pipeline_name}
     ${orig wait}=    SeleniumLibrary.Set Selenium Implicit Wait    10s
     Menu.Navigate To Page    Data Science Pipelines    Pipelines
-    Wait Until Element is Visible     //a[text()="${pipeline_name}"]          timeout=30s
+    Wait Until Element Is Visible     //a[text()="${pipeline_name}"]          timeout=30s
     Click Link      ${pipeline_name}
     Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Open Context Menu    //div[contains(@class, 'lines-content')]
@@ -209,7 +204,7 @@ Pipeline Yaml Should Be Readonly
     [Arguments]    ${pipeline_name}
     ${orig wait}=    SeleniumLibrary.Set Selenium Implicit Wait    10s
     Menu.Navigate To Page    Data Science Pipelines    Pipelines
-    Wait Until Element is Visible     //a[text()="${pipeline_name}"]          timeout=30s
+    Wait Until Element Is Visible     //a[text()="${pipeline_name}"]          timeout=30s
     Click Link      ${pipeline_name}
     Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Press Keys    //div[contains(@class, 'lines-content')]    cannot_enter_read_only
@@ -219,23 +214,24 @@ Pipeline Yaml Should Be Readonly
 
 Pipeline Should Be Listed
     [Documentation]    Verifies a pipeline is listed in Data Science Project > Pipelines
-    [Arguments]     ${pipeline_name}    ${pipeline_description}
-    Projects.Move To Tab    Pipelines
-    ${pipeline_name_xpath}=    Set Variable    //*[@data-testid="table-row-title-${pipeline_name}"]
-    Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_name_xpath}
+    [Arguments]     ${pipeline_name}    ${pipeline_description}=${EMPTY}
 
-    IF    "${pipeline_description}" != ${NONE}
+    Projects.Move To Tab    Pipelines
+    ${pipeline_row_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_row_xp}
+
+    IF    "${pipeline_description}" != ${EMPTY}
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
-        ...        ${pipeline_name_xpath}/following-sibling::*[p[text()="${pipeline_description}"]]
+        ...        ${pipeline_row_xp}/following-sibling::*[p[text()="${pipeline_description}"]]
     END
 
 Pipeline Should Not Be Listed
     [Documentation]    Verifies a pipeline not listed in Data Science Project > Pipelines
-    [Arguments]     ${pipeline_name}    ${pipeline_description}
+    [Arguments]     ${pipeline_name}
     Projects.Move To Tab    Pipelines
-    ${pipeline_name_xpath}=    Set Variable    //*[@data-testid="table-row-title-${pipeline_name}"]
-    Run Keyword And Continue On Failure    Wait Until Page Does Not Contain Element    ${pipeline_name_xpath}
+    ${pipeline_row_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
+    Run Keyword And Continue On Failure    Wait Until Page Does Not Contain Element    ${pipeline_row_xp}
 
 Pipeline Last Run Should Be
     [Documentation]    Checks the pipeline last run which is reported is the expected one
@@ -352,7 +348,6 @@ Verify Pipeline Server Deployments    # robocop: disable
     ${containerNames}=  Create List  mariadb
     Verify Deployment    ${mariadb}  1  1  ${containerNames}
 
-
 Wait Until Pipeline Server Is Deployed
     [Documentation]    Waits until all the expected pods of the pipeline server
     ...                are running
@@ -363,14 +358,15 @@ Wait Until Pipeline Server Is Deployed
 Wait Until Pipeline Server Is Deleted
     [Documentation]    Waits until all pipeline server pods are deleted
     [Arguments]    ${project_title}
-    FOR  ${index}  IN RANGE  0  30
-        ${pod_count}    Run    oc get pods -n ${project_title} -l component=data-science-pipelines | wc -l
+    # robocop: off=expression-can-be-simplified
+    FOR  ${_}  IN RANGE  0  30
+        ${pod_count}=    Run    oc get pods -n ${project_title} -l component=data-science-pipelines | wc -l
         IF  ${pod_count}==0  BREAK
         Sleep  1s
     END
 
 # TODO: we need to replace this keyword for a similar one checking in Data Science Pipelines > Runs
-#Verify Successful Pipeline Run Via Project UI
+# Verify Successful Pipeline Run Via Project UI
 #    [Documentation]    Validates that a given pipeline run in a given pipeline is in successful end state
 #    ...    In the DS Project view of a given project
 #    [Arguments]    ${pipeline_run_name}    ${pipeline_name}    ${project_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -220,7 +220,7 @@ Pipeline Should Be Listed
     ${pipeline_row_xp}=    Set Variable      (//*[@data-testid="table-row-title-${pipeline_name}"])[1]/../..
     Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_row_xp}
 
-    IF    "${pipeline_description}" != ${EMPTY}
+    IF    "${pipeline_description}" != "${EMPTY}"
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
         ...        ${pipeline_row_xp}/following-sibling::*[p[text()="${pipeline_description}"]]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -362,9 +362,9 @@ Wait Until Pipeline Server Is Deployed
 
 Wait Until Pipeline Server Is Deleted
     [Documentation]    Waits until all pipeline server pods are deleted
-
+    [Arguments]    ${project_title}
     FOR  ${index}  IN RANGE  0  30
-        ${pod_count}    Run    oc get pods -n ${data_science_project_name} -l component=data-science-pipelines | wc -l
+        ${pod_count}    Run    oc get pods -n ${project_title} -l component=data-science-pipelines | wc -l
         IF  ${pod_count}==0  BREAK
         Sleep  1s
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -406,6 +406,7 @@ Move To Tab
     [Arguments]    ${tab_title}
     Click Element    xpath://span[text()="${tab_title}"]
     Sleep    1s    reason=The tab page needs to load content according to user permissions
+    Maybe Wait For Dashboard Loading Spinner Page
 
 Create Data Science Project If Not Exists
     [Documentation]    If the given ${project_title} DS Project does not exist, it creates one.

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/433__data-science-pipelines-general.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/433__data-science-pipelines-general.robot
@@ -69,12 +69,15 @@ Create A Pipeline Server And Wait For Dsp Route
     ...    browser_alias=${user}-session
     Remove Pipeline Project    ${project}
     Create Data Science Project    title=${project}    description=
+    Projects.Move To Tab    Data connections
     Create S3 Data Connection    project_title=${project}    dc_name=${project}-dc
     ...                          aws_access_key=${S3.AWS_ACCESS_KEY_ID}
     ...                          aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...                          aws_s3_endpoint=${S3.AWS_DEFAULT_ENDPOINT}    aws_region=${S3.AWS_DEFAULT_REGION}
     ...                          aws_bucket_name=${S3_BUCKET}
-    Reload Page
     Create Pipeline Server    dc_name=${project}-dc    project_title=${project}
+    Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
+    Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
+
     ${status}    Login And Wait Dsp Route    ${user}    ${password}    ${project}
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/433__data-science-pipelines-general.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/433__data-science-pipelines-general.robot
@@ -76,8 +76,6 @@ Create A Pipeline Server And Wait For Dsp Route
     ...                          aws_s3_endpoint=${S3.AWS_DEFAULT_ENDPOINT}    aws_region=${S3.AWS_DEFAULT_REGION}
     ...                          aws_bucket_name=${S3_BUCKET}
     Create Pipeline Server    dc_name=${project}-dc    project_title=${project}
-    Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
-    Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
-
+    Wait Until Pipeline Server Is Deployed    project_title=${project}
     ${status}    Login And Wait Dsp Route    ${user}    ${password}    ${project}
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -23,15 +23,19 @@ ${PIPELINE_TEST_RUN_BASENAME}=    ${PIPELINE_TEST_BASENAME}-run
 
 
 *** Test Cases ***
-Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Page    # robocop: disable
+# robocop: disable:too-long-test-case
+Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Page
     [Documentation]    Verifies user are able to create and execute a DS Pipeline leveraging on
     ...                DS Project UI
     [Tags]    Smoke
     ...       ODS-2206    ODS-2226    ODS-2633
-    Create Pipeline Server    dc_name=${DC_NAME}
-    ...    project_title=${PRJ_TITLE}
-    Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
+
+    Open Data Science Project Details Page    ${PRJ_TITLE}
+
+    Create Pipeline Server    dc_name=${DC_NAME}    project_title=${PRJ_TITLE}
     Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
+    Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
+
     # Import pipeline but cancel dialog
     Import Pipeline    name=${PIPELINE_TEST_NAME}
     ...    description=${PIPELINE_TEST_DESC}
@@ -46,12 +50,14 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    project_title=${PRJ_TITLE}
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${FALSE}
+
     ## TODO: Fix these verifications
     ##Pipeline Context Menu Should Be Working    pipeline_name=${PIPELINE_TEST_NAME}
     ##Pipeline Yaml Should Be Readonly    pipeline_name=${PIPELINE_TEST_NAME}
-    Open Data Science Project Details Page    ${PRJ_TITLE}    tab_id=pipelines-projects
+
     Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
     ...    pipeline_description=${PIPELINE_TEST_DESC}
+
 #    # Create run but cancel dialog
     ${workflow_name}=    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}
     ...    pipeline_name=${PIPELINE_TEST_NAME}    run_type=Immediate
@@ -61,45 +67,19 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ${workflow_name}=    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}
     ...    pipeline_name=${PIPELINE_TEST_NAME}     run_type=Immediate
     Verify Pipeline Run Is Completed    ${PIPELINE_TEST_RUN_BASENAME}
-#    FIXME: fix pipeline logs checking
+
+#    TODO: fix pipeline logs checking
 #    ${data_prep_log}=    Get Pipeline Run Step Log    data-prep
 #    # deterministic: "Initial Dataset:" came from a print inside the python code.
 #    Should Contain    ${data_prep_log}    Initial Dataset:
-    # FIXME
+
+#   TODO: fix duplicated runs and archival testing
 #   Verify Data Science Parameter From A Duplicated Run Are The Same From The Compiled File
 #   ODHDataSciencePipelines.Archive Pipeline Run       ${PIPELINE_TEST_RUN_BASENAME}    ${PIPELINE_TEST_NAME}
-#   ODHDataSciencePipelines.Delete Pipeline           ${PIPELINE_TEST_NAME}
-#   ODHDataSciencePipelines.Delete Pipeline Server    ${PRJ_TITLE}
-    [Teardown]    Delete Data Science Project         ${PRJ_TITLE}
 
-Verify Pipeline Metadata Pods Are Not Deployed When Running Pipelines
-    [Documentation]    Verifies that metadata pods are not created when running a data science pipeline,
-    ...         as this feature is currently disabled.
-    [Tags]    Sanity
-    ...       Tier1
-    Open Data Science Project Details Page    project_title=${PRJ_TITLE}    tab_id=pipelines-projects
-    Create Pipeline Server    dc_name=${DC_NAME}
-    ...    project_title=${PRJ_TITLE}
-    Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
-    Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
-    Import Pipeline    name=${PIPELINE_TEST_NAME}
-    ...    description=${PIPELINE_TEST_DESC}
-    ...    project_title=${PRJ_TITLE}
-    ...    filepath=${PIPELINE_TEST_FILEPATH}
-    Pipeline Should Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
-    ...    pipeline_description=${PIPELINE_TEST_DESC}
-    ${workflow_name}=    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}
-    ...    pipeline_name=${PIPELINE_TEST_NAME}    run_type=Immediate
-    ## TODO: fix keywords checking job status to use Pipelines > Jobs
-    ## instead of the Projec Details Page
-    SeleniumLibrary.Wait Until Page Contains       Running     timeout=10s
-    SeleniumLibrary.Wait Until Page Contains       Completed   timeout=10m
-    @{pods} =    Oc Get    kind=Pod    namespace=${PRJ_TITLE}
-    FOR    ${pod}    IN    @{pods}
-        Log    ${pod['metadata']['name']}
-        Should Not Contain    ${pod['metadata']['name']}    ds-pipeline-metadata
-    END
-    [Teardown]    Delete Data Science Project    ${PRJ_TITLE}
+    ODHDataSciencePipelines.Delete Pipeline           ${PIPELINE_TEST_NAME}
+    ODHDataSciencePipelines.Delete Pipeline Server    ${PRJ_TITLE}
+    [Teardown]    Delete Data Science Project         ${PRJ_TITLE}
 
 *** Keywords ***
 Pipelines Suite Setup    # robocop: disable
@@ -110,6 +90,7 @@ Pipelines Suite Setup    # robocop: disable
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}
     ...    ocp_user_auth_type=${TEST_USER_3.AUTH_TYPE}
+
     Create Data Science Project    title=${PRJ_TITLE}
     ...    description=${PRJ_DESCRIPTION}
     Projects.Move To Tab    Data connections
@@ -124,12 +105,13 @@ Pipelines Suite Teardown
     Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
-Verify Pipeline Run Deployment Is Successful    # robocop: disable
+# robocop: disable:too-many-calls-in-keyword
+Verify DSPv1 Pipeline Run Deployment Is Successful
     [Documentation]    Verifies the correct deployment of the test pipeline run in the rhods namespace.
     ...                It checks all the expected pods for the "iris" test pipeline run used in the TC.
     [Arguments]    ${project_title}    ${workflow_name}
     ${namespace}=    Get Openshift Namespace From Data Science Project
-    ...    project_title=${PRJ_TITLE}
+    ...    project_title=${project_title}
     @{data_prep}=  Oc Get    kind=Pod    namespace=${namespace}
     ...    label_selector=tekton.dev/taskRun=${workflow_name}-data-prep
     ${containerNames}=  Create List    step-main    step-output-taskrun-name

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -18,7 +18,7 @@ ${PIPELINE_TEST_NAME}=    ${PIPELINE_TEST_BASENAME}-${TEST_USER_3.USERNAME}
 ${DC_NAME}=    ds-pipeline-conn
 ${PIPELINE_TEST_BASENAME}=    iris
 ${PIPELINE_TEST_DESC}=    test pipeline definition
-${PIPELINE_TEST_FILEPATH}=    ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline.yaml
+${PIPELINE_TEST_FILEPATH}=    ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_compiled.yaml
 ${PIPELINE_TEST_RUN_BASENAME}=    ${PIPELINE_TEST_BASENAME}-run
 
 
@@ -56,7 +56,6 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ${workflow_name}=    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}
     ...    pipeline_name=${PIPELINE_TEST_NAME}    run_type=Immediate
     ...    press_cancel=${TRUE}
-    # FIXME: remove workaround for hardcoded iris-pipeline parameters (related to RHOAIENG-4738)
     # Create run
     Open Data Science Project Details Page    ${PRJ_TITLE}    tab_id=pipelines-projects
     ${workflow_name}=    Create Pipeline Run    name=${PIPELINE_TEST_RUN_BASENAME}

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/434__data-science-pipelines-ui.robot
@@ -43,7 +43,7 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    filepath=${PIPELINE_TEST_FILEPATH}
     ...    press_cancel=${TRUE}
     Pipeline Should Not Be Listed    pipeline_name=${PIPELINE_TEST_NAME}
-    ...    pipeline_description=${PIPELINE_TEST_DESC}
+
     # Import pipeline
     Import Pipeline    name=${PIPELINE_TEST_NAME}
     ...    description=${PIPELINE_TEST_DESC}


### PR DESCRIPTION
- Fixes some errors in Pipelines UI tests for DSPv2  (there are still some TODOs and FIXME to be fixed in follow-up PRs)
- Modifies base image for iris-pipeline.py in order to work on disconnected clusters
- Adds some example pipelines for DSPv1 and DSPv2
- Tested successfully in rhods-ci-pr-test/2682 (failing tests are not related to the PR changes)
