### PR TITLE
Add self-signed CA bundle support for kserve grpc/http requests

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -301,10 +301,21 @@ Query Model Multiple Times
     ...                  - streaming: it returns the streamed generated response (i.e., one word per time)
     ...                In order to use a self-signed certificate when performing the request, pass the CA bundle file
     ...                path as the ${cert} argument - defaults to ${False}, i.e. insecure request.
-    [Arguments]    ${model_name}    ${namespace}    ${runtime}=caikit-tgis-runtime    ${isvc_name}=${model_name}
-    ...            ${inference_type}=all-tokens    ${n_times}=10    ${query_idx}=0    ${validate_response}=${TRUE}
-    ...            ${string_check_only}=${FALSE}    ${protocol}=grpc    ${port_forwarding}=${FALSE}    ${port}=443
-    ...            ${body_params}=&{EMPTY}    ${cert}=${False}    &{args}
+    [Arguments]    ${model_name}
+    ...            ${namespace}
+    ...            ${runtime}=caikit-tgis-runtime
+    ...            ${isvc_name}=${model_name}
+    ...            ${inference_type}=all-tokens
+    ...            ${n_times}=10
+    ...            ${query_idx}=0
+    ...            ${validate_response}=${TRUE}
+    ...            ${string_check_only}=${FALSE}
+    ...            ${protocol}=grpc
+    ...            ${port_forwarding}=${FALSE}
+    ...            ${port}=443
+    ...            ${body_params}=&{EMPTY}
+    ...            ${cert}=${False}
+    ...            &{args}
     IF    "${inference_type}" == "streaming"
         ${streamed_response}=    Set Variable    ${TRUE}
     ELSE
@@ -338,7 +349,7 @@ Query Model Multiple Times
             ...    endpoint=${endpoint}
             ...    json_body=${body}    json_header=${header}
             ...    insecure=${insecure}    plaintext=${plaintext}    skip_res_json=${skip_json_load_response}
-            ...    cabundle_file=${cert}    &{args}
+            ...    cert=${cert}    &{args}
          ELSE IF    "${protocol}" == "http"
             ${payload}=     ODHDashboardAPI.Prepare Payload     body=${body}    str_to_json=${TRUE}
             Log Dictionary    ${args}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -299,10 +299,12 @@ Query Model Multiple Times
     ...                ${inference_type} arguments accepts these 2 values for now:
     ...                  - all-tokens: it returns the entire generated response text
     ...                  - streaming: it returns the streamed generated response (i.e., one word per time)
+    ...                In order to use a self-signed certificate when performing the request, pass the CA bundle file
+    ...                path as the ${cert} argument - defaults to ${False}, i.e. insecure request.
     [Arguments]    ${model_name}    ${namespace}    ${runtime}=caikit-tgis-runtime    ${isvc_name}=${model_name}
     ...            ${inference_type}=all-tokens    ${n_times}=10    ${query_idx}=0    ${validate_response}=${TRUE}
     ...            ${string_check_only}=${FALSE}    ${protocol}=grpc    ${port_forwarding}=${FALSE}    ${port}=443
-    ...            ${body_params}=&{EMPTY}    &{args}
+    ...            ${body_params}=&{EMPTY}    ${cert}=${False}    &{args}
     IF    "${inference_type}" == "streaming"
         ${streamed_response}=    Set Variable    ${TRUE}
     ELSE
@@ -336,12 +338,12 @@ Query Model Multiple Times
             ...    endpoint=${endpoint}
             ...    json_body=${body}    json_header=${header}
             ...    insecure=${insecure}    plaintext=${plaintext}    skip_res_json=${skip_json_load_response}
-            ...    &{args}
+            ...    cabundle_file=${cert}    &{args}
          ELSE IF    "${protocol}" == "http"
             ${payload}=     ODHDashboardAPI.Prepare Payload     body=${body}    str_to_json=${TRUE}
             Log Dictionary    ${args}
             Set To Dictionary    ${args}    url=https://${host}:${port}/${endpoint}   expected_status=any
-            ...             headers=${header}   json=${payload}    verify=${False}
+            ...             headers=${header}   json=${payload}    verify=${cert}
             ${is_timeout}=    Run Keyword And Return Status    Dictionary Should Contain Key    ${args}    timeout
             IF    ${is_timeout} == ${FALSE}
                 Set To Dictionary    ${args}    timeout=10

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -212,13 +212,18 @@ Click Minus Button
 Query Model With GRPCURL
     [Arguments]    ${host}    ${port}    ${endpoint}    ${json_body}
     ...            ${json_header}=${NONE}    ${insecure}=${FALSE}    ${plaintext}=${FALSE}
-    ...            ${background}=${NONE}    ${skip_res_json}=${FALSE}    &{args}
+    ...            ${background}=${NONE}    ${skip_res_json}=${FALSE}    ${cabundle_file}=${False}    &{args}
     ${cmd}=    Set Variable    grpcurl -d ${json_body}
     IF    $json_header != None
         ${cmd}=    Catenate    ${cmd}    -H ${json_header}
     END
     IF    ${insecure} == ${TRUE}
         ${cmd}=    Catenate    ${cmd}    -insecure
+    ELSE  #-insecure and -cacert are incompatible with each other. Assuming we want either option always on.
+        IF    ${cabundle_file}==${False}
+            Log    The call will fail because you have not provided a valid CA bundle file
+        END
+        ${cmd}=    Catenate    ${cmd}    -cacert ${cabundle_file}
     END
     IF    ${plaintext} == ${TRUE}
         ${cmd}=    Catenate    ${cmd}    -plaintext

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -204,22 +204,30 @@ Click Minus Button
     Click Element    ${REPLICAS_MIN_BTN_XP}
 
 Query Model With GRPCURL
-    [Arguments]    ${host}    ${port}    ${endpoint}    ${json_body}
-    ...            ${json_header}=${NONE}    ${insecure}=${FALSE}    ${plaintext}=${FALSE}
-    ...            ${background}=${NONE}    ${skip_res_json}=${FALSE}    ${cabundle_file}=${False}    &{args}
+    [Arguments]    ${host}
+    ...            ${port}
+    ...            ${endpoint}
+    ...            ${json_body}
+    ...            ${json_header}=${NONE}
+    ...            ${insecure}=${FALSE}
+    ...            ${plaintext}=${FALSE}
+    ...            ${background}=${NONE}
+    ...            ${skip_res_json}=${FALSE}
+    ...            ${cert}=${False}
+    ...            &{args}
     ${cmd}=    Set Variable    grpcurl -d ${json_body}
     IF    $json_header != None
         ${cmd}=    Catenate    ${cmd}    -H ${json_header}
     END
-    IF    ${insecure} == ${TRUE}
+    IF    ${insecure}
         ${cmd}=    Catenate    ${cmd}    -insecure
-    ELSE  #-insecure and -cacert are incompatible with each other. Assuming we want either option always on.
-        IF    ${cabundle_file}==${False}
+    ELSE  # -insecure and -cacert are incompatible with each other. Assuming we want either option always on.
+        IF    ${cert}==${False}
             Log    The call will fail because you have not provided a valid CA bundle file
         END
-        ${cmd}=    Catenate    ${cmd}    -cacert ${cabundle_file}
+        ${cmd}=    Catenate    ${cmd}    -cacert ${cert}
     END
-    IF    ${plaintext} == ${TRUE}
+    IF    ${plaintext}
         ${cmd}=    Catenate    ${cmd}    -plaintext
     END
     # IF    "${proto_filepath}" != "${NONE}"


### PR DESCRIPTION
This PR adds support for passing self-signed (or anyway customized) CA bundles to Kserve GRPC and HTTP inference requests.
It is assumed that the request will either be insecure or have a valid CA bundle attached to it.

For GRPC requests, we use either the `-insecure` option or `-cacert` option (incompatible with each other). `-cacert` expects the file path to a valid CA Bundle.
For HTTP requests, we use the `verify` argument provided by the Requests library in Robot Framework - the argument accepts `True`/`False` (secure/insecure request) or a valid path to a CA bundle. 

Both options are abstracted into the `Query Model Multiple Times` keyword, which has a new argument `cert` which defaults to `False` (i.e. insecure requests for both GRPC and HTTP).  In order to validate the request, we need to pass a valid CA bundle file path as the `cert` argument.