### PR TITLE
Add option in fetch_new_test.py to automatically fetch previous release branch

### DIFF
--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -63,18 +63,16 @@ def get_branch(ref_to_exclude, selector_attribute):
     List the remote branches and sort by last commit date (ASC order), exclude $ref_to_exclude and get latest
     """
     ref_to_exclude_esc = ref_to_exclude.replace("/", r"\/")
-    if "master" in ref_to_exclude or "main" in ref_to_exclude:
-        cmd = f"git branch -r --sort={selector_attribute} | grep releases/"
-    else:
-        cmd = rf"git branch -r --sort={selector_attribute} | grep releases/  | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)'"
+    cmd = f"git branch -r --sort={selector_attribute} | grep releases/"
+    if "master" not in ref_to_exclude and "main" not in ref_to_exclude:
+        cmd += rf" | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)'"
     ret = execute_command(cmd)
     branches = ret.split(" ")
-    ret = branches[-1].split("\x00")[0].strip().replace("\n", "")
-    if ret != "":
-        print(f"Done. {ret} branch selected as ref_2")
-        return ret
-    else:
+    branch = branches[-1].split("\x00")[0].strip().replace("\n", "")
+    if not branch or "fatal:" in branch:
         raise Exception("Failed to auto-selecting ref_2 branch.")
+    print(f"Done. {branch} branch selected as ref_2")
+    return branch
 
 
 def extract_test_cases_from_ref(repo_local_path, ref, auto=False, selector_attribute=None, ref_to_exclude=None):

--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -25,7 +25,7 @@ def get_repository(test_repo):
     if "http" in test_repo or "git@" in test_repo:
         print("Cloning repo ", test_repo)
         cloned = True
-        ret = execute_command(f"git clone {test_repo} {repo_local_path}")
+        execute_command(f"git clone {test_repo} {repo_local_path}")
     elif not os.path.exists(test_repo):
         raise FileNotFoundError(f"local path {test_repo} was not found")
     else:
@@ -38,8 +38,8 @@ def checkout_repository(ref):
     """
     Checkouts the repository at current directory to the given branch/commit ($ref)
     """
-    ret = execute_command(f"git checkout {ref}")
-    ret = execute_command("git checkout")
+    execute_command(f"git checkout {ref}")
+    execute_command("git checkout")
 
 
 def get_branch(ref_to_exclude, selector_attribute):

--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -1,3 +1,19 @@
+"""
+Examples
+Input:
+python3 ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 releases/2.8.0 --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
+Output:
+---| Computing differences |----
+Done. Found 30 new tests in releases/2.8.0 which were not present in origin/releases/2.7.0
+
+Input:
+python3 ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 master  --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
+Output:
+---| Computing differences |----
+Done. Found 14 new tests in master which were not present in origin/releases/2.9.0
+
+"""
+
 import argparse
 import os
 import shutil

--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -23,9 +23,6 @@ def get_repository(test_repo):
     if "http" in test_repo or "git@" in test_repo:
         print("Cloning repo ", test_repo)
         ret = execute_command(f"git clone {test_repo} {repo_local_path}")
-        if "error" in ret.lower():
-            # actual error gets printed during "execute_command"
-            raise Exception("Failed to clone the given repository")
     elif not os.path.exists(test_repo):
         raise FileNotFoundError(f"local path {test_repo} was not found")
     else:
@@ -38,11 +35,7 @@ def checkout_repository(ref):
     """
     Checkouts the repository at current directory to the given branch/commit ($ref)
     """
-    ref_escaped = ref.strip().replace("\n", "")
-    ret = execute_command(f"git checkout {ref_escaped}")
-    if "error" in ret.lower():
-        # actual error gets printed during "execute_command"
-        raise Exception(f"Failed to checkout to the given branch/commit {ref}")
+    ret = execute_command(f"git checkout {ref}")
     ret = execute_command("git checkout")
 
 
@@ -52,8 +45,10 @@ def get_branch(ref_to_exclude, selector_attribute):
     """
     ref_to_exclude_esc = ref_to_exclude.replace("/", "\/")
     ret = execute_command(
-        f"git branch -r --sort={selector_attribute} | grep releases/  | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)' | tail -n 2"
+        f"git branch -r --sort={selector_attribute} | grep releases/  | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)'"
     )
+    branches = ret.split(" ")
+    ret = branches[-1].split('\x00')[0].strip().replace("\n", "")
     if ret != "":
         print(f"Done. {ret} branch selected as ref_2")
         return ret

--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -38,7 +38,8 @@ def checkout_repository(ref):
     """
     Checkouts the repository at current directory to the given branch/commit ($ref)
     """
-    ret = execute_command(f"git checkout {ref}")
+    ref_escaped = ref.strip().replace("\n", "")
+    ret = execute_command(f"git checkout {ref_escaped}")
     if "error" in ret.lower():
         # actual error gets printed during "execute_command"
         raise Exception(f"Failed to checkout to the given branch/commit {ref}")
@@ -49,7 +50,10 @@ def get_branch(ref_to_exclude, selector_attribute):
     """
     List the remote branches and sort by last commit date (ASC order), exclude $ref_to_exclude and get latest
     """
-    ret = execute_command(f"git branch -a --sort={selector_attribute} | grep releases/ | grep -v {ref_to_exclude}$ | tail -1")
+    ref_to_exclude_esc = ref_to_exclude.replace("/", "\/")
+    ret = execute_command(
+        f"git branch -r --sort={selector_attribute} | grep releases/  | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)' | tail -n 2"
+    )
     if ret != "":
         print(f"Done. {ret} branch selected as ref_2")
         return ret


### PR DESCRIPTION
In order to ease the integration in our CI/CI, this PR adds the option `--ref2-auto` and `--selector-attribute ` allowing the script to automatically select the previous releases branch of ods-ci wrt `--ref1`

Example of usage: 
```
python3 ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 releases/2.8.0 --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
```
```
python3 ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 master  --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
```
Output: 
```
---| Computing differences |----
Done. Found 30 new tests in releases/2.8.0 which were not present in origin/releases/2.7.0
```
```
---| Computing differences |----
Done. Found 14 new tests in master which were not present in origin/releases/2.9.0
```