### PR TITLE
[Fix] check for the CUDA version installed on image

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
@@ -8,7 +8,7 @@ Library     OperatingSystem
 Verify Installed CUDA Version
     [Documentation]  Checks the installed CUDA version
     [Arguments]  ${expected_version}
-    Run Cell And Check Output    !nvidia-smi | grep "CUDA Version:" | awk '{split($0,a); print a[9]}'
+    Run Cell And Check Output    !nvcc --version | grep "release" | sed "s/.*release \\\\(.*\\\\),.*/\\\\1/"
     ...    ${expected_version}
 
 Verify CUDA Is Not Installed

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-cuda-test.robot
@@ -13,7 +13,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         minimal-gpu
-${EXPECTED_CUDA_VERSION} =  12.4
+${EXPECTED_CUDA_VERSION} =  12.1
+${EXPECTED_CUDA_VERSION_N_1} =  11.8
 
 
 *** Test Cases ***
@@ -61,7 +62,7 @@ Verify Previous CUDA Notebook Image With GPU
     ...       ODS-2128
     [Setup]    N-1 CUDA Setup
     Spawn Notebook With Arguments    image=${NOTEBOOK_IMAGE}    size=Small    gpus=1    version=previous
-    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
+    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION_N_1}
     Verify PyTorch Can See GPU    install=True
     Verify Tensorflow Can See GPU    install=True
     ${nvcc_version} =  Run Cell And Get Output    input=!nvcc --version

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -15,7 +15,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         pytorch
-${EXPECTED_CUDA_VERSION} =  12.2
+${EXPECTED_CUDA_VERSION} =  12.1
+${EXPECTED_CUDA_VERSION_N_1} =  11.8
 
 
 *** Test Cases ***
@@ -87,7 +88,7 @@ Verify Previous PyTorch Notebook Image With GPU
     ...       ODS-2129
     [Setup]    N-1 PyTorch Setup
     Spawn Notebook With Arguments    image=${NOTEBOOK_IMAGE}    size=Small    gpus=1    version=previous
-    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
+    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION_N_1}
     Verify PyTorch Can See GPU
     Run Repo And Clean    https://github.com/lugi0/notebook-benchmarks    notebook-benchmarks/pytorch/fgsm_tutorial.ipynb
     [Teardown]    End Web Test

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -16,7 +16,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         tensorflow
-${EXPECTED_CUDA_VERSION} =  12.2
+${EXPECTED_CUDA_VERSION} =  12.1
+${EXPECTED_CUDA_VERSION_N_1} =  11.8
 
 
 *** Test Cases ***
@@ -85,7 +86,7 @@ Verify Previous Tensorflow Notebook Image With GPU
     ...       ODS-2130
     [Setup]    N-1 Tensorflow Setup
     Spawn Notebook With Arguments    image=${NOTEBOOK_IMAGE}    size=Small    gpus=1    version=previous
-    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
+    Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION_N_1}
     Verify Tensorflow Can See GPU
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
     [Teardown]    End Web Test


### PR DESCRIPTION
Up to now we used `nvidia-smi` for the CUDA version check, but because of the [1] we should rather use the `nvcc` tool for such operation.

Also, correct version of CUDA is 12.1 in our images now, see [2].

This is a followup of #1413 [3].

[1] https://issues.redhat.com/browse/RHOAIENG-6673
[2] https://github.com/red-hat-data-services/notebooks/blob/rhoai-2.9/cuda/ubi9-python-3.9/Dockerfile#L29
[3] aae86d286bc8ed7fd8cfb9c0c468b86cf6654764

---

CI: good - failed test is unrelated issue to this PR
![Screenshot from 2024-05-03 13-55-05](https://github.com/red-hat-data-services/ods-ci/assets/12250881/713770b9-f258-420e-96a8-47e10c613c18)
