### PR TITLE
create managed certificate using sa for disconnected cluster

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/bucket_secret.yaml
+++ b/ods_ci/tests/Resources/Files/llm/bucket_secret.yaml
@@ -2,10 +2,14 @@ apiVersion: v1
 kind: Secret
 metadata:
   annotations:
+    opendatahub.io/connection-type: s3
     serving.kserve.io/s3-endpoint: {{ENDPOINT}}
     serving.kserve.io/s3-usehttps: {{USE_HTTPS}}
     serving.kserve.io/s3-region: {{REGION}}
     serving.kserve.io/s3-useanoncredential: "false"
+  labels:
+    opendatahub.io/dashboard: "true"
+    opendatahub.io/managed: "true"
   name: {{NAME}}
 stringData:
   "AWS_ACCESS_KEY_ID": "{{ACCESS_KEY_ID}}"


### PR DESCRIPTION
Added fix for making secret created as managed so that it can be work for both managed and sm cluster and attach certificate automatically . I am not using normal data connection way since it is already cover by ui testing so this solution is going to cover other way of utilizing the secret.