### PR TITLE
[fix] close browser after each test in 415__ods_dashboard_projects.robot

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -10,6 +10,7 @@ Resource           ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProjec
 Suite Setup        Project Suite Setup
 Suite Teardown     Project Suite Teardown
 Test Setup         Launch Data Science Project Main Page
+Test Teardown      SeleniumLibrary.Close All Browsers
 Test Tags          Dashboard
 
 


### PR DESCRIPTION
Since each tests in this test-case starts a new browser window, let's be sure we also close it at the end of each test.

Motivation to this is an attempt to stabilize the Sanity run, where we bumped into an issue when test execution stopped for some reason at the execution of the: `Verify Event Log Is Accessible While Starting A Workbench` test. I'm not sure whether this change helps but it definitely didn't make things worse.

Examples of the failed execution:
```
17:28:56  Verify User Can Log Out And Return To Project From Jupyter Noteboo... [ WARN ] msg="pv_existent" argument not set, using default PV settings
17:29:02  [ WARN ] msg=There is probably no PVC with Display Name equal to 
17:29:58  [ WARN ] Executing keyword 'Wait Until Page Contains' failed:
17:29:58  Text 'Log in with OpenShift' did not appear in 15 seconds.
17:32:19  | FAIL |
17:32:19  Log in page did not appear as expected
17:32:19  ------------------------------------------------------------------------------
17:39:26  Verify Event Log Is Accessible While Starting A Workbench :: Verif... wrapper script does not seem to be touching the log file in /home/jenkins/workspace/rhoai/2.10/selfmanaged/cli/gcp/rhods-sanity@tmp/durable-80054c90
17:39:26  (JENKINS-48300: if on an extremely laggy filesystem, consider -Dorg.jenkinsci.plugins.durabletask.BourneShellScript.HEARTBEAT_CHECK_INTERVAL=86400)
```
and
```
18:48:11  Verify User Can Log Out And Return To Project From Jupyter Noteboo... [ WARN ] msg="pv_existent" argument not set, using default PV settings
18:48:11  [ WARN ] msg=There is probably no PVC with Display Name equal to 
18:48:50  [ WARN ] Executing keyword 'Wait Until Page Contains' failed:
18:48:50  Text 'Log in with OpenShift' did not appear in 15 seconds.
18:50:41  | PASS |
18:50:41  ------------------------------------------------------------------------------
19:19:33  Verify Event Log Is Accessible While Starting A Workbench :: Verif... [ WARN ] Keyword 'Capture Page Screenshot' could not be run on failure: Message: timeout: Timed out receiving message from renderer: 300.000
19:19:33    (Session info: chrome=123.0.6312.105)
19:19:33  Stacktrace:
19:19:33  #0 0x564459312483 <unknown>
19:19:33  #1 0x564458ffb90b <unknown>
19:19:33  #2 0x564458fe4d42 <unknown>
19:19:33  #3 0x564458fe4ae6 <unknown>
19:19:33  #4 0x564458fe2d19 <unknown>
19:19:33  #5 0x564458fe3250 <unknown>
19:19:33  #6 0x564458ff7b2d <unknown>
19:19:33  #7 0x564459007d1a <unknown>
19:19:33  #8 0x56445900d0cb <unknown>
19:19:33  #9 0x564458fe382f <unknown>
19:19:33  #10 0x564459007a92 <unknown>
19:19:33  #11 0x5644590894a5 <unknown>
19:19:33  #12 0x56445906a7d3 <unknown>
19:19:33  #13 0x564459039b0c <unknown>
19:19:33  #14 0x56445903a8de <unknown>
19:19:33  #15 0x5644592ddb1e <unknown>
19:19:33  #16 0x5644592e0f14 <unknown>
19:19:33  #17 0x5644592e09df <unknown>
19:19:33  #18 0x5644592e13e5 <unknown>
19:19:33  #19 0x5644592cf0bb <unknown>
19:19:33  #20 0x5644592e17d1 <unknown>
19:19:33  #21 0x5644592bad33 <unknown>
19:19:33  #22 0x564459301fa5 <unknown>
19:19:33  #23 0x564459302150 <unknown>
19:19:33  #24 0x564459311786 <unknown>
19:19:33  #25 0x7fefd420dc02 start_thread
```

---

CI: passed both locally and also standard sanity run, see `/job/rhods/job/rhods-sanity/1679` (in this case it didn't stuck, there's one instable test I shall check)
![image](https://github.com/red-hat-data-services/ods-ci/assets/12250881/5b4ae9ea-d43b-4db3-99c3-ce6584a497ef)
