### PR TITLE
[fix] Update image used for must-gather test

### DIFF
--- a/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Redirecting stdout/stderr of must-gather to a file, as it fills up the
 # process buffer and prevents the script from running further.
-oc adm must-gather --image=quay.io/modh/must-gather@sha256:c2d780156a0e7cec975c9c150bee00b1facb8f6213e7b98a7a489448d76dfd94 &> must-gather-results.txt
+oc adm must-gather --image=quay.io/modh/must-gather@sha256:5dd8b6f7e72c7fb3a5b46a48304514e4975fd6ed171cc3b1386771151020110a &> must-gather-results.txt
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
A new image was build accidentally a couple of days ago. This image should contain same code as the previous one, but since it is build recently, multiple packages from base image are updated.

Also, since this image has been marked for 2.9.0 already and is tagged as stable, we should start to use it in our tests too [1,2].

* [1] https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-2.9.md
* [2] https://access.redhat.com/solutions/7061604

CI:
![Screenshot from 2024-05-04 13-13-16](https://github.com/red-hat-data-services/ods-ci/assets/12250881/4e0a93f6-c8ff-46fb-8f4f-d54c45d4cac2)

---

Note: this deserves to be backported to 2.8.z only if the next release will be using this image; current prepared 2.8.2 is still marked with the old image: https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-2.8.2.md
