### PR TITLE
Add a `trainingoperator` component to the DSC template list

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -17,22 +17,22 @@ spec:
       devFlags: <kserve_devflags>
       defaultDeploymentMode: Serverless
       managementState: <kserve_value>
+    kueue:
+      devFlags: <kueue_devflags>
+      managementState: <kueue_value>
     modelmeshserving:
       devFlags: <modelmeshserving_devflags>
       managementState: <modelmeshserving_value>
     ray:
       devFlags: <ray_devflags>
       managementState: <ray_value>
-    kueue:
-      devFlags: <kueue_devflags>
-      managementState: <kueue_value>
+    trainingoperator:
+      devFlags: <trainingoperator_devflags>
+      managementState: <trainingoperator_value>
     trustyai:
       devFlags: <trustyai_devflags>
       managementState: <trustyai_value>
     workbenches:
       devFlags: <workbenches_devflags>
       managementState: <workbenches_value>
-    trainingoperator:
-      devFlags: <trainingoperator_devflags>
-      managementState: <trainingoperator_value>
 

--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -32,4 +32,7 @@ spec:
     workbenches:
       devFlags: <workbenches_devflags>
       managementState: <workbenches_value>
+    trainingoperator:
+      devFlags: <trainingoperator_devflags>
+      managementState: <trainingoperator_value>
 

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -9,7 +9,7 @@ Resource   ../../../../tests/Resources/Page/OCPDashboard/UserManagement/Groups.r
 *** Variables ***
 ${DSC_NAME} =    default-dsc
 ${DSCI_NAME} =    default-dsci
-@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai    kueue  # robocop: disable
+@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai    kueue    trainingoperator  # robocop: disable
 ${SERVERLESS_OP_NAME}=     serverless-operator
 ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -9,7 +9,16 @@ Resource   ../../../../tests/Resources/Page/OCPDashboard/UserManagement/Groups.r
 *** Variables ***
 ${DSC_NAME} =    default-dsc
 ${DSCI_NAME} =    default-dsci
-@{COMPONENT_LIST} =    dashboard    datasciencepipelines    kserve    modelmeshserving    workbenches    codeflare    ray    trustyai    kueue    trainingoperator  # robocop: disable
+@{COMPONENT_LIST} =    codeflare
+...    dashboard
+...    datasciencepipelines
+...    kserve
+...    kueue
+...    modelmeshserving
+...    ray
+...    trainingoperator
+...    trustyai
+...    workbenches
 ${SERVERLESS_OP_NAME}=     serverless-operator
 ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless


### PR DESCRIPTION
This was added to RHOAI 2.10 as Removed by default.

In the second commit, I ordered the components alphabetically.

CI: TODO