### PR TITLE
Verify RHODS version before and after upgrade

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/120__upgrades/121__during_upgrade.robot
+++ b/ods_ci/tests/Tests/100__deploy/120__upgrades/121__during_upgrade.robot
@@ -94,19 +94,21 @@ RHODS Version Should Be Greater Than
     [Arguments]  ${initial_version}
     ${ver} =  Get RHODS Version
     ${ver} =  Fetch From Left  ${ver}  -
-    Should Be True    '${ver}' > '${initial_version}'    msg=RHODS version was not greater than initial version ${initial_version}
+    Should Be True    '${ver}' > '${initial_version}'    msg=Version wasn't greater than initial one ${initial_version}
 
 Get Operator Pod Creation Date
     [Documentation]    Retrieves the creation date of the RHODS operator pod.
     ...                Returns the creation date as a string.
     ...                Fails if the command to retrieve the creation date fails.
-    ${return_code}    ${creation_date}    Run And Return Rc And Output    oc get pod -n ${OPERATOR_NAMESPACE} -l name=rhods-operator --no-headers -o jsonpath='{.items[0].metadata.creationTimestamp}'
+    ${return_code}    ${creation_date} =  Run And Return Rc And Output
+    ...    oc get pod -n ${OPERATOR_NAMESPACE} -l name=rhods-operator --no-headers -o jsonpath='{.items[0].metadata.creationTimestamp}'
     Should Be Equal As Integers    ${return_code}     0   msg=Error while getting creation date of the operator pod
-    [Return]    ${creation_date}
+    RETURN    ${creation_date}
 
 Operator Pod Creation Date Should Be Updated
     [Documentation]    Checks if the operator pod creation date has been updated after the upgrade.
     ...                Fails if the updated creation date is not more recent than the initial creation date.
     [Arguments]  ${initial_creation_date}
     ${updated_creation_date} =  Get Operator Pod Creation Date
-    Should Be True    '${updated_creation_date}' > '${initial_creation_date}'    msg=Operator pod creation date was not updated after upgrade
+    Should Be True    '${updated_creation_date}' > '${initial_creation_date}'
+    ...    msg=Operator pod creation date was not updated after upgrade


### PR DESCRIPTION
Refactor upgrade test to check if version after upgrade is greater than the initial version. The previous approach that checked if the pods in the operator namespace were Pending after 10s was causing the test to fail, because the pods were already running before 10s, and playing with that sleep timer might make the test flaky. I think the right way to confirm if the upgrade has been successful is to check the CSV version and that the pods in the operator namespace are running once the CSV version has been updated

rh-pre-commit.version: 2.2.0
rh-pre-commit.check-secrets: ENABLED