### PR TITLE
fix: Dashboard tests diet

### DIFF
--- a/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/400__ods_dashboard.robot
@@ -121,8 +121,7 @@ Verify License Of Disabled Cards Can Be Re-validated
 
 Verify CSS Style Of Getting Started Descriptions
     [Documentation]    Verifies the CSS style is not changed. It uses JupyterHub card as sample
-    [Tags]    Smoke
-    ...       Tier1
+    [Tags]    Tier1
     ...       ODS-1165
     Click Link    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore

--- a/ods_ci/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/411__ods_dashboard_settings_pvc_size.robot
@@ -57,8 +57,7 @@ Verify User Can Spawn Notebook After Changing PVC Size Using UI
     [Documentation]   Verify if dedicated admin user able to chnage PVC
     ...    and RHODS user is able to spawn notebook for supported PVC
     ...    and verify PVC size
-    [Tags]    Sanity
-    ...       Tier1
+    [Tags]    Tier1
     ...       ODS-1220    ODS-1222
     Verify PVC change using UI     ${S_SIZE}
     ${pvc_size}   Get Notebook PVC Size        username=${TEST_USER.USERNAME}   namespace=${NOTEBOOKS_NAMESPACE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/412__ods_dashboard_resources.robot
@@ -26,8 +26,7 @@ Verify Quick Starts Work As Expected On Yes And Restart
     [Documentation]   Verify the Quickstarts are completed successfully
     ...    when all steps are marked as yes and restarted later
     ...    ProductBug: RHOAIENG-5273
-    [Tags]  Sanity
-    ...     Tier1
+    [Tags]  Tier1
     ...     ODS-1306    ODS-1308    ODS-1166    ODS-1406    ODS-1405
     Set Quick Starts Elements List Based On RHODS Type
     Validate Number Of Quick Starts In Dashboard Is As Expected    ${QUICKSTART_ELEMENTS}

--- a/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
@@ -13,7 +13,6 @@ Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
     ...                check OdhDashboardConfig CRD gets updated according to Admin UI
     [Tags]  ODS-1661    ODS-1555
     ...     Tier1
-    ...     Sanity
     Launch Dashboard And Check User Management Option Is Available For The User   ${TEST_USER.USERNAME}   ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Clear User Management Settings
     Add OpenShift Groups To Data Science Administrators   rhods-admins  rhods-users
@@ -81,7 +80,6 @@ Verify Automatically Detects a Group Selected Is Removed and Notify the User
     ...    message / notification
     [Tags]  ODS-1686
     ...     Tier1
-    ...     Sanity
     ${new_group_name}=    Set Variable    new-group-test
     Create Group  ${new_group_name}
     Launch Dashboard And Check User Management Option Is Available For The User   ${TEST_USER.USERNAME}   ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -10,7 +10,6 @@ Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDashboardAPI.resource
 Resource          ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 Suite Setup       Endpoint Testing Setup
 Suite Teardown    Endpoint Testing Teardown
-Test Tags         Dashboard
 
 
 *** Variables ***

--- a/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/414__ods_dashboard_api.robot
@@ -257,7 +257,7 @@ Verify Access To Notebook envs/configmap API Endpoint
     ...                 `configmap/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
 
     [Tags]    ODS-1719
-    ...       Tier1    Sanity
+    ...       Tier1
     ...       Security
     Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     ${NOTEBOOK_BASIC_USER}=   Get Safe Username    ${TEST_USER_3.USERNAME}
@@ -306,7 +306,7 @@ Verify Access To Notebook envs/secret API Endpoint
     ...                 The syntax to reach this endpoint is:
     ...                 `secret/<notebook_namespace>/jupyterhub-singleuser-profile-{username}-envs`
     [Tags]    ODS-1720
-    ...       Tier1    Sanity
+    ...       Tier1
     ...       Security
     Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     ${NOTEBOOK_BASIC_USER}=   Get Safe Username    ${TEST_USER_3.USERNAME}
@@ -564,7 +564,7 @@ Verify Access to notebooks API Endpoint
     ...                 The syntax to reach this endpoint is:
     ...                 `notebooks/<notebook_namespace>/jupyter-nb-<username_nb>`
     [Tags]    ODS-1729
-    ...       Tier1    Sanity
+    ...       Tier1
     ...       Security
     ${NOTEBOOK_CR_NAME}  ${IMAGE_TAG_NAME}=    Spawn Minimal Python Notebook Server     username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     ${NB_BASIC_USER}=   Get Safe Username    ${TEST_USER_3.USERNAME}
@@ -629,7 +629,7 @@ Verify Access to rolebindings API Endpoint
     ...                 The syntax to reach this endpoint is:
     ...                 `rolebindings/<dashboard_namespace>/<notebook_namespace>-image-pullers`
     [Tags]    ODS-1730
-    ...       Tier1    Sanity
+    ...       Tier1
     ...       Security
     Perform Dashboard API Endpoint GET Call   endpoint=${ROLE_BIND_ENDPOINT_PT1}    token=${BASIC_USER_TOKEN}
     Operation Should Be Allowed

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects.robot
@@ -57,7 +57,7 @@ ${NEW_PRJ_TITLE}=   ODS-CI DS Project Updated
 Verify Data Science Projects Page Is Accessible
     [Documentation]    Verifies "Data Science Projects" page is accessible from
     ...                the navigation menu on the left
-    [Tags]    Smoke    Sanity
+    [Tags]    Smoke
     ...       Tier1
     ...       ODS-1876
     Open Data Science Projects Home Page
@@ -66,7 +66,7 @@ Verify Data Science Projects Page Is Accessible
 Verify User Can Access Jupyter Launcher From DS Project Page
     [Documentation]    Verifies Data Science Projects home page contains
     ...                a link to Jupyter Spawner and it is working
-    [Tags]    Smoke    Sanity
+    [Tags]    Smoke
     ...       Tier1
     ...       ODS-1877
     Open Data Science Projects Home Page
@@ -77,7 +77,7 @@ Verify User Can Access Jupyter Launcher From DS Project Page
 Verify Workbench Images Have Multiple Versions
     [Documentation]    Verifies that workbench images have an additional
     ...                dropdown which supports N/N-1 image versions.
-    [Tags]    Smoke    Sanity
+    [Tags]    Sanity
     ...       Tier1
     ...       ODS-2131
     Open Data Science Project Details Page    project_title=${PRJ_TITLE}    tab_id=workbenches
@@ -105,7 +105,7 @@ Verify User Cannot Create Project Using Special Chars In Resource Name
     Close Generic Modal If Present
 
 Verify User Can Create A Data Science Project
-    [Tags]    Smoke    Sanity    ODS-1775    Tier1
+    [Tags]    Smoke    ODS-1775    Tier1
     [Documentation]    Verifies users can create a DS project
     Open Data Science Projects Home Page
     Log    message=DS Project creation covered by the Suite Setup
@@ -114,7 +114,7 @@ Verify User Can Create A Data Science Project
     ${ns_name}=    Check Corresponding Namespace Exists    project_title=${PRJ_TITLE}
 
 Verify User Can Create And Start A Workbench With Existent PV Storage
-    [Tags]    Smoke    Sanity    ODS-1814    Tier1
+    [Tags]    Smoke    ODS-1814    Tier1
     [Documentation]    Verifies users can create a workbench and connect an existent PersistenVolume
     ${pv_name}=    Set Variable    ${PV_BASENAME}-existent
     Create PersistentVolume Storage    name=${pv_name}    description=${PV_DESCRIPTION}    project_title=${PRJ_TITLE}
@@ -161,7 +161,7 @@ Verify User Can Create A PV Storage
     ...    Delete PVC In Project From CLI    pvc_title=${pv_name}    project_title=${PRJ_TITLE}
 
 Verify User Can Create And Start A Workbench Adding A New PV Storage
-    [Tags]    Smoke    Sanity    ODS-1816    Tier1    ExcludeOnDisconnected
+    [Tags]    Sanity    ODS-1816    Tier1    ExcludeOnDisconnected
     [Documentation]    Verifies users can create a workbench and connect a new PersistenVolume
     ...    We skip this test on Disconnected environment because we have a PVs predefined there hardcoded to 100Gi.
     ...    Since there is a size check in this test, it would fail unless some extra condition to be brought in here.
@@ -432,7 +432,7 @@ Verify Error Is Reported When Workbench Fails To Start    # robocop: disable
     Wait Until Project Is Open    project_title=${PRJ_TITLE}
 
 Verify Users Can Start, Stop, Launch And Delete A Workbench
-    [Tags]    Smoke    Sanity    Tier1
+    [Tags]    Smoke    Tier1
     ...       ODS-1813    ODS-1815   ODS-1817
     [Documentation]    Verifies users can start, stop, launch and delete a running workbench from project details page
     [Setup]        Run Keywords
@@ -502,7 +502,7 @@ Verify Users Can Start, Stop And Launch A Workbench From DS Projects Home Page
     ...    SeleniumLibrary.Close Browser
 
 Verify User Can Delete A Data Science Project
-    [Tags]    Smoke    Sanity    Tier1
+    [Tags]    Smoke    Tier1
     ...       ODS-1784
     [Documentation]    Verifies users can delete a Data Science project
     Open Data Science Projects Home Page

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_additional.robot
@@ -133,7 +133,7 @@ Verify User Can Remove GPUs From Workbench
 Verify DS Projects Home Page Shows The Right Number Of Items The User Has Selected
     [Documentation]    Verifies that correct number of data science projects appear when
     ...                multiple data science projects are added
-    [Tags]    ODS-2015    Sanity    Tier1
+    [Tags]    ODS-2015    Tier1
     [Setup]    Launch Data Science Project Main Page    username=${TEST_USER_4.USERNAME}
     ${all_projects}=    Create Multiple Data Science Projects    title=ds-project-ldap-user     description=numbered project -
     ...    number=20

--- a/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/415__ods_dashboard_projects/415__ods_dashboard_projects_permissions_mgmt.robot
@@ -84,7 +84,7 @@ Verify User Can Assign Access Permissions To User Groups
     ${USER_C} Should Not Have Access To ${PRJ_USER_B_TITLE}
 
 Verify Project Sharing Does Not Override Dashboard Permissions
-    [Tags]                  Tier1                   Sanity                  ODS-2223
+    [Tags]                  Tier1                   ODS-2223
     [Setup]                 Set RHODS Users Group To rhods-users
     Launch Data Science Project Main Page    username=${OCP_ADMIN_USER.USERNAME}    password=${OCP_ADMIN_USER.PASSWORD}
     ...    ocp_user_auth_type=${OCP_ADMIN_USER.AUTH_TYPE}

--- a/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/420__model_serving/423__model_serving_customruntimes.robot
@@ -58,7 +58,7 @@ Verify RHODS Admins Can Import A Custom Serving Runtime Template For Each Servin
 Verify RHODS Users Can Deploy A Model Using A Custom Serving Runtime
     [Documentation]    Verifies that a model can be deployed using only the UI.
     ...    At the end of the process, verifies the correct resources have been deployed.
-    [Tags]    Sanity    Tier1    ODS-2281    ModelMesh
+    [Tags]    Tier1    ODS-2281    ModelMesh
     [Setup]    Run Keywords
     ...    Skip If Component Is Not Enabled    modelmeshserving
     ...    AND


### PR DESCRIPTION
Reducing Dashboard tests execution time:

**Smoke**: (*)
- Base: ~10 mins (rhods-smoke/5899)
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/c8e06b29-f804-4296-9a9f-bdacab02b6c0)

- After this PR: ~7 mins (rhods-smoke/5908)
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/82e05a2e-8541-41dd-8828-a85b20b8813a)


**Sanity**: (**)
- Base: ~100 mins (rhods-smoke/5900)
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/b6c3bbbd-afa3-4631-b311-eda2168f1cc6)

- After this PR: ~48 mins (rhods-smoke/5912)
![image](https://github.com/red-hat-data-services/ods-ci/assets/31654558/dd7541ca-9a1c-4a52-b9e9-7256d47ca730)

_(*)NOTE: The smoke can not be slimmed. Dashboard is everywhere and uses UI always.
(**) NOTE: Times are just aproximations, due to some execution errors (failed tests)_

