### PR TITLE
[fix] the test for special usernames

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/special-user-testing.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/special-user-testing.robot
@@ -38,6 +38,9 @@ Login Verify Logout
     [Arguments]  ${username}  ${password}  ${auth}
     Logout From RHODS Dashboard
     Login To RHODS Dashboard  ${username}  ${password}  ${auth}
+    # We need to Launch Jupyter app again, because there is a redirect to the `enabled` page in the
+    # Login To RHODS Dashboard keyword now as a workaround.
+    Launch Jupyter From RHODS Dashboard Link
     User Is Allowed
     Page Should Contain  ${username}
     Capture Page Screenshot  special-user-login-{index}.png


### PR DESCRIPTION
This started failing after this workaround #1432 ([1]). Originally the test expected that after logout and another login, the user is redirected to the original page where logout started. This doesn't happen anymore because of this new redirect to `enabled` paged in the mentioned workaround.

Once the workaround is removed, we can delete the line added in this PR also. Though, the main point of the test isn't to check where the page is open after login, but the actual login names work as expected only.

* [1] f9dfc88c6e9eba212b06f72eb210e17312967b8c