### PR TITLE
Fix expected version of Jupyterhub-git package for 2024.1 images

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
@@ -19,7 +19,7 @@ Test Tags          JupyterHub
 &{package_versions}      # robocop: disable
 ${JupyterLab_Version}         v3.6
 ${Notebook_Version}           v6.5
-${JupyterLab-git_Version}     v0.42
+${JupyterLab-git_Version}     v0.44
 
 
 *** Test Cases ***


### PR DESCRIPTION
This is a change introduced in RHOAI 2.9

---

Tested locally:

![Screenshot from 2024-04-18 08-21-36](https://github.com/red-hat-data-services/ods-ci/assets/12250881/f172775f-bf6f-4530-905f-842f95004725)
