### PR TITLE
[fix] must-gather test to use the image targeted for 2.8.3

### DIFF
--- a/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Redirecting stdout/stderr of must-gather to a file, as it fills up the
 # process buffer and prevents the script from running further.
-oc adm must-gather --image=quay.io/modh/must-gather@sha256:c2d780156a0e7cec975c9c150bee00b1facb8f6213e7b98a7a489448d76dfd94 &> must-gather-results.txt
+oc adm must-gather --image=quay.io/modh/must-gather@sha256:f49988620efc6227f931c964e45e935838406340a096db84f5736c05066f1cc6 &> must-gather-results.txt
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
There was, yet again, accidentally build a new stable image of must-gather meaning that the image was updated. Technically no changes got in, but since its a new build, some packages and dependencies may be of a newer version than before.

Anyway, it was decided that we're gonna use this for the release unfortunatelly...