### PR TITLE
Speed-up execution of keyword "Is RHODS Self-Managed" in local

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -65,7 +65,7 @@ Is RHODS Self-Managed
     ...                 in the cluster (e.g., usually on OSD, ROSA).
     ...                 Returns ${TRUE} if RHODS Self-Managed is installed or if PRODUCT=ODH
     IF  "${PRODUCT}" == "ODH"  RETURN     ${TRUE}
-    ${rc} =    Run And Return Rc    oc get catalogsource addon-managed-odh-catalog -n ${OPERATOR_NAMESPACE}
+    ${rc}=    Run And Return Rc    oc get catalogsource addon-managed-odh-catalog -n ${OPERATOR_NAMESPACE}
     Run Keyword And Return    Run Keyword And Return Status      Should Not Be Equal As Numbers    ${rc}    ${0}
 
 Get MachineSets

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -65,11 +65,8 @@ Is RHODS Self-Managed
     ...                 in the cluster (e.g., usually on OSD, ROSA).
     ...                 Returns ${TRUE} if RHODS Self-Managed is installed or if PRODUCT=ODH
     IF  "${PRODUCT}" == "ODH"  RETURN     ${TRUE}
-    ${is_managed} =    Run Keyword And Return Status    OpenshiftLibrary.Oc Get
-    ...                                                      kind=CatalogSource
-    ...                                                      name=addon-managed-odh-catalog
-    ...                                                      namespace=${OPERATOR_NAMESPACE}
-    Run Keyword And Return    Evaluate    not ${is_managed}
+    ${rc} =    Run And Return Rc    oc get catalogsource addon-managed-odh-catalog -n ${OPERATOR_NAMESPACE}
+    Run Keyword And Return    Run Keyword And Return Status      Should Not Be Equal As Numbers    ${rc}    ${0}
 
 Get MachineSets
     [Documentation]    Returns a list of machinesets names
@@ -223,7 +220,7 @@ Verify Pod Logs Do Not Contain
     ${match_list} 	 Get Regexp Matches   ${pod_logs}     ${regex_pattern}
     ${entry_msg}      Remove Duplicates      ${match_list}
     ${length}         Get Length   ${entry_msg}
-    IF   ${length} != ${0}    FAIL    Pod ${pod_name} logs should not contain regexp ${regex_pattern}. Matching log entry: ${entry_msg} 
+    IF   ${length} != ${0}    FAIL    Pod ${pod_name} logs should not contain regexp ${regex_pattern}. Matching log entry: ${entry_msg}
     ...    ELSE    Log    message=Pod ${pod_name} logs does not contain regexp ${regex_pattern}    level=INFO
 
 Is Resource Present

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -62,8 +62,11 @@ Verify Notebook CR Is Running
 
 Is RHODS Self-Managed
     [Documentation]     Returns ${FALSE} if RHODS Managed (i.e., Cloud version) is installed
-    ...                 in the cluster (e.g., usually on OSD, ROSA).
-    ...                 Returns ${TRUE} if RHODS Self-Managed is installed or if PRODUCT=ODH
+    ...    in the cluster (e.g., usually on OSD, ROSA).
+    ...    Returns ${TRUE} if RHODS Self-Managed is installed or if PRODUCT=ODH
+    ...
+    ...    Note: this keyword is not using OpenShift library to speed up its execution on local.
+    ...    You'll find more info at https://github.com/red-hat-data-services/ods-ci/pull/1366
     IF  "${PRODUCT}" == "ODH"  RETURN     ${TRUE}
     ${rc}=    Run And Return Rc    oc get catalogsource addon-managed-odh-catalog -n ${OPERATOR_NAMESPACE}
     Run Keyword And Return    Run Keyword And Return Status      Should Not Be Equal As Numbers    ${rc}    ${0}


### PR DESCRIPTION
The keyword `RHOSi Setup` calls keyword `Is RHODS Self-Managed`, which is using the Robot Framework OpenShiftLibrary to perform `Oc Get ...` 

The problem is that the OpenShiftLibrary library takes more than 10s to load for the first time, slowing down development in local. 

This PR modifies the `Is RHODS Self-Managed` keyword not to use the OpenShift Library in order to speed up execution.

Tested successfully in local and rhods-ci-pr-test/2683

Original:
![speed-if-rhods-is-self-managed-original-managed](https://github.com/red-hat-data-services/ods-ci/assets/66894/149c993d-580b-4ec0-b448-1c7877adb748)

With this PR:
![speed-if-rhods-is-self-managed-updated-managed](https://github.com/red-hat-data-services/ods-ci/assets/66894/a8456433-2b41-4c6a-baa5-31bce912cc6e)

