### PR TITLE
fix: 30s sleep when ISVC is loaded in order to avoid polling treshold

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -865,6 +865,7 @@ Wait For ISVC To Be Loaded
     [Documentation]    Waits for the ISVC to be Loaded
     [Arguments]    ${isvc_name}    ${namespace}    ${retries}=36
     Wait Until Keyword Succeeds    ${retries} times    5s    ISVC Should Be Loaded    ${isvc_name}    ${namespace}
+    Sleep    30s    msg=There is a 20 seconds polling
 
 ISVC Should Be Loaded
     [Documentation]    Check if the ISVC is Loaded (i.e., Success status in the grid)


### PR DESCRIPTION
We were getting a lot of  errors when trying to query a deployed model just a few moments it gets it's "Loaded" value in the activeModelState. 
This was happening because there is some 20~30 seconds of delay after deploying the model due to polling.
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/d62586d2-364a-4a83-88e5-f5b66a89df88)

