### PR TITLE
Fix "FA100", # Missing `from __future__ import annotations`, but uses `typing.Optional`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -125,7 +125,6 @@ ignore = [
   "B006", # Do not use mutable data structures for argument defaults
   "COM812", # Trailing comma missing
   "F841", # Local variable `response` is assigned to but never used
-  "FA100", # Missing `from __future__ import annotations`, but uses `typing.Optional`
   "INP001", # File `ods_ci/tests/Resources/Page/ODH/JupyterHub/jupyter-helper.py` is part of an implicit namespace package. Add an `__init__.py`.
   "N806", # Variable `outputText` in function should be lowercase
   "N813", # Camelcase `ElementTree` imported as lowercase `et`


### PR DESCRIPTION
This has been fixed previously by removing the `typing.Optional` from the files and replacing it with `|`. Let's just remove the suppression.