### PR TITLE
Add tagger date and version:refname sort attribute for fetching releases branches

### DIFF
--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -63,7 +63,7 @@ def checkout_repository(ref):
 
 def get_branch(ref_to_exclude, selector_attribute):
     """
-    List the remote branches and sort by last commit date (ASC order), exclude $ref_to_exclude and get latest
+    List the remote branches and sort by selector_attribute date (ASC order), exclude $ref_to_exclude and get latest
     """
     ref_to_exclude_esc = ref_to_exclude.replace("/", r"\/")
     cmd = f"git branch -r --sort={selector_attribute} | grep releases/"
@@ -195,8 +195,8 @@ if __name__ == "__main__":
         help="Select the git attribute to use when --ref2-auto is enabled",
         action="store",
         dest="selector_attribute",
-        choices=["creatordate", "committerdate", "authordate"],
-        default="creatordate",
+        choices=["creatordate", "committerdate", "authordate", "taggerdate", "version:refname"],
+        default="version:refname",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
the currently supported attribute to sort branches in fetch_tests.py script may give wrong results if an older branch gets updated (e.g., backporting new ods-ci patches to releases/2.8.0 branch).

With this PR we will have `taggerdate` (date of tag creation) and `version:refname` (taking branch name as prod version). I think the second one might be better to use.