### PR TITLE
[fix] expected title of the browser window when running with ODH

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -10,7 +10,9 @@ Library       JupyterLibrary
 
 
 *** Variables ***
+# This variable is overriden for ODH runs via 'ods_ci/test-variables-odh-overwrite.yml'
 ${ODH_DASHBOARD_PROJECT_NAME}=   Red Hat OpenShift AI
+
 ${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-v5-c-drawer__panel-main"]//button[.='Enable']
 ${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-v5-c-drawer__panel-main"]//*[.='Get started']
 ${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-v5-c-card'))]

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -455,7 +455,7 @@ Verify Users Can Start, Stop, Launch And Delete A Workbench
     ...    auth_type=${TEST_USER_3.AUTH_TYPE}
     Check Launched Workbench Is The Correct One     workbench_title=${WORKBENCH_TITLE}
     ...    image=${NB_IMAGE}    project_title=${PRJ_TITLE}
-    SeleniumLibrary.Switch Window    title=Red Hat OpenShift AI
+    SeleniumLibrary.Switch Window    title=${ODH_DASHBOARD_PROJECT_NAME}
     Wait Until Project Is Open    project_title=${PRJ_TITLE}
     Delete Workbench    workbench_title=${WORKBENCH_TITLE}
     Workbench Should Not Be Listed    workbench_title=${WORKBENCH_TITLE}


### PR DESCRIPTION
This fixes following smoke test run on ODH:
* `Verify Users Can Start, Stop, Launch And Delete A Workbench`

CI tested both on ODH and RHOAI:
![Screenshot from 2024-05-17 14-00-08](https://github.com/red-hat-data-services/ods-ci/assets/12250881/160a87a2-6558-4a87-b9c0-a73952ac81e3)
