### PR TITLE
fix: ODS-2276 and ODS-2279 issues

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -92,9 +92,9 @@ Select Model Serving Platform
     [Documentation]    Selects which model serving platform the serving runtime could be executed on
     [Arguments]    ${platform}="both"
     ${platform_link_name}=    Get From Dictionary    ${PLATFORM_NAMES_MAPPING}    ${platform.lower()}
-    Click Element    xpath://div[@data-testid="custom-serving-runtime-selection"]//button
-    Wait Until Page Contains Element    xpath://a[text()="${platform_link_name}"]
-    Click Link    ${platform_link_name}
+    Click Button    xpath://button[@data-testid="custom-serving-runtime-selection"]
+    Wait Until Page Contains Element    xpath://span[text()="${platform_link_name}"]
+    Click Element    xpath://span[text()="${platform_link_name}"]
 
 Select Runtime API Protocol
     [Documentation]    Selects which API protocol for the runtime


### PR DESCRIPTION
During the nightlies exectuion (e.g.: autotrigger-smoke/127) the tests 

- ODS-2276: Verify RHODS Admins Can Import A Custom Serving Runtime Template By Uploading A YAML file
- ODS-2279: Verify RHODS Admins Can Delete A Custom Serving Runtime Template

were failing due some xpath changes

Test results: 
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/122b82eb-00bb-4b02-a41c-5d3c90c3b5db)
