### PR TITLE
Rhoaieng 6358 restore custom ca bundle

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -136,7 +136,7 @@ Set Trusted CA Bundle Management State
     Should Be Equal    "${rc}"    "0"   msg=${output}
 
 Get Custom CA Bundle Value In DSCI
-    [Documentation]    Get Custdom CA Bundle Value
+    [Documentation]    Get DSCI Custdom CA Bundle Value
     [Arguments]    ${DSCI}    ${namespace}
     ${rc}   ${value}=    Run And Return Rc And Output
     ...    oc get DSCInitialization/${DSCI_NAME} -n ${namespace} -o 'jsonpath={.spec.trustedCABundle.customCABundle}'

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -96,6 +96,7 @@ Restore DSCI Trusted CA Bundle Settings
     Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}   ''    ${OPERATOR_NS}
     Set Trusted CA Bundle Management State    ${DSCI_NAME}    Managed    ${OPERATOR_NS}
     Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}    ${custsom_ca_value}    ${OPERATOR_NS}
+
 Is CA Bundle Value Present
     [Documentation]    Check if the ConfigtMap contains Custom CA Bundle value
     [Arguments]    ${config_map}    ${custom_ca_bundle_value}    ${namespace}        ${expected_result}
@@ -137,9 +138,9 @@ Set Trusted CA Bundle Management State
 
 Get Custom CA Bundle Value In DSCI
     [Documentation]    Get DSCI Custdom CA Bundle Value
-    [Arguments]    ${DSCI}    ${namespace}
+    [Arguments]    ${dsci}    ${namespace}
     ${rc}   ${value}=    Run And Return Rc And Output
-    ...    oc get DSCInitialization/${DSCI_NAME} -n ${namespace} -o 'jsonpath={.spec.trustedCABundle.customCABundle}'
+    ...    oc get DSCInitialization/${dsci} -n ${namespace} -o 'jsonpath={.spec.trustedCABundle.customCABundle}'
     Should Be Equal    "${rc}"    "0"   msg=${value}
 
     RETURN    ${value}

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/139__trusted_ca_bundles.robot
@@ -91,11 +91,10 @@ Suite Teardown
 
 Restore DSCI Trusted CA Bundle Settings
     [Documentation]    Restore DSCI Trusted CA Bundle settings to original tate
-    [Arguments]    ${custsom_ca_value}
+    [Arguments]    ${custom_ca_value}
 
-    Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}   ''    ${OPERATOR_NS}
     Set Trusted CA Bundle Management State    ${DSCI_NAME}    Managed    ${OPERATOR_NS}
-    Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}    ${custsom_ca_value}    ${OPERATOR_NS}
+    Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}    ${custom_ca_value}    ${OPERATOR_NS}
 
 Is CA Bundle Value Present
     [Documentation]    Check if the ConfigtMap contains Custom CA Bundle value


### PR DESCRIPTION
This fix will restore the original DSCi customCABundle to original value.

Verified fix by populating customCABundle with a CA prior to running the tests, and then ensuring that the CA was restored.