### PR TITLE
[Jupyter] RHOAIENG-7490 update test tags - remove many from Sanity

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/custom-image.robot
@@ -11,7 +11,7 @@ Library          JupyterLibrary
 Library          OpenShiftLibrary
 Suite Setup      Custom Notebook Settings Suite Setup
 Suite Teardown   End Web Test
-Test Tags       JupyterHub
+Test Tags        JupyterHub
 
 
 
@@ -30,14 +30,14 @@ ${IMAGESTREAM_NAME}=
 Verify Admin User Can Access Custom Notebook Settings
     [Documentation]    Verifies an admin user can reach the custom notebook
     ...    settings page.
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-1366
     Pass Execution    Passing tests, as suite setup ensures page can be reached
 
 Verify Custom Image Can Be Added
     [Documentation]    Imports the custom image via UI
     ...                Then loads the spawner and tries using the custom img
-    [Tags]    Sanity    Tier1    ExcludeOnDisconnected
+    [Tags]    Tier1    ExcludeOnDisconnected
     ...       ODS-1208    ODS-1365
     ${CLEANUP}=  Set Variable  False
     Create Custom Image
@@ -63,7 +63,7 @@ Verify Custom Image Can Be Added
 Test Duplicate Image
     [Documentation]  Test adding two images with the same name (should fail)
     ...       ProductBug - https://issues.redhat.com/browse/RHOAIENG-1192
-    [Tags]    Sanity    Tier1    ExcludeOnDisconnected
+    [Tags]    Tier1    ExcludeOnDisconnected
     ...       ODS-1368
     Sleep  1
     Create Custom Image
@@ -81,7 +81,7 @@ Test Duplicate Image
 
 Test Bad Image URL
     [Documentation]  Test adding an image with a bad repo URL (should fail)
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-1367
     ${OG_URL}=  Set Variable  ${IMG_URL}
     ${IMG_URL}=  Set Variable  quay.io/RandomName/RandomImage:v1.2.3
@@ -95,7 +95,7 @@ Test Bad Image URL
 Test Image From Local registry
     [Documentation]  Try creating a custom image using a local registry URL (i.e. OOTB image)
     ...       Issue reported for this test in the past - https://github.com/opendatahub-io/odh-dashboard/issues/2185
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-2470
     ${CLEANUP}=  Set Variable  False
     Open Notebook Images Page

--- a/ods_ci/tests/Tests/500__jupyterhub/image-iteration.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/image-iteration.robot
@@ -20,12 +20,12 @@ ${python_dict}  {'classifiers':[${generic-1}, ${minimal-1}], 'clustering':[${gen
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait For RHODS Dashboard To Load
 
 Iterative Testing Classifiers
-  [Tags]  Sanity  POLARION-ID-Classifiers    Tier1
+  [Tags]  POLARION-ID-Classifiers    Tier1
   ...     Execution-Time-Over-15m
   &{DICTIONARY} =  Evaluate  ${python_dict}
   FOR  ${sublist}  IN  @{DICTIONARY}[classifiers]

--- a/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/jupyterhub-user-access.robot
@@ -31,7 +31,7 @@ Verify User Can Set Custom RHODS Groups
     ...                via ODH Dashboard UI in `Settings -> User management` section, see:
     ...                `Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook` in
     ...                ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     ODS-293    ODS-503
     [Setup]      Set Standard RHODS Groups Variables
     Create Custom Groups

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-pytorch-test.robot
@@ -22,14 +22,14 @@ ${EXPECTED_CUDA_VERSION_N_1} =  11.8
 *** Test Cases ***
 Verify PyTorch Image Can Be Spawned
     [Documentation]    Spawns pytorch image
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     PLACEHOLDER  # category tags
     ...     ODS-1149
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 PyTorch Image Workload Test
     [Documentation]    Runs a pytorch workload
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     PLACEHOLDER  # category tags
     ...     ODS-1150
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
@@ -38,7 +38,7 @@ PyTorch Image Workload Test
 
 Verify Tensorboard Is Accessible
     [Documentation]  Verifies that tensorboard is accessible
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     PLACEHOLDER
     ...     ODS-1414
     Close Previous Server
@@ -51,7 +51,7 @@ Verify Tensorboard Is Accessible
 
 Verify PyTorch Image Can Be Spawned With GPU
     [Documentation]    Spawns PyTorch image with 1 GPU
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1145
     Clean Up Server
@@ -62,21 +62,21 @@ Verify PyTorch Image Can Be Spawned With GPU
 
 Verify PyTorch Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1146
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify PyTorch Library Can See GPUs In PyTorch Image
     [Documentation]    Verifies PyTorch can see the GPU
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1147
     Verify Pytorch Can See GPU
 
 Verify PyTorch Image GPU Workload
     [Documentation]  Runs a workload on GPUs in PyTorch image
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1148
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/fgsm_tutorial.ipynb

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-tensorflow-test.robot
@@ -23,15 +23,14 @@ ${EXPECTED_CUDA_VERSION_N_1} =  11.8
 *** Test Cases ***
 Verify Tensorflow Image Can Be Spawned
     [Documentation]    Spawns tensorflow image
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     PLACEHOLDER  # Category tags
     ...     ODS-1155
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 Tensorflow Workload Test
     [Documentation]    Runs tensorflow workload
-    [Tags]  Sanity    Tier1
-    ...     Tier1
+    [Tags]  Tier1
     ...     ODS-1156
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
     Capture Page Screenshot
@@ -39,8 +38,7 @@ Tensorflow Workload Test
 
 Verify Tensorboard Is Accessible
     [Documentation]  Verifies that tensorboard is accessible
-    [Tags]  Sanity    Tier1
-    ...     Tier1
+    [Tags]  Tier1
     ...     ODS-1413
     Close Previous Server
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  size=Small
@@ -52,7 +50,7 @@ Verify Tensorboard Is Accessible
 
 Verify Tensorflow Image Can Be Spawned With GPU
     [Documentation]    Spawns PyTorch image with 1 GPU
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1151
     Close Previous Server
@@ -60,21 +58,21 @@ Verify Tensorflow Image Can Be Spawned With GPU
 
 Verify Tensorflow Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1152
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify Tensorflow Library Can See GPUs In Tensorflow Image
     [Documentation]    Verifies Tensorlow can see the GPU
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1153
     Verify Tensorflow Can See GPU
 
 Verify Tensorflow Image GPU Workload
     [Documentation]  Runs a workload on GPUs in Tensorflow image
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     Resources-GPU
     ...     ODS-1154
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb

--- a/ods_ci/tests/Tests/500__jupyterhub/minimal-vscode-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/minimal-vscode-test.robot
@@ -20,7 +20,7 @@ ${NOTEBOOK_IMAGE} =         code-server
 *** Test Cases ***
 Verify VSCode Image Can Be Spawned
     [Documentation]    Spawns vscode image
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 

--- a/ods_ci/tests/Tests/500__jupyterhub/multiple-image-tags.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/multiple-image-tags.robot
@@ -33,7 +33,7 @@ Verify All OOTB Images Have Version Dropdowns
 Verify All OOTB Images Spawn Previous Versions
     [Documentation]    Verifies all images in ${IMAGE_LIST} can be spawned using
     ...                the previous version, and the spawned image is the correct one.
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-2126
     [Setup]    Multiple Image Tags Suite Setup
     FOR    ${image}    IN    @{IMAGE_LIST}

--- a/ods_ci/tests/Tests/500__jupyterhub/networkpolicy-test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/networkpolicy-test.robot
@@ -15,7 +15,7 @@ Test Tags       JupyterHub
 Test Network Policy Effect
     [Documentation]    Spawns two Notebooks with two different users and verifies
     ...    That the new network policies prevent user2 from accessing user1's workspace
-    [Tags]  Sanity    Tier1
+    [Tags]  Tier1
     ...     ODS-2046
     Open Browser And Start Notebook As First User
     Open Browser And Start Notebook As Second User With Env Vars

--- a/ods_ci/tests/Tests/500__jupyterhub/test-filling-pvc.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-filling-pvc.robot
@@ -26,7 +26,7 @@ ${FILE_NAME}            fill-notebook-pvc-to-complete-100.ipynb
 Verify Users Get Notifications If Storage Capacity Limits Get Exceeded
     [Documentation]    Runs a jupyter notebook to fill the user PVC to 100% and verifies that
     ...    a "No space left on device" OSError and a "File Save Error" dialog are shown
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-539
 
     ${error} =    Run Git Repo And Return Last Cell Error Text    ${LINK_OF_GITHUB}    ${PATH_TO_FILE}

--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git-notebook.robot
@@ -13,15 +13,15 @@ Test Tags       JupyterHub
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   Launch Jupyter From RHODS Dashboard Link
 
 Can Login to Jupyterhub
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   ${authorization_required} =  Is Service Account Authorization Required
   IF  ${authorization_required}  Authorize jupyterhub service account
@@ -29,12 +29,12 @@ Can Login to Jupyterhub
   Wait Until Page Contains  Start a notebook server
 
 Can Spawn Notebook
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   Fix Spawner Status
   Spawn Notebook With Arguments  image=science-notebook
 
 Can Launch Python3 Smoke Test Notebook
-  [Tags]  Sanity    Tier1
+  [Tags]  Tier1
   ##################################################
   # Manual Notebook Input
   ##################################################

--- a/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-jupyterlab-git.robot
@@ -21,7 +21,7 @@ ${COMMIT_MSG}       commit msg2
 Verify Pushing Project Changes Remote Repository
     [Documentation]    Verifies that changes has been pushed successfully to remote repository
     [Tags]    ODS-326
-    ...       Sanity    Tier1
+    ...       Tier1
     Set Staging Status
     ${randnum}=    Generate Random String    9    [NUMBERS]
     ${commit_message}=    Catenate    ${COMMIT_MSG}    ${randnum}
@@ -36,7 +36,7 @@ Verify Pushing Project Changes Remote Repository
 Verify Updating Project With Changes From Git Repository
     [Documentation]    Verifies that changes has been pulled successfully to local repository
     [Tags]    ODS-324
-    ...       Sanity    Tier1
+    ...       Tier1
     Set Staging Status
     Clone Git Repository And Open    ${REPO_URL}    ${FILE_PATH}
     Sleep    1s

--- a/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-versions.robot
@@ -25,41 +25,41 @@ ${JupyterLab-git_Version}     v0.44
 *** Test Cases ***
 Open JupyterHub Spawner Page
     [Documentation]    Verifies that Spawner page can be loaded
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-695
     Pass Execution    Passing tests, as suite setup ensures that spawner can be loaded
 
 Verify Libraries in Minimal Image
     [Documentation]    Verifies libraries in Minimal Python image
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     Verify List Of Libraries In Image    minimal-notebook    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Cuda Image
     [Documentation]    Verifies libraries in Cuda image
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     Verify List Of Libraries In Image    minimal-gpu    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in SDS Image
     [Documentation]    Verifies libraries in Standard Data Science image
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     Verify List Of Libraries In Image    science-notebook    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}
     ...    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in PyTorch Image
     [Documentation]    Verifies libraries in PyTorch image
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-215    ODS-216    ODS-217    ODS-218    ODS-466
     Verify List Of Libraries In Image    pytorch    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Tensorflow Image
     [Documentation]    Verifies libraries in Tensorflow image
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-204    ODS-205    ODS-206    ODS-207  ODS-474
     Verify List Of Libraries In Image    tensorflow    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify All Images And Spawner
     [Documentation]    Verifies that all images have the correct libraries with same versions
-    [Tags]    Sanity    Tier1
+    [Tags]    Tier1
     ...       ODS-340    ODS-452    ODS-468
     List Should Not Contain Value    ${status_list}    FAIL
     ${length} =    Get Length    ${status_list}

--- a/ods_ci/tests/Tests/500__jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test.robot
@@ -16,7 +16,7 @@ Test Tags        JupyterHub
 
 *** Test Cases ***
 Logged Into OpenShift
-    [Tags]   Sanity    Smoke
+    [Tags]   Smoke
     ...      Tier1
     ...      ODS-127
     Open OCP Console
@@ -24,7 +24,7 @@ Logged Into OpenShift
     Wait Until OpenShift Console Is Loaded
 
 Can Launch Jupyterhub
-    [Tags]   Sanity    Smoke
+    [Tags]   Smoke
     ...      Tier1
     ...      ODS-935
     #This keyword will work with accounts that are not cluster admins.
@@ -34,7 +34,7 @@ Can Launch Jupyterhub
     Launch Jupyter From RHODS Dashboard Link
 
 Can Login To Jupyterhub
-    [Tags]   Sanity    Smoke
+    [Tags]   Smoke
     ...      Tier1
     ...      ODS-936
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
@@ -43,7 +43,7 @@ Can Login To Jupyterhub
     Wait Until Page Contains  Start a notebook server
 
 Can Spawn Notebook
-    [Tags]  Sanity  Smoke
+    [Tags]  Smoke
     ...     Tier1
     ...     ODS-1808
     Fix Spawner Status


### PR DESCRIPTION
This change is to reduce the execution time of the Sanity tests. Removing many tests from Sanity and keeping it only in Smoke or Tier1.

* https://issues.redhat.com/browse/RHOAIENG-7490