### PR TITLE
fix mktemp on macOS

### DIFF
--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -362,7 +362,7 @@ if ! ${SUBFOLDER}; then
   case "$(uname -s)" in
     Darwin)
         # shellcheck disable=SC2046
-        TEST_ARTIFACT_DIR=$(mktemp -d  "${TEST_ARTIFACT_DIR}" -t "${TEST_ARTIFACT_DIR}"/ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)
+        TEST_ARTIFACT_DIR=$(mktemp -d  -t ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX) -p "${TEST_ARTIFACT_DIR}"
          ;;
     Linux)
         # shellcheck disable=SC2046


### PR DESCRIPTION
The creation of a temp dir in the test-output folder for ods-ci appears to be broken in macOS, causing the `run_robot_test.sh` script to fail when run on a vanilla system using all defaults.
This variation of the command will create a directory called `ods-ci-$(date +%Y-%m-%d-%H-%M)-XXXXXXXXXX)` within the TEST_ARTIFACT_DIR directory (i.e. by default `ods_ci/test-output/`).