### PR TITLE
Fix Verify Switcher to Masterhead test

### DIFF
--- a/ods_ci/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/ods_ci/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -40,14 +40,14 @@ Maybe Agree RH Terms and Conditions
   END
 
 Maybe Accept Cookie Policy
-  ${cookie_required}=  Run Keyword And Return Status  Page Should Contain  We use cookies on this site
+  ${cookie_required}=  Run Keyword And Return Status  Wait Until Page Contains Element
+  ...    xpath=//iframe[@title='TrustArc Cookie Consent Manager']  timeout=10
   IF    ${cookie_required} == True
     Select Frame    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
     Wait Until Page Contains Element    xpath=//a[contains(@class, 'required')]  timeout=10
     Click Link    xpath=//a[contains(@class, 'required')]
-    Wait Until Page Contains Element    xpath=//a[contains(@class, 'close')]  timeout=10
-    Click Link    xpath=//a[contains(@class, 'close')]
-    Wait Until Page Does Not Contain    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
+    Wait Until Page Does Not Contain Element    xpath=//iframe[@title='TrustArc Cookie Consent Manager']
+    Wait Until Page Does Not Contain    We use cookies on this site
     Unselect Frame
     Capture Page Screenshot  cookieaccepted.png
   END

--- a/ods_ci/tests/Resources/Page/HybridCloudConsole/OCM.robot
+++ b/ods_ci/tests/Resources/Page/HybridCloudConsole/OCM.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Resource        ../../Common.robot
+Resource        ./HCCLogin.robot
 
 Library         SeleniumLibrary
 
@@ -9,11 +10,12 @@ Wait Until OCM Cluster Page Is Loaded
     [Documentation]     wait until the OCM page loads for ${cluster_name}
     [Arguments]    ${cluster_name}
     Wait OCM Splash Page
-    Element Should Contain    //div[@class="pf-l-split__item"]/h1    ${cluster_name}
+    Element Should Contain    //div[@class="pf-v5-l-split__item"]/h1    ${cluster_name}
 
 Login To OCM
     [Documentation]    Login to the OpenShift Cluster Manager
-    Input Text    //div[@class="pf-v5-c-form__group"]/input    ${SSO.USERNAME}
+    Maybe Accept Cookie Policy
+    Input Text    //div[@class="pf-c-form__group"]/input    ${SSO.USERNAME}  # This is OCM page, so not PatternFly 5
     Click Button   //*[@id="login-show-step2"]
     Sleep   1s
     Input Text    //*[@id="password"]    ${SSO.PASSWORD}

--- a/ods_ci/tests/Tests/100__deploy/100__installation/101__installation.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/101__installation.robot
@@ -15,8 +15,8 @@ Suite Teardown   Installation Suite Teardown
 
 
 *** Variables ***
-${Stage_URL}    https://qaprodauth.console.redhat.com/openshift
-${Prod_URL}     https://console.redhat.com/openshift
+${STAGE_URL}    https://console.dev.redhat.com/openshift
+${PROD_URL}     https://console.redhat.com/openshift
 
 
 *** Test Cases ***
@@ -62,9 +62,9 @@ Decide OCM URL And Open Link
   [Documentation]   Decides OCM URL based on the OpenShift Console URL and open the URL.
   ${cluster_type}=  Fetch ODS Cluster Environment
   IF    "${cluster_type}" == "stage"
-        ${OCM_URL}=     Set Variable    ${Stage_URL}
+        ${OCM_URL}=     Set Variable    ${STAGE_URL}
   ELSE
-        ${OCM_URL}=     Set Variable    ${Prod_URL}
+        ${OCM_URL}=     Set Variable    ${PROD_URL}
   END
   Go To     ${OCM_URL}
 

--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -627,7 +627,7 @@ Check Application Switcher Links To Openshift Cluster Manager
     ${cluster_name}=    Get Cluster Name By Cluster ID    ${cluster_id}
     ${cluster_env}=    Fetch ODS Cluster Environment
     IF    "${cluster_env}" == "stage"
-        ${ocm_staging_link}=    Set Variable    https://qaprodauth.console.redhat.com/openshift/details/${cluster_id}
+        ${ocm_staging_link}=    Set Variable    https://console.dev.redhat.com/openshift/details/${cluster_id}
         Check HTTP Status Code    link_to_check=${ocm_staging_link}    verify_ssl=${False}
         Go To   ${ocm_staging_link}
     ELSE

--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -217,11 +217,16 @@ class OpenshiftClusterManager:
             sys.exit(1)
 
     def get_osd_cluster_id(self):
-        """Gets osd cluster ID"""
+        """Gets OSD cluster ID used by ocm"""
+
+        # "id": "2ans0g24pc4l4f08fcu6tdusf883avvu",              --- ID used by ocm tool - this is what we get
+        #                                                            (and also what we provide to make this function reflexive)
+        # "name": "mods-sa-mastr4",                              --- name of the cluster (we provide in self.cluster_name)
+        # "external_id": "feb5a50a-b9ce-40ad-99a7-69159f0ca957", --- ID of the cluster itself (we provide in self.cluster_name)
 
         if not self.cluster_id:
-            cmd = "ocm list clusters -p search=\"name = '{}' or id = '{}'\" --columns id --no-headers".format(
-                self.cluster_name, self.cluster_name
+            cmd = "ocm list clusters -p search=\"name = '{}' or id = '{}' or external_id = '{}'\" --columns id --no-headers".format(
+                self.cluster_name, self.cluster_name, self.cluster_name
             )
             cluster_id = execute_command(cmd)
             if cluster_id in [None, ""]:


### PR DESCRIPTION
After recent changes to how we handle the ocm functions, this test started to interrupt our test execution with the following error:

```
03:48:15  Suite Setup: Tests.Ods Dashboard.Ods Dashboard: Alerts should not be firing: ['Data Science Pipeline Application Unavailable (for:120, state:firing)', 'Data Science Pipeline APIServer Unavailable (for:120, state:firing)', 'Data Science Pipeline PersistenceAgent Unavailable (for:120, state:firing)', 'Data Science Pipeline ScheduledWorkflows Unavailable (for:120, state:firing)', 'User notebook pvc usage at 100% (for:120, state:firing)']
03:48:36  Verify Switcher to Masterhead :: Checks the link in switcher and a... [ ERROR ] Unable to retrieve cluster ID for cluster name feb5a50a-b9ce-40ad-99a7-69159f0ca957. EXITING
03:48:36  [ ERROR ] Execution stopped by user.
03:48:36  253
```

The test execution was interrupted completely after this error so we didn't have any test report to use. This change fixes this error and provides also other fixes to make this test pass:

![Screenshot from 2024-04-24 09-36-34](https://github.com/red-hat-data-services/ods-ci/assets/12250881/53cf31cd-ae13-4d27-a095-51947837b8ff)

Note: for some reason the test pass on my local machine but fails on our Jenkins CI, so there will be more check needed. Although, the failure is further in the test execution compared to current situation `rhoai/job/2.9/job/managed/job/stage/job/aws/job/rhods-tier2/8`.

I don't have more time to dig into it right now, so I propose to merge this as is so we don't see the execution interruption at least.