### PR TITLE
[Backport 2.9] Bumping default retry to 150 in Wait Until Operator Subscription Last Condition Is

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -366,6 +366,7 @@ Install Kserve Dependencies
           Wait Until Operator Subscription Last Condition Is
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${AUTHORINO_SUB_NAME}
+          ...    retry=150
     ELSE
           Log To Console    message=Authorino Operator is already installed
     END
@@ -377,6 +378,7 @@ Install Kserve Dependencies
           Wait Until Operator Subscription Last Condition Is
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${SERVICEMESH_SUB_NAME}
+          ...    retry=150
     ELSE
           Log To Console    message=ServiceMesh Operator is already installed
     END
@@ -393,7 +395,8 @@ Install Kserve Dependencies
           Wait Until Operator Subscription Last Condition Is
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${SERVERLESS_SUB_NAME}
-          ...    namespace=${SERVERLESS_NS}    retry=100
+          ...    namespace=${SERVERLESS_NS}
+          ...    retry=150
           Wait For Pods To Be Ready    label_selector=name=knative-openshift
           ...    namespace=${SERVERLESS_NS}
           Wait For Pods To Be Ready    label_selector=name=knative-openshift-ingress

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -66,7 +66,8 @@ Wait Until Operator Subscription Last Condition Is    # robocop: disable
     [Documentation]    Keeps checking until the subscription status matches the expected status
     [Arguments]    ${type}    ${status}    ${reason}
     ...    ${subcription_name}    ${namespace}=openshift-operators
-    ...    ${retry}=20    ${retry_interval}=3s
+    ...    ${retry}=60
+    ...    ${retry_interval}=3s
     Wait Until Keyword Succeeds    ${retry} times    ${retry_interval}    Operator Subscription Last Condition Should Be    # robocop: disable
     ...    type=${type}     status=${status}
     ...    reason=${reason}    subcription_name=${subcription_name}


### PR DESCRIPTION
Backports https://github.com/red-hat-data-services/ods-ci/pull/1470 to releases/2.9.0 branch