### PR TITLE
[fix] attempt to stabilize the Elyra testing

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/435__data-science-pipelines-elyra.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/435__data-science-pipelines-elyra.robot
@@ -101,6 +101,7 @@ Elyra Pipelines SDS Setup
     ...    project_title=${PRJ_TITLE}
     Wait Until Pipeline Server Is Deployed    project_title=${PRJ_TITLE}
     Create Env Var List If RHODS Is Self-Managed
+    Sleep    15s    reason=Wait until pipeline server is detected by dashboard
 
 Elyra Pipelines SDS Teardown
     [Documentation]    Closes the browser and deletes the DS Project created


### PR DESCRIPTION
During the testing, it happens quite often that on Jenkins the Elyra tests fail. Based on the test results and screenshots, it looks like the workbench for test is being started too early after the pipelines server is created. As such, it doesn't have the runtime configuration pre-created automatically. This patch should add some wait time to Dashboard to detect the running pipeline server. It's what is used in master branch right now [1].

The code in master has been rewritten significantly already, so it doesn't make much sense to backport it fully.

* [1] https://github.com/red-hat-data-services/ods-ci/blob/ebfeefc0a9efb9e14772b118c67ccc4f3c5f6c83/ods_ci/tests/Tests/400__ods_dashboard/430__data_science_pipelines/435__data-science-pipelines-elyra.robot#L80