### PR TITLE
Backport changes to release/2.8.0 branch

### DIFF
--- a/ods_ci/tests/Resources/Page/OCPLogin/OCPLogin.robot
+++ b/ods_ci/tests/Resources/Page/OCPLogin/OCPLogin.robot
@@ -15,3 +15,9 @@ Login To OCP Using API
   [Arguments]    ${username}      ${password}
   ${rc}    ${out}=    Run And Return Rc And Output    oc login $(oc whoami --show-server) -u ${username} -p ${password}  #robocop:disable
   Should Be Equal As Integers    ${rc}    ${0}
+
+Login To OCP Using API And Kubeconfig
+  [Documentation]   Login to openshift using username and password, storing credentials to Kubeconfig file
+  [Arguments]    ${username}      ${password}      ${kubeconfig}
+  ${rc}    ${out}=    Run And Return Rc And Output    oc login $(oc whoami --show-server) -u ${username} -p ${password} --kubeconfig=${kubeconfig} --insecure-skip-tls-verify=true    #robocop:disable
+  Should Be Equal As Integers    ${rc}    ${0}

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-kueue-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-kueue-e2e-tests.robot
@@ -6,17 +6,18 @@ Library           OperatingSystem
 Library           Process
 Library           OpenShiftLibrary
 Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+Resource          ../../../tests/Resources/Page/OCPLogin/OCPLogin.robot
 
 
 *** Variables ***
-${KUEUE_KUBECONFIG}         %{HOME}/.kube/config
+${KUEUE_KUBECONFIG}         %{WORKSPACE=.}/kueue-kubeconfig
 ${WORKER_NODE}              ${EMPTY}
 ${KUEUE_RELEASE_ASSETS}     %{KUEUE_RELEASE_ASSETS=https://github.com/opendatahub-io/kueue/releases/latest/download}
 
 *** Test Cases ***
 Run E2E test
     [Documentation]    Run ginkgo E2E single cluster test
-    [Tags]  Tier2
+    [Tags]  Tier1
     ...     Kueue
     ...     DistributedWorkloads
     Run Kueue E2E Test    e2e_test.go
@@ -40,6 +41,9 @@ Prepare Kueue E2E Test Suite
     IF    ${result.rc} != 0
         FAIL    Unable to retrieve e2e-singlecluster compiled binary
     END
+
+    # Store login information into dedicated config
+    Login To OCP Using API And Kubeconfig    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${KUEUE_KUBECONFIG}
 
     Enable Component    kueue
     Wait Component Ready    kueue


### PR DESCRIPTION
Backport https://github.com/red-hat-data-services/ods-ci/pull/1334/ to release/2.8.0 branch