### PR TITLE
Set default SR for Kserve to Caikit+TGIS

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -413,7 +413,7 @@ Deploy Kserve Model Via UI  #robocop: disable
 Set Model Server Runtime
     [Documentation]    Opens the Serving runtime dropdown in the deploy model modal window for models
     ...    and select the given runtime
-    [Arguments]    ${runtime}=Caikit
+    [Arguments]    ${runtime}=Caikit TGIS
     Page Should Contain Element    ${KSERVE_RUNTIME_DROPDOWN}
     Click Element    ${KSERVE_RUNTIME_DROPDOWN}
     Click Element    ${KSERVE_RUNTIME_DROPDOWN}/..//span[contains(text(),"${runtime}")]


### PR DESCRIPTION
A new SR will be added to the dropdown of the dashboard for the Caikit standalone server; the current default of the `Set Model Server Runtime` will pick instead of the intended Caikit+TGIS server used by the majority of tests.
Update the default value to pick Caikit+TGIS.