### PR TITLE
fix: use activeModelState to wait ISVC status

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -824,7 +824,10 @@ Wait For Model KServe Deployment To Be Ready
     ...                the deployment has the expected pods and containers
     [Arguments]    ${label_selector}    ${namespace}    ${runtime}
     ...    ${timeout}=300s    ${exp_replicas}=${1}
-    Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=${timeout}
+    # Get the model name from the label_selector variable
+    ${splitted_str}    Split String    ${label_selector}    =
+    ${model_name}    Set Variable    ${splitted_str}[1]
+    Wait For ISVC To Be Loaded     ${model_name}     ${namespace}
     Verify Model KServe Deployment    ${label_selector}    ${namespace}    ${runtime}    ${exp_replicas}
 
 Verify Model KServe Deployment
@@ -857,3 +860,25 @@ Verify Model KServe Deployment
     ${n_containers}=    Get Length    ${containers}
     Run Keyword And Continue On Failure    Verify Deployment    ${model_pods}  ${exp_replicas}
     ...    ${n_containers}  ${containers}
+
+Wait For ISVC To Be Loaded
+    [Documentation]    Waits for the ISVC to be Loaded (i.e., Success status in the grid)
+    [Arguments]    ${isvc_name}    ${namespace}    ${retries}=36
+    ${rc}    ${isvc_status}=    Run And Return Rc And Output
+    ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
+    ${condition1}=    Evaluate    "${isvc_status}"=="${EMPTY}"
+    ${condition2}=    Evaluate    ${rc}==0
+    ${condition3}=    Evaluate    ${retries} > 0
+    WHILE    ${condition1} and ${condition2} and ${condition3}
+        Sleep    5s
+        ${retries}=    Evaluate    ${retries} - 1
+        ${rc}    ${isvc_status}=    Run And Return Rc And Output
+        ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
+        ${condition1}=    Evaluate    "${isvc_status}"=="${EMPTY}"
+        ${condition2}=    Evaluate    ${rc}==0
+        ${condition3}=    Evaluate    ${retries} > 0
+    END
+    IF    ${rc} != ${0}
+        Fail    msg=ISVC not ready
+    END
+    Should Be Equal As Strings    ${isvc_status}    Loaded

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -864,9 +864,9 @@ Verify Model KServe Deployment
 Wait For ISVC To Be Loaded
     [Documentation]    Waits for the ISVC to be Loaded (i.e., Success status in the grid)
     [Arguments]    ${isvc_name}    ${namespace}    ${retries}=36
-    ${condition1}=${TRUE}
-    ${condition2}=${TRUE}
-    ${condition3}=${TRUE}
+    ${condition1}=    Set Variable  ${True}
+    ${condition2}=    Set Variable  ${True}
+    ${condition3}=    Set Variable  ${True}
     WHILE    ${condition1} and ${condition2} and ${condition3}
         Sleep    5s
         ${retries}=    Evaluate    ${retries} - 1

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -862,21 +862,14 @@ Verify Model KServe Deployment
     ...    ${n_containers}  ${containers}
 
 Wait For ISVC To Be Loaded
-    [Documentation]    Waits for the ISVC to be Loaded (i.e., Success status in the grid)
+    [Documentation]    Waits for the ISVC to be Loaded
     [Arguments]    ${isvc_name}    ${namespace}    ${retries}=36
-    ${condition1}=    Set Variable  ${True}
-    ${condition2}=    Set Variable  ${True}
-    ${condition3}=    Set Variable  ${True}
-    WHILE    ${condition1} and ${condition2} and ${condition3}
-        Sleep    5s
-        ${retries}=    Evaluate    ${retries} - 1
-        ${rc}    ${isvc_status}=    Run And Return Rc And Output
+    Wait Until Keyword Succeeds    ${retries} times    5s    ISVC Should Be Loaded    ${isvc_name}    ${namespace}
+
+ISVC Should Be Loaded
+    [Documentation]    Check if the ISVC is Loaded (i.e., Success status in the grid)
+    [Arguments]    ${isvc_name}    ${namespace}
+    ${rc}    ${isvc_status}=    Run And Return Rc And Output
         ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
-        ${condition1}=    Evaluate    "${isvc_status}"=="${EMPTY}"
-        ${condition2}=    Evaluate    ${rc}==0
-        ${condition3}=    Evaluate    ${retries} > 0
-    END
-    IF    ${rc} != ${0}
-        Fail    msg=ISVC not ready
-    END
-    Should Be Equal As Strings    ${isvc_status}    Loaded
+    Should Be Equal As Integers    ${rc}    ${0}
+    Should Not Be Empty    ${isvc_status}

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -864,11 +864,9 @@ Verify Model KServe Deployment
 Wait For ISVC To Be Loaded
     [Documentation]    Waits for the ISVC to be Loaded (i.e., Success status in the grid)
     [Arguments]    ${isvc_name}    ${namespace}    ${retries}=36
-    ${rc}    ${isvc_status}=    Run And Return Rc And Output
-    ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
-    ${condition1}=    Evaluate    "${isvc_status}"=="${EMPTY}"
-    ${condition2}=    Evaluate    ${rc}==0
-    ${condition3}=    Evaluate    ${retries} > 0
+    ${condition1}=${TRUE}
+    ${condition2}=${TRUE}
+    ${condition3}=${TRUE}
     WHILE    ${condition1} and ${condition2} and ${condition3}
         Sleep    5s
         ${retries}=    Evaluate    ${retries} - 1

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -872,4 +872,4 @@ ISVC Should Be Loaded
     ${rc}    ${isvc_status}=    Run And Return Rc And Output
     ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
     Should Be Equal As Integers    ${rc}    ${0}
-    Should Not Be Empty    ${isvc_status}
+    Should Be Equal As Strings    ${isvc_status}    Loaded

--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -870,6 +870,6 @@ ISVC Should Be Loaded
     [Documentation]    Check if the ISVC is Loaded (i.e., Success status in the grid)
     [Arguments]    ${isvc_name}    ${namespace}
     ${rc}    ${isvc_status}=    Run And Return Rc And Output
-        ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
+    ...    oc get isvc ${isvc_name} -n ${namespace} -o=jsonpath='{.status.modelStatus.states.activeModelState}'
     Should Be Equal As Integers    ${rc}    ${0}
     Should Not Be Empty    ${isvc_status}


### PR DESCRIPTION
We are having some timeout issues with de deployment of models (e.g.: autotrigger-smoke/116)

After some discussion, we thought that the best way to fix it is by waiting for `.status.modelStatus.states.activeModelState == Loaded`

![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/06edf25e-4a0a-4d04-94b6-cf27ca5ce7a5)



