### PR TITLE
[fix] two test that starts Standard Data Science workbench on ODH

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -33,8 +33,12 @@ ${WORKBENCH_STOP_BTN_XP}=                 xpath=//button[text()="Stop workbench"
 ${WORKBENCH_IMAGE_VER_LABEL}=        //label[@for="workbench-image-version-selection"]
 ${WORKBENCH_IMAGE_VER_BUTTON}=       ${WORKBENCH_IMAGE_VER_LABEL}/../..//button
 ${WORKBENCH_IMAGE_VER_DROPDOWN}=     //*[@id="workbench-image-version-selection"]
+# Standard Data Science https://github.com/red-hat-data-services/notebooks/blob/main/manifests/base/jupyter-datascience-notebook-imagestream.yaml
+# vs
+# Jupyter Data Science https://github.com/opendatahub-io/notebooks/blob/main/manifests/base/jupyter-datascience-notebook-imagestream.yaml
 &{IMAGE_ID_MAPPING}=                 Minimal Python=minimal-notebook    CUDA=minimal-gpu   PyTorch=pytorch
-...                                  Standard Data Science=data-science-notebook    TensorFlow=tensorflow
+...                                  Standard Data Science=data-science-notebook    Jupyter Data Science=datascience-notebook
+...                                  TensorFlow=tensorflow
 ${KEYVALUE_TYPE}=        Key / value
 ${UPLOAD_TYPE}=        Upload
 ${ENV_VARIABLES_SECTION_XP}=        xpath=//section[@aria-label="Environment variables"]
@@ -204,6 +208,13 @@ Select An Existent PV
 Select Workbench Jupyter Image
     [Documentation]    Selects a Jupyter image in the workbench creation page
     [Arguments]     ${image_name}    ${version}=default
+    IF  "${PRODUCT}" == "ODH"
+        # The name of the Standard Data Science image in ODH is Jupyter Data Science
+        IF  "${image_name}" == "Standard Data Science"
+            ${image_name}=    Set Variable    Jupyter Data Science
+        END
+    END
+
     Click Element    //a[@href="#notebook-image"]
     Wait Until Page Contains Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}
     Click Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}


### PR DESCRIPTION
On ODH the image name for Standard Data Science is actually named Jupyter Data Science. As such, we should change the expected image name when running on ODH and not on RHOAI.

This should fix these two tests run in smoke:

* `Verify Pipelines Integration With Elyra When Using Standard Data Science Image`
* `Verify Workbench Images Have Multiple Versions`

CI:
![Screenshot from 2024-05-17 13-57-42](https://github.com/red-hat-data-services/ods-ci/assets/12250881/3225b159-4c37-4217-b6b3-88dec10b0a69)
![Screenshot from 2024-05-17 13-57-47](https://github.com/red-hat-data-services/ods-ci/assets/12250881/4b7dde56-e286-47f1-8794-7776c4035324)
