### PR TITLE
Update Serving Runtime images for API testing

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
+      image: quay.io/modh/text-generation-inference@sha256:18048121be7624d8cfe3f387e6de7ebb2e9376213f795d66cada26d8391229ca
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -23,7 +23,7 @@ spec:
       ## Note: cannot add readiness/liveness probes to this container because knative will refuse them.
       # multi-container probing will be available after https://github.com/knative/serving/pull/14853 is merged
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:444bca43c99bfc4b961c926f5f10c556488613912f5e333011e98b3407d76d00
+      image: quay.io/modh/caikit-tgis-serving@sha256:c3d4c06293a5fea59ed347c410f9c8472e500816079ab380fb3c376d09f4a926
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -10,7 +10,7 @@ spec:
       name: caikit
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
+      image: quay.io/modh/text-generation-inference@sha256:18048121be7624d8cfe3f387e6de7ebb2e9376213f795d66cada26d8391229ca
       command: ["text-generation-launcher"]
       args: ["--model-name=/mnt/models/artifacts/"]
       env:
@@ -21,7 +21,7 @@ spec:
       #     cpu: 8
       #     memory: 16Gi
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:444bca43c99bfc4b961c926f5f10c556488613912f5e333011e98b3407d76d00
+      image: quay.io/modh/caikit-tgis-serving@sha256:c3d4c06293a5fea59ed347c410f9c8472e500816079ab380fb3c376d09f4a926
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/tgis_servingruntime_grpc.yaml
@@ -9,7 +9,7 @@ spec:
       name: pytorch
   containers:
     - name: kserve-container
-      image: quay.io/modh/text-generation-inference@sha256:b87d83c65c9c5897d8a6881a160f5c65b9d7ba1d8a27bdc1ee229e60af654a9c
+      image: quay.io/modh/text-generation-inference@sha256:18048121be7624d8cfe3f387e6de7ebb2e9376213f795d66cada26d8391229ca
       command: ["text-generation-launcher"]
       args:
         - "--model-name=/mnt/models/"


### PR DESCRIPTION
With this PR, the Caikit+TGIS and TGIS runtime images will match to the latest rhoai-2.9 tags in quay and the images which are used in Dashboard UI

PR validation:
- reg test (caikit+tgis and tgis) subset of tests: `rhods-ci-pr-test/2731` - 1 failure in streaming response validation probably due to a new attribute added in the responde from Caikit runtime. Needs to be fix (maybe in a different PR). 1 failure in the teardown of canary test but it seems a timing issue, cluster looks ok.
-  TGIS basic model deployment tested offline: 
![image](https://github.com/red-hat-data-services/ods-ci/assets/88311595/0d6610fe-3934-4900-97f9-8ef27a82059a)
