### PR TITLE
Moved API to v2beta1

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesAPI.py
+++ b/ods_ci/libs/DataSciencePipelinesAPI.py
@@ -55,7 +55,7 @@ class DataSciencePipelinesAPI:
         count = 0
         while status != 200 and count < timeout:
             response, status = self.do_get(
-                f"https://{self.route}/apis/v1beta1/runs",
+                f"https://{self.route}/apis/v2beta1/runs",
                 headers={"Authorization": f"Bearer {self.sa_token}"},
             )
             # 503 -> service not deployed

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -28,7 +28,7 @@ Install DataSciencePipelinesApplication CR
     Oc Apply    kind=DataSciencePipelinesApplication    src=${DATA_SCIENCE_PIPELINES_APPLICATION_PATH}/${dsp_file}    namespace=${project}
     IF    ${assert_install}==True
         ${generation_value}    Run    oc get datasciencepipelinesapplications -n ${project} -o json | jq '.items[0].metadata.generation'
-        Should Be True    ${generation_value} == 1    DataSciencePipelinesApplication created
+        Should Be True    ${generation_value} == 2    DataSciencePipelinesApplication created
     END
 
 Fill In Pipeline Import Form

--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/431__data-science-pipelines-api.robot
@@ -33,9 +33,9 @@ Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     ${status}    Login And Wait Dsp Route    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     ...         project-redirect-http
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long
-    ${url}    Do Http Request    apis/v1beta1/runs
+    ${url}    Do Http Request    apis/v2beta1/runs
     Should Start With    ${url}    https
-    Remove Pipeline Project    project-redirect-http
+    [Teardown]    Remove Pipeline Project    project-redirect-http
 
 Verify DSPO Operator Reconciliation Retry
     [Documentation]    Verify DSPO Operator is able to recover from missing components during the initialization


### PR DESCRIPTION
Found the leftovers during JIRA verification. Most the API are compatible, nothing to worry about

```
sh ods_ci/run_robot_test.sh --set-urls-variables true --extra-robot-args '-L DEBUG -i ODS-2234' --skip-oclogin

Error from server (NotFound): namespaces "project-redirect-http" not found
Verify Ods Users Can Do Http Request That Must Be Redirected to Ht... | PASS |
------------------------------------------------------------------------------
Tests.Ods Dashboard.Data Science Pipelines.Data-Science-Pipelines-... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard.Data Science Pipelines                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Ods Dashboard                                                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
==============================================================================
```
