### PR TITLE
[Backport 2.9] Bumping timeout or retries to avoid flaky timeless issues

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -151,7 +151,7 @@ Verify RHODS Installation
     Wait For Pods Numbers   1
        ...                   namespace=${APPLICATIONS_NAMESPACE}
        ...                   label_selector=control-plane=kserve-controller-manager
-       ...                   timeout=120
+       ...                   timeout=400
   END
 
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true" or "${workbenches}" == "true" or "${modelmeshserving}" == "true" or "${datasciencepipelines}" == "true"  # robocop: disable
@@ -393,7 +393,7 @@ Install Kserve Dependencies
           Wait Until Operator Subscription Last Condition Is
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${SERVERLESS_SUB_NAME}
-          ...    namespace=${SERVERLESS_NS}
+          ...    namespace=${SERVERLESS_NS} retry=100
           Wait For Pods To Be Ready    label_selector=name=knative-openshift
           ...    namespace=${SERVERLESS_NS}
           Wait For Pods To Be Ready    label_selector=name=knative-openshift-ingress

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -176,7 +176,7 @@ Get CodeFlare Version
 #robocop: disable: line-too-long
 Wait Until Csv Is Ready
   [Documentation]   Waits ${timeout} for Operators CSV '${display_name}' to have status phase 'Succeeded'
-  [Arguments]    ${display_name}    ${timeout}=3m    ${operators_namespace}=openshift-operators
+  [Arguments]    ${display_name}    ${timeout}=10m    ${operators_namespace}=openshift-operators
   Log    Waiting ${timeout} for Operator CSV '${display_name}' in ${operators_namespace} to have status phase 'Succeeded'    console=yes
   WHILE   True    limit=${timeout}
   ...    on_limit_message=${timeout} Timeout exceeded waiting for CSV '${display_name}' to be created


### PR DESCRIPTION
Backport from master to release/2.9.0:

https://github.com/red-hat-data-services/ods-ci/pull/1461