### PR TITLE
Bumping timeout or retries to avoid flaky timeless issues (#1461)

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -393,7 +393,7 @@ Install Kserve Dependencies
           Wait Until Operator Subscription Last Condition Is
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${SERVERLESS_SUB_NAME}
-          ...    namespace=${SERVERLESS_NS} retry=100
+          ...    namespace=${SERVERLESS_NS}    retry=100
           Wait For Pods To Be Ready    label_selector=name=knative-openshift
           ...    namespace=${SERVERLESS_NS}
           Wait For Pods To Be Ready    label_selector=name=knative-openshift-ingress


### PR DESCRIPTION
* Bump pod timeout from 120 to 400 sec

* Bump serverless operator retries from 20 to 100

Fixes https://github.com/red-hat-data-services/ods-ci/pull/1462