### PR TITLE
 Add support for vllm serverless http

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -23,6 +23,7 @@ ${MODELS_BUCKET}=    ${S3.BUCKET_3}
 ${SERVICEMESH_CR_NS}=    istio-system
 &{RUNTIME_FLIEPATHS}=    caikit-tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/caikit_tgis_servingruntime_{{protocol}}.yaml
 ...                      tgis-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/tgis_servingruntime_{{protocol}}.yaml
+...                      vllm-runtime=${LLM_RESOURCES_DIRPATH}/serving_runtimes/vllm_servingruntime_{{protocol}}.yaml
 ${DOWNLOAD_PVC_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/download_model_in_pvc.yaml
 ${DOWNLOAD_PVC_FILLED_FILEPATH}=    ${LLM_RESOURCES_DIRPATH}/download_model_in_pvc_filled.yaml
 

--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -151,8 +151,28 @@
             "query_text": "{'role': 'system','content': 'You are a poetic assistant, skilled in explaining complex programming concepts with creative flair.'},{'role': 'user','content': 'Compose a poem that explains the concept of recursion in programming.'}",
             "models": {
                 "gpt2": {
-                    "vllm": {
+                    "vllm-runtime": {
                         "chat-completions_response_text": "A friend of mine came over to the house to play with his wife. He was asleep, and he felt like he'd been hit by a speeding car. He's a big guy. He's like the kind of guy who may not have a very good head, but he's big enough to stand up at a table and read something. I was like, \"I'm going to play with this.\"\n\nThat's where I started playing with my car. It was something I never dreamed of doing, but I'd never imagined that it would be such a big deal.\n\nWe started playing with it. When I was about 12, we started playing with it to see how it would turn out. I was 26, and I was playing it for the first time for the first time ever. It was fun. I remember thinking it was like a different game than I had ever played before. I remember thinking the first time we played would be like, \"Oh my god, I've never played a game like this before before.\"\n\nIt was surreal. I was in my 20s at the time. We got to have a party in my house at the time. I was sitting in the living room with my friend, who's 28. We're from Dallas, and his wife is a pretty big girl. He's about 6 feet tall and 250 pounds. On the phone with his friend said, \"Dad, is it possible you'll be able to do this without your beard?\" I was like, \"Absolutely, actually.\" I thought, \"I'm going to do it.\"\n\nI finally did it and it turned out pretty well. I was able to take our photo with our friend, and he got excited and started laughing. He was like, \"That's awesome.\" I sat in his living room for two hours and made sure he was really excited. He was really excited. We ended up having a workshop and we have a lot of stuff to do.\n\nHe just started playing. It's been amazing. I'm like, \"It's going to be huge.\" At first I was like, \"Wow, my god that's amazing.\" I was like, \"Wow, my God that's awesome.\" He's like, \"I'm so excited about this!\" He was like, \"Oh my god, I can't wait to do it!\"\n\nHe had that awesome physique. He was super skinny. He was like, \"I'm so excited about it.\" He was like, \"Really?\" I was like, \"Yeah, I'm so excited! I'm so excited.\" We did it for two weeks and it turned out pretty well.\n\nHe's like, \"I hope it stays that way.\" I was like, \"I hope it stays that way.\" He was like, \"Oh my god, I've never even played with a computer before!\" I was like, \"Yeah, it's just fun to play with a computer.\" He was like, \"Oh my god, I can't wait to play with a computer!\" He was like, \"It's just a cool thing to do!\"\n\nI was doing it with my friend's dog, a puppy.\n\nI was doing it with my friend's dog. People said, \"You think that's cool?\" I said, \"Yeah, that's cool.\" We had the dog. He was a little bit shy and it was a little bit intimidating and scary.\n\nWe played it twice. It was like a game. He was like, \"Oh my God I've never played with a computer before!\" I was like, \"I hope it stays that way.\" He was like, \"Yeah, it's just a cool thing to do!\" He was like, \"Oh my god, I can't wait to do it!\"\n\nWe played it again on the bus, on the weekend.\n\nWe played it again on the weekend.\n\nThen we went to the store and bought a new Canon 5D Mark II.\n\nI couldn't believe what the customer was saying. I was like, \"That sounds amazing!\" He was like, \"That's amazing!\"\n\nHe was like, \"Wow! That's awesome!\" So we were like, \"Wow! That looks awesome!\" He's like, \"Yeah, that looks awesome!\" I was like, \"Wow! That looks awesome! That looks awesome!\"\n\nWe played it twice again.\n\nI was like, \"Wow! That sounds awesome!\" He was like, \"Wow! That sounds awesome! That sounds awesome!\" I was like, \"Wow! That looks awesome!\"\n\nHe was like, \"Wow! That sounds awesome! That looks awesome!\"\n\nI was just like, \"Wow! That looks awesome! That looks awesome!\" He was like"
+                    }
+                }
+            }
+        },
+        {
+            "query_text": "{'role': 'user' , 'content' : '。桜の木は、桜の花が咲くと'}",
+            "models": {
+                "elyza-japanese":{
+                    "vllm-runtime": {
+                        "chat-completions_response_text": "{\"id\":\"cmpl-53b80efcc34f4dfcbd0b325ff0777051\",\"object\":\"chat.completion\",\"created\":1716276132,\"model\":\"e\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"  桜の木は、桜の花が咲くと芽吹きが始まります。つぼみは膨らみ、色が開き、準備ができた芽を支えます。葉が落ちるまでの間に、芽かきをして、芽だけを残します。\"},\"logprobs\":null,\"finish_reason\":\"stop\",\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":29,\"total_tokens\":181,\"completion_tokens\":152}}"
+                    }
+                }
+            }
+        },
+        {
+            "query_text": "。桜の木は、桜の花が咲くと",
+            "models": {
+                "elyza-japanese":{
+                    "vllm-runtime": {
+                        "completions_response_text": "{\"id\":\"cmpl-8faf5129deac4da88d002e4526fd88a4\",\"object\":\"text_completion\",\"created\":1716279480,\"model\":\"e\",\"choices\":[{\"index\":0,\"text\":\"徒長する。つまり芽吹\",\"logprobs\":null,\"finish_reason\":\"length\",\"stop_reason\":null}],\"usage\":{\"promp21,\"total_tokens\":37,\"completion_tokens\":16}}"
                     }
                 }
             }

--- a/ods_ci/tests/Resources/Files/llm/runtime_query_formats.json
+++ b/ods_ci/tests/Resources/Files/llm/runtime_query_formats.json
@@ -97,7 +97,7 @@
         },
         "containers": ["kserve-container"]
     },
-    "vllm": {
+    "vllm-runtime": {
         "endpoints": {
             "chat-completions": {
                 "http": {
@@ -108,6 +108,18 @@
                         "response": "choices",
                         "completion_tokens":  "completion_tokens",
                         "response_text":    "content"
+                    }
+                }
+            },
+            "completions"  : {
+                "http": {
+                    "endpoint": "v1/completions",
+                    "header": "Content-Type:application/json",
+                    "body": "{'model': '${model_name}','prompt': '${query_text}'}",
+                    "response_fields_map": {
+                        "response": "choices",
+                        "completion_tokens":  "completion_tokens",
+                        "response_text":    "text"
                     }
                 }
             }

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/overlay/vllm/env_param.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/overlay/vllm/env_param.yaml
@@ -1,0 +1,11 @@
+- op: add
+  path: /spec/predictor/model/env
+  value:
+        - name: HF_HUB_CACHE
+          value: /tmp
+        - name: TRANSFORMERS_CACHE
+          value: $(HF_HUB_CACHE)
+        - name: DTYPE
+          value: float16
+        - name: SERVED_MODEL_NAME
+          value: ${model_name}

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/overlay/vllm/kustomization.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/overlay/vllm/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: prompt-tuned-model
+resources:
+  - ../../base/
+patches:
+  - path: env_param.yaml
+    target:
+      kind: InferenceService

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/vllm_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/vllm_servingruntime_http.yaml
@@ -1,0 +1,29 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: vllm-runtime
+spec:
+  builtInAdapter:
+    modelLoadingTimeoutMillis: 90000
+  containers:
+    - args:
+        - --model
+        - /mnt/models/
+        - --download-dir
+        - /models-cache
+        - --port
+        - "8080"
+      image: quay.io/opendatahub/vllm:fast-ibm-nightly-2024-05-21
+      name: kserve-container
+      command:
+        - python3
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      ports:
+        - containerPort: 8080
+          name: http1
+          protocol: TCP
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: pytorch

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -218,6 +218,7 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ...    kserve_mode=${KSERVE_MODE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
+
 Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                (mpt-7b-instruct2) using Kserve and TGIS runtime
@@ -257,12 +258,6 @@ Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     ...    inference_type=model-info    n_times=1
     ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
-    [Teardown]    Run Keywords
-    ...    Clean Up Test Project    test_ns=${test_namespace}
-    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
-    ...    kserve_mode=${KSERVE_MODE}
-    ...    AND
-    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -11,14 +11,14 @@ Test Tags         KServe-LLM
 
 *** Variables ***
 ${TEST_NS}=    tgismodel
-${RUNTIME_NAME}=   tgis-runtime   #vllm-runtime
+${RUNTIME_NAME}=  tgis-runtime   #vllm-runtime
 ${USE_PVC}=    ${TRUE}
 ${DOWNLOAD_IN_PVC}=    ${TRUE}
 ${USE_GPU}=    ${FALSE}
-${KSERVE_MODE}=    RawDeployment
+${KSERVE_MODE}=    RawDeployment   #Serverless
 ${MODEL_FORMAT}=   pytorch       #vLLM
 ${PROTOCOL}=     grpc         #http
-${OVERLAY}=    vllm
+${OVERLAY}=      ${EMPTY}               #vllm
 
 
 *** Test Cases ***
@@ -162,14 +162,18 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
 Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and TGIS standalone runtime
-    [Tags]    RHOAIENG-3479
+    [Tags]    RHOAIENG-3479     VLLM
     Setup Test Variables    model_name=elyza-japanese    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
     Set Project And Runtime    runtime=${RUNTIME_NAME}     namespace=${test_namespace}
     ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}   protocol=${PROTOCOL}
     ...    storage_size=70Gi    model_path=${model_path}
     ${requests}=    Create Dictionary    memory=40Gi
-    ${overlays}=   Create List    ${OVERLAY}
+    IF    "${OVERLAY}" != "${EMPTY}"
+          ${overlays}=   Create List    ${OVERLAY}
+    ELSE
+          ${overlays}=   Create List
+    END
     Compile Inference Service YAML    isvc_name=${model_name}
     ...    sa_name=${EMPTY}
     ...    model_storage_uri=${storage_uri}
@@ -183,29 +187,37 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
     ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=all-tokens    n_times=1    protocol=${PROTOCOL}
-    ...    namespace=${test_namespace}   query_idx=4    validate_response=${TRUE}    # temp
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=streaming    n_times=1    protocol=${PROTOCOL}
-    ...    namespace=${test_namespace}    query_idx=4    validate_response=${FALSE}
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=tokenize    n_times=1    query_idx=4
-    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=model-info    n_times=1
-    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
-    ...    port_forwarding=${use_port_forwarding}
+    IF   "${RUNTIME_NAME}" == "tgis-runtime" and "${KSERVE_MODE}" == "RawDeployment"
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=all-tokens    n_times=1    protocol=${PROTOCOL}
+            ...    namespace=${test_namespace}   query_idx=4    validate_response=${TRUE}    # temp
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=streaming    n_times=1    protocol=${PROTOCOL}
+            ...    namespace=${test_namespace}    query_idx=4    validate_response=${FALSE}
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=tokenize    n_times=1    query_idx=4
+            ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=model-info    n_times=1
+            ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+            ...    port_forwarding=${use_port_forwarding}
+    ELSE IF    "${RUNTIME_NAME}" == "vllm-runtime" and "${KSERVE_MODE}" == "Serverless"
+            Query Model Multiple Times    model_name=${model_name}      runtime=${RUNTIME_NAME}    protocol=http
+            ...    inference_type=chat-completions    n_times=1    query_idx=9
+            ...    namespace=${test_namespace}    string_check_only=${TRUE}
+            Query Model Multiple Times    model_name=${model_name}      runtime=${RUNTIME_NAME}    protocol=http
+            ...    inference_type=completions    n_times=1    query_idx=10
+            ...    namespace=${test_namespace}    string_check_only=${TRUE}
+    END
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
     ...    kserve_mode=${KSERVE_MODE}
     ...    AND
     ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
-
 Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                (mpt-7b-instruct2) using Kserve and TGIS runtime
@@ -245,6 +257,12 @@ Verify User Can Serve And Query A ibm/mpt-7b-instruct2 Model
     ...    inference_type=model-info    n_times=1
     ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
     ...    port_forwarding=${use_port_forwarding}
+    [Teardown]    Run Keywords
+    ...    Clean Up Test Project    test_ns=${test_namespace}
+    ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}
+    ...    kserve_mode=${KSERVE_MODE}
+    ...    AND
+    ...    Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"    Terminate Process    llm-query-process    kill=true
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/vllm/426__model_serving_vllm_metrics.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/vllm/426__model_serving_vllm_metrics.robot
@@ -57,7 +57,7 @@ Verify User Can Deploy A Model With Vllm Via CLI
     Deploy Model Via CLI    ${IS_FILEPATH}    ${TEST_NS}
     Wait For Pods To Be Ready    label_selector=serving.kserve.io/inferenceservice=vllm-gpt2-openai
     ...    namespace=${TEST_NS}
-    Query Model Multiple Times    model_name=gpt2    isvc_name=vllm-gpt2-openai    runtime=vllm    protocol=http
+    Query Model Multiple Times    model_name=gpt2    isvc_name=vllm-gpt2-openai    runtime=vllm-runtime   protocol=http
     ...    inference_type=chat-completions    n_times=3    query_idx=8
     ...    namespace=${TEST_NS}    string_check_only=${TRUE}
 


### PR DESCRIPTION
This is a basic skeleton to add support for VLLM serverless deployment for the Elyza model. I will be adding support for other models in an upcoming new PR.

For raw deployment, as of today, VLLM scope is only for this endpoint with gRPC. Conditions will be changed in the future as required.

openai()rest) Endpoints will be validated only for serverless; although we can validate the HTTP endpoint in raw deployment, we will not add the support until it is required by IBM.


` sh ods_ci/run_robot_test.sh --skip-oclogin true --extra-robot-args '-i VLLM --variable RUNTIME_NAME:vllm-runtime --variable USE_GPU:"${TRUE}" --variable KSERVE_MODE:Serverless --variable PROTOCOL:http  --variable OVERLAY:vllm'`
