### PR TITLE
RHOAIENG-7305 - Authoreno and ServiceMesh ODH Fix

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -92,9 +92,12 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_NAME}    Red Hat OpenShift AI
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
+        Set Suite Variable    ${AUTHORINO_CR_NS}    redhat-ods-applications-auth-provider
+
     ELSE IF    "${PRODUCT}" == "ODH"
         Set Suite Variable    ${OPERATOR_APPNAME}  Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_NAME}    Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
+        Set Suite Variable    ${AUTHORINO_CR_NS}    opendatahub-auth-provider
     END

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/140__service_mesh.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/140__service_mesh.robot
@@ -4,13 +4,13 @@ Documentation       Test Cases to verify Service Mesh integration
 Library             Collections
 Resource            ../../../../Resources/OCP.resource
 Resource            ../../../../Resources/ODS.robot
+Resource            ../../../../Resources/RHOSi.resource
 Suite Setup         Suite Setup
 Suite Teardown      Suite Teardown
 
 
 *** Variables ***
 ${OPERATOR_NS}                              ${OPERATOR_NAMESPACE}
-${RHOAI_OPERATOR_DEPLOYMENT_NAME}           rhods-operator
 ${DSCI_NAME}                                default-dsci
 ${SERVICE_MESH_OPERATOR_NS}                 openshift-operators
 ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
@@ -59,7 +59,7 @@ Suite Setup
     [Documentation]    Suite Setup
     RHOSi Setup
     Wait Until Operator Ready    ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    ${SERVICE_MESH_OPERATOR_NS}
-    Wait Until Operator Ready    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
+    Wait Until Operator Ready    ${OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
     Wait For DSCI Ready State    ${DSCI_NAME}    ${OPERATOR_NS}
 
 Suite Teardown

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/141__authorino.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/141__authorino.robot
@@ -4,19 +4,18 @@ Documentation       Test Cases to verify RHOAI operator integration with Authori
 Library             Collections
 Resource            ../../../../Resources/OCP.resource
 Resource            ../../../../Resources/ODS.robot
+Resource            ../../../../Resources/RHOSi.resource
 Suite Setup         Suite Setup
 Suite Teardown      Suite Teardown
 
 
 *** Variables ***
 ${OPERATOR_NS}                              ${OPERATOR_NAMESPACE}
-${RHOAI_OPERATOR_DEPLOYMENT_NAME}           rhods-operator
 ${DSCI_NAME}                                default-dsci
 ${SERVICE_MESH_OPERATOR_NS}                 openshift-operators
 ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
 ${AUTHORINO_OPERATOR_NS}                    openshift-operators
 ${AUTHORINO_OPERATOR_DEPLOYMENT_NAME}       authorino-operator
-${AUTHORINO_CR_NS}                          redhat-ods-applications-auth-provider
 ${AUTHORINO_CR_NAME}                        authorino
 
 ${IS_PRESENT}                           0
@@ -40,7 +39,7 @@ Suite Setup
     [Documentation]    Suite Setup
     RHOSi Setup
     Wait Until Operator Ready    ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    ${SERVICE_MESH_OPERATOR_NS}
-    Wait Until Operator Ready    ${RHOAI_OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
+    Wait Until Operator Ready    ${OPERATOR_DEPLOYMENT_NAME}    ${OPERATOR_NS}
     Wait Until Operator Ready    ${AUTHORINO_OPERATOR_DEPLOYMENT_NAME}    ${AUTHORINO_OPERATOR_NS}
     Wait For DSCI Ready State    ${DSCI_NAME}    ${OPERATOR_NS}
 


### PR DESCRIPTION
The Robot automation Authoreno and Service Mesh test cases do not properly run on ODH.

Issues fixed:

 Authoreno:
    Operator Deployment name needs to use global OPERATOR_DEPLOYMENT_NAME
    Authoreno Deployment namespace is different for ODH and RHOAI

Service Mesh:
    Operator Deployment name needs to use global OPERATOR_DEPLOYMENT_NAME
