### PR TITLE
Exclude image digest verification on nightly builds

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -293,6 +293,7 @@ Verify All The Pods Are Using Image Digest Instead Of Tags
     ...       Tier1
     ...       ODS-2406
     ...       ExcludeOnODH
+    ...       ExcludeOnNightly
     ${return_code}    ${output} =    Run And Return Rc And Output    oc get ns -l opendatahub.io/generated-namespace -o jsonpath='{.items[*].metadata.name}' ; echo ; oc get ns -l opendatahub.io/dashboard -o jsonpath='{.items[*].metadata.name}'  # robocop: disable
     Should Be Equal As Integers	 ${return_code}	 0  msg=Error getting the namespace using label
     ${projects_list} =    Split String    ${output}


### PR DESCRIPTION
Nightly builds can contain images with tags