### PR TITLE
fix: DS Projects permission mgmt tests

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -248,7 +248,7 @@ ${username} Should Have Edit Access To ${project_title}
     Open Data Science Projects Home Page
     Reload Page If Project ${project_title} Is Not Listed
     Wait Until Project Is Listed    project_title=${project_title}
-    Open Data Science Project Details Page    ${project_title}    tab_id=permissions
+    Open Data Science Project Details Page    ${project_title}
     Permissions Tab Should Not Be Accessible
     # add checks on subsections
 


### PR DESCRIPTION
During the execution of the different QGs for 2.9 version, we've detected that some of the DS Project permission management tests were failing due to some modifications in the UI.
This PR fixes the following tests:

- ODS-2201: Verify User Can Make Their Owned DS Project Accessible To Other Users
- ODS-2202: Verify User Can Modify And Revoke Access To DS Projects From Other Users
- ODS-2208: Verify User Can Assign Access Permissions To User Groups

Test results:
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/d9fb7245-5723-4b11-8423-c8e798839520)
