### PR TITLE
Update existing kuberay image to use sha digest instead of tag

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
@@ -64,7 +64,7 @@ Run Kuberay E2E Test
     ...    env:KUBERAY_TEST_TIMEOUT_SHORT=2m
     ...    env:KUBERAY_TEST_TIMEOUT_MEDIUM=7m
     ...    env:KUBERAY_TEST_TIMEOUT_LONG=10m
-    ...    env:KUBERAY_TEST_RAY_IMAGE=quay.io/project-codeflare/ray:latest-py39-cu118
+    ...    env:KUBERAY_TEST_RAY_IMAGE=quay.io/project-codeflare/ray:latest-py39-cu118@sha256:72b9972b4c9fd39bfd8a1450d8227890fbda75425859a710f3514f17412ae20f
     ...    shell=true
     ...    stderr=STDOUT
     ...    timeout=20m


### PR DESCRIPTION
 - Update existing kuberay image to use sha digest instead of tag which will make it usable in disconnected cluster as well.