### PR TITLE
[fix] the expected network policy content for the ODH execution

### DIFF
--- a/ods_ci/tests/Resources/Files/expected_ctrl_np_template.txt
+++ b/ods_ci/tests/Resources/Files/expected_ctrl_np_template.txt
@@ -3,7 +3,7 @@
     {
       "namespaceSelector": {
         "matchLabels": {
-          "kubernetes.io/metadata.name": "redhat-ods-applications"
+          "kubernetes.io/metadata.name": "SELECTOR_LABEL_VALUE"
         }
       }
     }

--- a/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
+++ b/ods_ci/tests/Tests/100__deploy/100__installation/102__post_install.robot
@@ -275,7 +275,8 @@ Verify RHODS Notebooks Network Policies
     ${CR_name} =    Get User CR Notebook Name    username=${TEST_USER.USERNAME}
     ${policy_ctrl} =    Run
     ...    oc get networkpolicy ${CR_name}-ctrl-np -n ${NOTEBOOKS_NAMESPACE} -o json | jq '.spec.ingress[0]'
-    ${expected_policy_ctrl} =    Get File    ods_ci/tests/Resources/Files/expected_ctrl_np.txt
+    ${rc}    ${expected_policy_ctrl} =    Run And Return Rc And Output
+    ...    sed "s#SELECTOR_LABEL_VALUE#${APPLICATIONS_NAMESPACE}#" ods_ci/tests/Resources/Files/expected_ctrl_np_template.txt  # robocop: disable:line-too-long
     Should Be Equal As Strings    ${policy_ctrl}    ${expected_policy_ctrl}
     Log    ${policy_ctrl}
     Log    ${expected_policy_ctrl}


### PR DESCRIPTION
This was failing with ODH because there is a different network policy content. I think that the content in ODH is as expected, as such, I have updated our test to match this difference and work properly on both ODH and RHOAI installations.

Tested both with ODH and RHOAI installation:

![Screenshot from 2024-05-17 12-10-13](https://github.com/red-hat-data-services/ods-ci/assets/12250881/acb73654-7864-455c-b829-9bf0800afb96)
