### PR TITLE
[fix] disable the custom manifest support temporarily

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -314,13 +314,13 @@ Apply Custom Manifest in DataScienceCluster CustomResource Using Test Variables
 
     ${file_path} =    Set Variable    tasks/Resources/Files/
     FOR    ${cmp}    IN    @{COMPONENT_LIST}
-        IF    $cmp in $CUSTOM_MANIFESTS
-            ${manifest_string}=    Convert To String    ${CUSTOM_MANIFESTS}[${cmp}]
-            # Use sed to replace the placeholder with the YAML string
-            Run    sed -i "s|<${cmp}_devflags>|${manifest_string}|g" ${file_path}dsc_apply.yml
-        ELSE
+        # IF    $cmp in ${CUSTOM_MANIFESTS}
+        #     ${manifest_string}=    Convert To String    ${CUSTOM_MANIFESTS}[${cmp}]
+        #     # Use sed to replace the placeholder with the YAML string
+        #     Run    sed -i "s|<${cmp}_devflags>|${manifest_string}|g" ${file_path}dsc_apply.yml
+        # ELSE
             Run    sed -i "s|<${cmp}_devflags>||g" ${file_path}dsc_apply.yml
-        END
+        # END
     END
 
 Component Should Be Enabled


### PR DESCRIPTION
Reason is that this doesn't work when empty array is generated in test-variables.yml file. This should be easy to fix, but I'm lazy to do it.

This is a followup of #1445.

Tested and job passed for me.