### PR TITLE
RHOAIENG-6517 Automate support for configuration of controller resources

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -93,22 +93,16 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
         Set Suite Variable    ${AUTHORINO_CR_NS}    redhat-ods-applications-auth-provider
-<<<<<<< Updated upstream
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=rhods-dashboard
-=======
         Set Suite Variable    ${APPLICATIONS_NAMESPACE}    redhat-ods-applications
->>>>>>> Stashed changes
     ELSE IF    "${PRODUCT}" == "ODH"
         Set Suite Variable    ${OPERATOR_APPNAME}  Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_NAME}    Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
         Set Suite Variable    ${AUTHORINO_CR_NS}    opendatahub-auth-provider
-<<<<<<< Updated upstream
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
-=======
         Set Suite Variable    ${APPLICATIONS_NAMESPACE}    opendatahub
->>>>>>> Stashed changes
     END

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -93,14 +93,22 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
         Set Suite Variable    ${AUTHORINO_CR_NS}    redhat-ods-applications-auth-provider
+<<<<<<< Updated upstream
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=rhods-dashboard
+=======
+        Set Suite Variable    ${APPLICATIONS_NAMESPACE}    redhat-ods-applications
+>>>>>>> Stashed changes
     ELSE IF    "${PRODUCT}" == "ODH"
         Set Suite Variable    ${OPERATOR_APPNAME}  Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_NAME}    Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
         Set Suite Variable    ${AUTHORINO_CR_NS}    opendatahub-auth-provider
+<<<<<<< Updated upstream
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
+=======
+        Set Suite Variable    ${APPLICATIONS_NAMESPACE}    opendatahub
+>>>>>>> Stashed changes
     END

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
@@ -30,12 +30,9 @@ ${IS_NOT_PRESENT}    1
 ...  KUEUE=${EMPTY}
 ...  CODEFLARE=${EMPTY}
 ...  TRAINING=${EMPTY}
-<<<<<<< Updated upstream
 ...  DASHBOARD=${EMPTY}
 ...  DATASCIENCEPIPELINES=${EMPTY}
-=======
 @{CONTROLLERS_LIST} =    kserve-controller-manager    odh-model-controller    modelmesh-controller
->>>>>>> Stashed changes
 
 
 *** Test Cases ***
@@ -92,13 +89,8 @@ Validate Ray Removed State
 
 Validate Training Operator Managed State
     [Documentation]    Validate that the DSC Training Operator component Managed state creates the expected resources,
-<<<<<<< Updated upstream
     ...    check that Training deployment is created and pod is in Ready state
     [Tags]    Operator    Tier1    RHOAIENG-6627    training-managed
-=======
-    ...    check that Training deployment and pod are created
-    [Tags]    Operator    Tier1    RHOAIENG-g    training-managed
->>>>>>> Stashed changes
 
     Set DSC Component Managed State And Wait For Completion   trainingoperator    ${TRAINING_DEPLOYMENT_NAME}    ${TRAINING_LABEL_SELECTOR}
 
@@ -112,7 +104,6 @@ Validate Training Operator Removed State
 
     [Teardown]     Restore DSC Component State    trainingoperator    ${TRAINING_DEPLOYMENT_NAME}    ${TRAINING_LABEL_SELECTOR}    ${SAVED_MANAGEMENT_STATES.TRAINING}
 
-<<<<<<< Updated upstream
 Validate Dashboard Managed State
     [Documentation]    Validate that the DSC Dashboard component Managed state creates the expected resources,
     ...    check that Dashboard deployment is created and all pods are in Ready state
@@ -146,7 +137,6 @@ Validate Datasciencepipelines Removed State
     Set DSC Component Removed State And Wait For Completion   datasciencepipelines    ${DATASCIENCEPIPELINES_DEPLOYMENT_NAME}    ${DATASCIENCEPIPELINES_LABEL_SELECTOR}
 
     [Teardown]     Restore DSC Component State    datasciencepipelines    ${DATASCIENCEPIPELINES_DEPLOYMENT_NAME}    ${DATASCIENCEPIPELINES_LABEL_SELECTOR}    ${SAVED_MANAGEMENT_STATES.DATASCIENCEPIPELINES}
-=======
 Validate Support For Configuration Of Controller Resources
     [Documentation]    Validate support for configuration of controller resources in component deployments
     [Tags]    Operator    Tier1    ODS-2664
@@ -176,14 +166,12 @@ Validate Support For Configuration Of Controller Resources
         Should Be Equal As Integers    ${rc}    ${0}
     END
 
->>>>>>> Stashed changes
 
 
 *** Keywords ***
 Suite Setup
     [Documentation]    Suite Setup
     RHOSi Setup
-<<<<<<< Updated upstream
     Wait For DSC Conditions Reconciled    ${OPERATOR_NS}     ${DSC_NAME}
     ${SAVED_MANAGEMENT_STATES.RAY}=     Get DSC Component State    ${DSC_NAME}    ray    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.KUEUE}=     Get DSC Component State    ${DSC_NAME}    kueue    ${OPERATOR_NS}
@@ -192,14 +180,6 @@ Suite Setup
     ${SAVED_MANAGEMENT_STATES.DASHBOARD}=     Get DSC Component State    ${DSC_NAME}    dashboard    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.DATASCIENCEPIPELINES}=     Get DSC Component State    ${DSC_NAME}    datasciencepipelines    ${OPERATOR_NS}
     Set Suite Variable    ${SAVED_MANAGEMENT_STATES}
-=======
-    # Wait For DSC Conditions Reconciled    ${OPERATOR_NS}     ${DSC_NAME}
-    # ${SAVED_MANAGEMENT_STATES.RAY}=     Get DSC Component State    ${DSC_NAME}    ray    ${OPERATOR_NS}
-    # ${SAVED_MANAGEMENT_STATES.KUEUE}=     Get DSC Component State    ${DSC_NAME}    kueue    ${OPERATOR_NS}
-    # ${SAVED_MANAGEMENT_STATES.CODEFLARE}=     Get DSC Component State    ${DSC_NAME}    codeflare    ${OPERATOR_NS}
-    # ${SAVED_MANAGEMENT_STATES.TRAINING}=     Get DSC Component State    ${DSC_NAME}    trainingoperator    ${OPERATOR_NS}
-    # Set Suite Variable    ${SAVED_MANAGEMENT_STATES}
->>>>>>> Stashed changes
 
 Suite Teardown
     [Documentation]    Suite Teardown

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
@@ -161,7 +161,7 @@ Validate Support For Configuration Of Controller Resources
         Should Not Match    ${d_obj_dictionary.spec.template.spec.serviceAccountName}    random-sa-name
         # Restore old values
         # delete the Deployment resource for operator to recreate 
-        ${rc}    ${out}=    Run And Return Rc And Output
+        ${rc}=    Run And Return Rc
         ...    oc delete Deployment ${controller} -n ${APPLICATIONS_NAMESPACE}
         Should Be Equal As Integers    ${rc}    ${0}
     END

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/142__dsc_components.robot
@@ -30,8 +30,12 @@ ${IS_NOT_PRESENT}    1
 ...  KUEUE=${EMPTY}
 ...  CODEFLARE=${EMPTY}
 ...  TRAINING=${EMPTY}
+<<<<<<< Updated upstream
 ...  DASHBOARD=${EMPTY}
 ...  DATASCIENCEPIPELINES=${EMPTY}
+=======
+@{CONTROLLERS_LIST} =    kserve-controller-manager    odh-model-controller    modelmesh-controller
+>>>>>>> Stashed changes
 
 
 *** Test Cases ***
@@ -88,8 +92,13 @@ Validate Ray Removed State
 
 Validate Training Operator Managed State
     [Documentation]    Validate that the DSC Training Operator component Managed state creates the expected resources,
+<<<<<<< Updated upstream
     ...    check that Training deployment is created and pod is in Ready state
     [Tags]    Operator    Tier1    RHOAIENG-6627    training-managed
+=======
+    ...    check that Training deployment and pod are created
+    [Tags]    Operator    Tier1    RHOAIENG-g    training-managed
+>>>>>>> Stashed changes
 
     Set DSC Component Managed State And Wait For Completion   trainingoperator    ${TRAINING_DEPLOYMENT_NAME}    ${TRAINING_LABEL_SELECTOR}
 
@@ -103,6 +112,7 @@ Validate Training Operator Removed State
 
     [Teardown]     Restore DSC Component State    trainingoperator    ${TRAINING_DEPLOYMENT_NAME}    ${TRAINING_LABEL_SELECTOR}    ${SAVED_MANAGEMENT_STATES.TRAINING}
 
+<<<<<<< Updated upstream
 Validate Dashboard Managed State
     [Documentation]    Validate that the DSC Dashboard component Managed state creates the expected resources,
     ...    check that Dashboard deployment is created and all pods are in Ready state
@@ -136,12 +146,44 @@ Validate Datasciencepipelines Removed State
     Set DSC Component Removed State And Wait For Completion   datasciencepipelines    ${DATASCIENCEPIPELINES_DEPLOYMENT_NAME}    ${DATASCIENCEPIPELINES_LABEL_SELECTOR}
 
     [Teardown]     Restore DSC Component State    datasciencepipelines    ${DATASCIENCEPIPELINES_DEPLOYMENT_NAME}    ${DATASCIENCEPIPELINES_LABEL_SELECTOR}    ${SAVED_MANAGEMENT_STATES.DATASCIENCEPIPELINES}
+=======
+Validate Support For Configuration Of Controller Resources
+    [Documentation]    Validate support for configuration of controller resources in component deployments
+    [Tags]    Operator    Tier1    ODS-2664
+    FOR   ${controller}    IN    @{CONTROLLERS_LIST}
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    oc patch Deployment ${controller} -n ${APPLICATIONS_NAMESPACE} --type=json -p="[{'op': 'replace', 'path': '/spec/template/spec/containers/0/resources/limits/cpu', 'value': '600m'}]"    # robocop: disable
+        Should Be Equal As Integers    ${rc}    ${0}
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    oc patch Deployment ${controller} -n ${APPLICATIONS_NAMESPACE} --type=json -p="[{'op': 'replace', 'path': '/spec/template/spec/containers/0/resources/limits/memory', 'value': '6Gi'}]"    # robocop: disable
+        Should Be Equal As Integers    ${rc}    ${0}
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    oc patch Deployment ${controller} -n ${APPLICATIONS_NAMESPACE} --type=json -p="[{'op': 'replace', 'path': '/spec/template/spec/serviceAccountName', 'value': 'random-sa-name'}]"    # robocop: disable
+        Should Be Equal As Integers    ${rc}    ${0}
+        Sleep  40  reason=Wait until Deployment is reloaded after being overwritten by Operator
+        @{d_obj} =  OpenShiftLibrary.Oc Get  kind=Deployment  name=${controller}    namespace=${APPLICATIONS_NAMESPACE}
+        &{d_obj_dictionary} =  Set Variable  ${d_obj}[0]    
+        ${cpu_limit}=    Set Variable    ${d_obj_dictionary.spec.template.spec.containers[0].resources.limits.cpu}
+        ${memory_limit}=    Set Variable    ${d_obj_dictionary.spec.template.spec.containers[0].resources.limits.memory}
+        ${sa_name}=    Set Variable    ${d_obj_dictionary.spec.template.spec.serviceAccountName}
+        Should Match    ${d_obj_dictionary.spec.template.spec.containers[0].resources.limits.cpu}    ${cpu_limit}
+        Should Match    ${d_obj_dictionary.spec.template.spec.containers[0].resources.limits.memory}    ${memory_limit}
+        Should Not Match    ${d_obj_dictionary.spec.template.spec.serviceAccountName}    random-sa-name
+        # Restore old values
+        # delete the Deployment resource for operator to recreate 
+        ${rc}    ${out}=    Run And Return Rc And Output
+        ...    oc delete Deployment ${controller} -n ${APPLICATIONS_NAMESPACE}
+        Should Be Equal As Integers    ${rc}    ${0}
+    END
+
+>>>>>>> Stashed changes
 
 
 *** Keywords ***
 Suite Setup
     [Documentation]    Suite Setup
     RHOSi Setup
+<<<<<<< Updated upstream
     Wait For DSC Conditions Reconciled    ${OPERATOR_NS}     ${DSC_NAME}
     ${SAVED_MANAGEMENT_STATES.RAY}=     Get DSC Component State    ${DSC_NAME}    ray    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.KUEUE}=     Get DSC Component State    ${DSC_NAME}    kueue    ${OPERATOR_NS}
@@ -150,6 +192,14 @@ Suite Setup
     ${SAVED_MANAGEMENT_STATES.DASHBOARD}=     Get DSC Component State    ${DSC_NAME}    dashboard    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.DATASCIENCEPIPELINES}=     Get DSC Component State    ${DSC_NAME}    datasciencepipelines    ${OPERATOR_NS}
     Set Suite Variable    ${SAVED_MANAGEMENT_STATES}
+=======
+    # Wait For DSC Conditions Reconciled    ${OPERATOR_NS}     ${DSC_NAME}
+    # ${SAVED_MANAGEMENT_STATES.RAY}=     Get DSC Component State    ${DSC_NAME}    ray    ${OPERATOR_NS}
+    # ${SAVED_MANAGEMENT_STATES.KUEUE}=     Get DSC Component State    ${DSC_NAME}    kueue    ${OPERATOR_NS}
+    # ${SAVED_MANAGEMENT_STATES.CODEFLARE}=     Get DSC Component State    ${DSC_NAME}    codeflare    ${OPERATOR_NS}
+    # ${SAVED_MANAGEMENT_STATES.TRAINING}=     Get DSC Component State    ${DSC_NAME}    trainingoperator    ${OPERATOR_NS}
+    # Set Suite Variable    ${SAVED_MANAGEMENT_STATES}
+>>>>>>> Stashed changes
 
 Suite Teardown
     [Documentation]    Suite Teardown


### PR DESCRIPTION
This Test Case validates that is possible to edit the resources fields inside controller deployment Yaml files for KServe and Model Mesh and the new values do not get overwritten by the Operator except for the fields outside of resources.