### PR TITLE
Added support for grpc in vllm

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
+++ b/ods_ci/tests/Resources/Files/llm/model_expected_responses.json
@@ -176,6 +176,26 @@
                     }
                 }
             }
+        },
+        {
+            "query_text": "San Francisco is a",
+            "models": {
+                "llama-2-13b-chat":{
+                    "vllm-runtime": {
+                        "completions_response_text": "{\"object\":\"text_completion\",\"created\":,\"model\":\"llama-2-13b-chat\",\"choices\":[{\"index\":0,\"text\":\" beautiful city that is full of life and energy. Located along the San Francisco\",\"logprobs\":null,\"finish_reason\":\"length\",\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":5,\"total_tokens\":21,\"completion_tokens\":16}}"
+                    }
+                }
+            }
+        },
+        {
+            "query_text": "{'role': 'user' , 'content' : 'Say this is a test!'}",
+            "models": {
+                "llama-2-13b-chat":{
+                    "vllm-runtime": {
+                        "chat-completions_response_text": "{\"object\":\"chat.completion\",\"created\":,\"model\":\"llama-2-13b-chat\",\"choices\":[{\"index\":0,\"message\":{\"role\":\"assistant\",\"content\":\"  This is a test!\"},\"logprobs\":null,\"finish_reason\":\"stop\",\"stop_reason\":null}],\"usage\":{\"prompt_tokens\":15,\"total_tokens\":22,\"completion_tokens\":7}}"
+                    }
+                }
+            }
         }
     ],
     "model-info": {

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/vllm_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/vllm_servingruntime_grpc.yaml
@@ -1,0 +1,29 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: ServingRuntime
+metadata:
+  name: vllm-runtime
+spec:
+  builtInAdapter:
+    modelLoadingTimeoutMillis: 90000
+  containers:
+    - args:
+        - --model
+        - /mnt/models/
+        - --download-dir
+        - /models-cache
+        - --port
+        - "8080"
+      image: quay.io/opendatahub/vllm:fast-ibm-nightly-2024-05-21
+      name: kserve-container
+      command:
+        - python3
+        - '-m'
+        - vllm.entrypoints.openai.api_server
+      ports:
+        - containerPort: 8033
+          name: h2c
+          protocol: TCP
+  multiModel: false
+  supportedModelFormats:
+    - autoSelect: true
+      name: pytorch

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/422__model_serving_llm_models.robot
@@ -161,7 +161,7 @@ Verify User Can Serve And Query A google/flan-t5-xxl Model
 
 Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
-    ...                using Kserve and TGIS standalone runtime
+    ...                using Kserve and TGIS standalone or vllm runtime
     [Tags]    RHOAIENG-3479     VLLM
     Setup Test Variables    model_name=elyza-japanese    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}    model_path=ELYZA-japanese-Llama-2-7b-instruct-hf
@@ -187,10 +187,11 @@ Verify User Can Serve And Query A elyza/elyza-japanese-llama-2-7b-instruct Model
     ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
     ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
-    IF   "${RUNTIME_NAME}" == "tgis-runtime" and "${KSERVE_MODE}" == "RawDeployment"
+    IF     "${RUNTIME_NAME}" == "tgis-runtime" or "${KSERVE_MODE}" == "RawDeployment"
+            Set Test Variable    ${RUNTIME_NAME}    tgis-runtime
             Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
             ...    inference_type=all-tokens    n_times=1    protocol=${PROTOCOL}
-            ...    namespace=${test_namespace}   query_idx=4    validate_response=${TRUE}    # temp
+            ...    namespace=${test_namespace}   query_idx=4    validate_response=${FALSE}    # temp
             ...    port_forwarding=${use_port_forwarding}
             Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
             ...    inference_type=streaming    n_times=1    protocol=${PROTOCOL}
@@ -351,20 +352,25 @@ Verify User Can Serve And Query A codellama/codellama-34b-instruct-hf Model
 
 Verify User Can Serve And Query A meta-llama/llama-2-13b-chat Model
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
-    ...                using Kserve and TGIS standalone runtime
-    [Tags]    RHOAIENG-3483
+    ...                using Kserve and TGIS standalone or vllm runtime
+    [Tags]    RHOAIENG-3483    VLLM
     Setup Test Variables    model_name=llama-2-13b-chat    use_pvc=${USE_PVC}    use_gpu=${USE_GPU}
     ...    kserve_mode=${KSERVE_MODE}    model_path=Llama-2-13b-chat-hf
     Set Project And Runtime    runtime=${RUNTIME_NAME}     namespace=${test_namespace}
-    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}
+    ...    download_in_pvc=${DOWNLOAD_IN_PVC}    model_name=${model_name}    protocol=${PROTOCOL}
     ...    storage_size=70Gi    model_path=${model_path}
     ${requests}=    Create Dictionary    memory=40Gi
-    ${overlays}=    Create List
+    IF    "${OVERLAY}" != "${EMPTY}"
+          ${overlays}=   Create List    ${OVERLAY}
+    ELSE
+          ${overlays}=   Create List
+    END
     Compile Inference Service YAML    isvc_name=${model_name}
     ...    sa_name=${EMPTY}
     ...    model_storage_uri=${storage_uri}
     ...    model_format=${MODEL_FORMAT}    serving_runtime=${RUNTIME_NAME}
     ...    limits_dict=${limits}    requests_dict=${requests}    kserve_mode=${KSERVE_MODE}
+    ...    overlays=${overlays}
     Deploy Model Via CLI    isvc_filepath=${INFERENCESERVICE_FILLED_FILEPATH}
     ...    namespace=${test_namespace}
     Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
@@ -372,22 +378,32 @@ Verify User Can Serve And Query A meta-llama/llama-2-13b-chat Model
     ${pod_name}=  Get Pod Name    namespace=${test_namespace}    label_selector=serving.kserve.io/inferenceservice=${model_name}
     Run Keyword If    "${KSERVE_MODE}"=="RawDeployment"
     ...    Start Port-forwarding    namespace=${test_namespace}    pod_name=${pod_name}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=all-tokens    n_times=1    protocol=${PROTOCOL}
-    ...    namespace=${test_namespace}   query_idx=0   validate_response=${TRUE}    # temp
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=streaming    n_times=1    protocol=${PROTOCOL}
-    ...    namespace=${test_namespace}    query_idx=0    validate_response=${FALSE}
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=model-info    n_times=0
-    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
-    ...    port_forwarding=${use_port_forwarding}
-    Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
-    ...    inference_type=tokenize    n_times=0    query_idx=0
-    ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
-    ...    port_forwarding=${use_port_forwarding}
+    IF     "${RUNTIME_NAME}" == "tgis-runtime" or "${KSERVE_MODE}" == "RawDeployment"
+            Set Test Variable    ${RUNTIME_NAME}    tgis-runtime
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=all-tokens    n_times=1    protocol=${PROTOCOL}
+            ...    namespace=${test_namespace}   query_idx=0   validate_response=${TRUE}    # temp
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=streaming    n_times=1    protocol=${PROTOCOL}
+            ...    namespace=${test_namespace}    query_idx=0    validate_response=${FALSE}
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=model-info    n_times=0
+            ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+            ...    port_forwarding=${use_port_forwarding}
+            Query Model Multiple Times    model_name=${model_name}    runtime=${RUNTIME_NAME}
+            ...    inference_type=tokenize    n_times=0    query_idx=0
+            ...    namespace=${test_namespace}    validate_response=${TRUE}    string_check_only=${TRUE}
+            ...    port_forwarding=${use_port_forwarding}
+    ELSE IF    "${RUNTIME_NAME}" == "vllm-runtime" and "${KSERVE_MODE}" == "Serverless"
+            Query Model Multiple Times    model_name=${model_name}      runtime=${RUNTIME_NAME}    protocol=http
+            ...    inference_type=chat-completions    n_times=1    query_idx=12
+            ...    namespace=${test_namespace}    string_check_only=${TRUE}
+            Query Model Multiple Times    model_name=${model_name}      runtime=${RUNTIME_NAME}    protocol=http
+            ...    inference_type=completions    n_times=1    query_idx=11
+            ...    namespace=${test_namespace}    string_check_only=${TRUE}
+    END
     [Teardown]    Run Keywords
     ...    Clean Up Test Project    test_ns=${test_namespace}
     ...    isvc_names=${models_names}    wait_prj_deletion=${FALSE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/vllm/426__model_serving_vllm_metrics.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/LLMs/vllm/426__model_serving_vllm_metrics.robot
@@ -44,7 +44,7 @@ ${TEST_NS}=                   vllm-gpt2
 *** Test Cases ***
 Verify User Can Deploy A Model With Vllm Via CLI
     [Documentation]    Deploy a model (gpt2) using the vllm runtime and confirm that it's running
-    [Tags]    Tier1    Sanity    Resources-GPU    RHOAIENG-6264
+    [Tags]    Tier1    Sanity    Resources-GPU    RHOAIENG-6264   VLLM
     ${rc}    ${out}=    Run And Return Rc And Output    oc apply -f ${DL_POD_FILEPATH}
     Should Be Equal As Integers    ${rc}    ${0}
     Wait For Pods To Succeed    label_selector=gpt-download-pod=true    namespace=${TEST_NS}


### PR DESCRIPTION
for serverless:

`sh ods_ci/run_robot_test.sh --skip-oclogin true --extra-robot-args '-i VLLM  --variable RUNTIME_NAME:vllm-runtime --variable USE_GPU:"${TRUE}" --variable KSERVE_MODE:Serverless --variable PROTOCOL:http  --variable OVERLAY:vllm'`

raw(grpc):
sh ods_ci/run_robot_test.sh --skip-oclogin true --extra-robot-args '-i VLLM --variable RUNTIME_NAME:vllm-runtime --variable USE_GPU:"${TRUE}" --variable KSERVE_MODE:RawDeployment --variable PROTOCOL:grpc  --variable OVERLAY:vllm'
