### PR TITLE
[2.8] Add tagger date and version:refname sort attribute for fetching releases branches

### DIFF
--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -60,7 +60,7 @@ def checkout_repository(ref):
 
 def get_branch(ref_to_exclude, selector_attribute):
     """
-    List the remote branches and sort by last commit date (ASC order), exclude $ref_to_exclude and get latest
+    List the remote branches and sort by selector_attribute date (ASC order), exclude $ref_to_exclude and get latest
     """
     ref_to_exclude_esc = ref_to_exclude.replace("/", r"\/")
     cmd = f"git branch -r --sort={selector_attribute} | grep releases/"
@@ -192,8 +192,8 @@ if __name__ == "__main__":
         help="Select the git attribute to use when --ref2-auto is enabled",
         action="store",
         dest="selector_attribute",
-        choices=["creatordate", "committerdate", "authordate"],
-        default="creatordate",
+        choices=["creatordate", "committerdate", "authordate", "taggerdate", "version:refname"],
+        default="version:refname",
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
backporting https://github.com/red-hat-data-services/ods-ci/pull/1503 into releases/2.8.0 branch