### PR TITLE
fix: wait for kserve inference host via cli

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -600,12 +600,19 @@ Traffic Should Be Redirected Based On Canary Percentage
 
 Get KServe Inference Host Via CLI
     [Documentation]    Fetches the model URL
-    [Arguments]    ${isvc_name}    ${namespace}
-    Sleep    5s
-    ${rc}    ${ksvc_host}=    Run And Return Rc And Output
-    ...    oc get isvc ${isvc_name} -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
-    # ...    oc get ksvc ${isvc_name}-predictor -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
-    Should Be Equal As Integers    ${rc}    ${0}
+    [Arguments]    ${isvc_name}    ${namespace}    ${retries}=10
+    ${ksvc_host}=    Set Variable    ""
+    ${condition1}=    Evaluate    ${ksvc_host}=="${EMPTY}"
+    ${condition2}=    Evaluate    ${retries} > 0
+    WHILE    ${condition1} and ${condition2}
+        Sleep    5s
+        ${rc}    ${ksvc_host}=    Run And Return Rc And Output
+        ...    oc get isvc ${isvc_name} -n ${namespace} -o jsonpath='{.status.url}' | cut -d'/' -f3
+        Should Be Equal As Integers    ${rc}    ${0}
+        ${retries} =    Evaluate    ${retries} - 1
+        ${condition1}=    Evaluate    "${ksvc_host}"=="${EMPTY}"
+        ${condition2}=    Evaluate    ${retries} > 0
+    END
     Should Not Be Empty    ${ksvc_host}
     RETURN    ${ksvc_host}
 


### PR DESCRIPTION
Sometimes (as we can see in the autotrigger-smoke/116 run) we were getting an empty inference endpoint even with the 5 seconds wait
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/3f6f2a2b-99e7-4dec-92a2-e647fa090369)
which was making our tests flaky.

With this PR we wait actively (5 seconds each iteration) in order to have inference endpoint when trying to retrieve it:
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/c2f681fc-91c6-4ed3-b9ef-a048efe61d24)
