### PR TITLE
[fix] Update must-gather image reference for the RHOAI 2.10

### DIFF
--- a/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Tests/505__must_gather/get-must-gather-logs.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # Redirecting stdout/stderr of must-gather to a file, as it fills up the
 # process buffer and prevents the script from running further.
-oc adm must-gather --image=quay.io/modh/must-gather@sha256:5dd8b6f7e72c7fb3a5b46a48304514e4975fd6ed171cc3b1386771151020110a &> must-gather-results.txt
+oc adm must-gather --image=quay.io/modh/must-gather@sha256:1bd8735d715b624c1eaf484454b0d6d400a334d8cbba47f99883626f36e96657 &> must-gather-results.txt
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
This new image was created specifically for the RHOAI 2.10 release.

See [1,2] for more info.

* [1] https://quay.io/repository/modh/must-gather/manifest/sha256:1bd8735d715b624c1eaf484454b0d6d400a334d8cbba47f99883626f36e96657
* [2] https://github.com/red-hat-data-services/rhoai-disconnected-install-helper/blob/main/rhoai-2.10.md?plain=1#L51

---

CI: didn't tested - hope we don't need to :angel: 

For the future we should come up with some more intelligent solution as this is gonna be changing for each release from 2.10 on.