### PR TITLE
Fix required xpaths for the selection of the model server template

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -2,6 +2,7 @@
 Documentation    Collection of keywords to interact with Model Servers
 Resource       ../../../../Page/Components/Components.resource
 Resource       ../../../../Common.robot
+Resource       ../ODHModelServing.resource
 Resource       Projects.resource
 
 
@@ -164,13 +165,6 @@ Verify Displayed GPU Count In Single Model Serving
     ${current_accs}=    SeleniumLibrary.Get Text
     ...    xpath://td[@data-label="Name"]/div[text()="${model_name}"]/../../../tr[last()]//span[.="Number of accelerators"]/../../dd/div  #robocop: disable
     Should Match    ${current_accs}    ${no_gpus}
-
-Set Model Server Runtime
-    [Documentation]    Selects a given Runtime for the model server
-    [Arguments]    ${runtime}
-    Open Serving runtime Options Menu  # robocop: disable
-    Click Element    xpath://div[@id="serving-runtime-template-selection"]//li//*[text()="${runtime}"]
-    # TODO: Implement Custom
 
 Set Model Server Name
     [Documentation]    Sets a custom name for the model server

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -76,7 +76,7 @@ Serve Model
     Select Project    ${project_name}
     Set Model Name    ${model_name}
     Select Model Server    ${model_server}
-    IF    "${serving_runtime}" != "${NONE}"    Select Kserve Serving Runtime    ${serving_runtime}
+    IF    "${serving_runtime}" != "${NONE}"    Set Model Server Runtime    ${serving_runtime}
     SeleniumLibrary.Wait Until Page Contains Element    xpath://span[.="Model framework (name - version)"]
     Select Framework    ${framework}
     IF    ${existing_data_connection}==${TRUE}
@@ -393,7 +393,7 @@ Deploy Kserve Model Via UI  #robocop: disable
     Click Button    ${DEPLOY_MODEL_BTN}
     Wait Until Page Contains Element    xpath=${KSERVE_MODAL_HEADER}
     Set Model Name   ${model_name}
-    Select Kserve Serving Runtime    ${serving_runtime}
+    Set Model Server Runtime    ${serving_runtime}
     Select Framework    ${model_framework}
     Set Replicas Number With Buttons    ${replicas}
     Set Server Size    ${size}
@@ -411,8 +411,9 @@ Deploy Kserve Model Via UI  #robocop: disable
     Click Button    Deploy
     Wait Until Page Does Not Contain Element    xpath=${KSERVE_MODAL_HEADER}   timeout=60s
 
-Select Kserve Serving Runtime
-    [Documentation]    Opens the Runtime dropdown in the deploy modal for kserve models and select the given runtime
+Set Model Server Runtime
+    [Documentation]    Opens the Serving runtime dropdown in the deploy model modal window for models
+    ...    and select the given runtime
     [Arguments]    ${runtime}=Caikit
     Page Should Contain Element    ${KSERVE_RUNTIME_DROPDOWN}
     Click Element    ${KSERVE_RUNTIME_DROPDOWN}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -24,7 +24,7 @@ ${MS_TABLE_ENDPOINT_INPUT}=    ${MS_TABLE_ENDPOINT}//div[@class="pf-v5-c-clipboa
 ${MS_TABLE_STATUS_SUCCESS}=     //span[contains(@class,"pf-v5-c-icon__content")][contains(@class,"pf-m-success")]
 ${MS_TABLE_STATUS_FAILURE}=     //span[contains(@class,"pf-v5-c-icon__content")][contains(@class,"pf-m-danger")]
 ${KSERVE_MODAL_HEADER}=    //header[@class="pf-v5-c-modal-box__header"]/h1[.="Deploy model"]
-${KSERVE_RUNTIME_DROPDOWN}=    //span[.="Serving runtime"]/../../..//div[@id="serving-runtime-template-selection"]
+${KSERVE_RUNTIME_DROPDOWN}=    //button[@data-testid="serving-runtime-template-selection"]
 ${LLM_RESOURCES_DIRPATH}=    ods_ci/tests/Resources/Files/llm
 ${DEPLOY_MODEL_BTN}=    //button[contains(@data-testid,"deploy")]
 
@@ -415,8 +415,8 @@ Select Kserve Serving Runtime
     [Documentation]    Opens the Runtime dropdown in the deploy modal for kserve models and select the given runtime
     [Arguments]    ${runtime}=Caikit
     Page Should Contain Element    ${KSERVE_RUNTIME_DROPDOWN}
-    Click Element    ${KSERVE_RUNTIME_DROPDOWN}/button
-    Click Element    ${KSERVE_RUNTIME_DROPDOWN}/ul//span[contains(text(),"${runtime}")]
+    Click Element    ${KSERVE_RUNTIME_DROPDOWN}
+    Click Element    ${KSERVE_RUNTIME_DROPDOWN}/..//span[contains(text(),"${runtime}")]
 
 Get Kserve Inference Host Via UI
     [Documentation]    Fetches the host of the model's URL from the Data Science Project UI


### PR DESCRIPTION
This change is necessary for the latest RHOAI 2.9 preRC build.

---

Local check:

```
./ods_ci/run_robot_test.sh --extra-robot-args '-i ODS-2626 -i ODS-2519 -i ODS-2552 -i ODS-2555 -i ODS-2268' --open-report true
```

CI: `rhods-smoke/5113/`