### PR TITLE
RHOAIENG-9157: check for a successful experiment instead of successful run

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -209,7 +209,7 @@ Verify Experiment Has Completed
     [Documentation]    Check that the "Last 5 runs" field of an "Experiments and runs" screen reports success
     [Arguments]    ${experiment_name}    ${pipeline_run_name}    ${timeout}=10m
     SeleniumLibrary.Wait Until Page Contains Element
-    ...    //tr[td[@data-label="Experiment"]/a[text()="standard data science pipeline"]] // td[@data-label="Last 5 runs"] // span[contains(class, "pf-v5-c-icon__content pf-m-success")]
+    ...    //tr[td[@data-label="Experiment"]/a[text()="${experiment_name}"]] // td[@data-label="Last 5 runs"] // span[contains(class, "pf-v5-c-icon__content pf-m-success")]
     ...    timeout=${timeout}
     SeleniumLibrary.Capture Page Screenshot
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -209,7 +209,7 @@ Verify Experiment Has Completed
     [Documentation]    Check that the "Last 5 runs" field of an "Experiments and runs" screen reports success
     [Arguments]    ${experiment_name}    ${pipeline_run_name}    ${timeout}=10m
     SeleniumLibrary.Wait Until Page Contains Element
-    ...    //tr[td[@data-label="Experiment"]/a[text()="${experiment_name}"]] // td[@data-label="Last 5 runs"] // span[contains(class, "pf-v5-c-icon__content pf-m-success")]
+    ...    //tr[td[@data-label="Experiment"]/a[text()="${experiment_name}"]] // td[@data-label="Last 5 runs"] // span[contains(@class, "pf-m-success")]
     ...    timeout=${timeout}
     SeleniumLibrary.Capture Page Screenshot
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -205,6 +205,15 @@ Verify Pipeline Run Is Completed
     Capture Page Screenshot
 
 # robocop: disable:line-too-long
+Verify Experiment Has Completed
+    [Documentation]    Check that the "Last 5 runs" field of an "Experiments and runs" screen reports success
+    [Arguments]    ${experiment_name}    ${pipeline_run_name}    ${timeout}=10m
+    SeleniumLibrary.Wait Until Page Contains Element
+    ...    //tr[td[@data-label="Experiment"]/a[text()="standard data science pipeline"]] // td[@data-label="Last 5 runs"] // span[contains(class, "pf-v5-c-icon__content pf-m-success")]
+    ...    timeout=${timeout}
+    SeleniumLibrary.Capture Page Screenshot
+
+# robocop: disable:line-too-long
 Get Pipeline Run Duplicate Parameters
     [Documentation]    Get Pipeline Run Duplicate Parameters
     [Arguments]    ${pipeline_run_name}

--- a/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
@@ -110,7 +110,7 @@ Verify Pipelines Integration With Elyra Running Hello World Pipeline Test     # 
     Menu.Navigate To Page    Experiments    Experiments and runs
     Select Pipeline Project By Name    ${PRJ_TITLE}
     Log    ${pipeline_run_name}
-    Verify Experiment Has Completed    "standard data science pipeline"    ${pipeline_run_name}    timeout=5m
+    Verify Experiment Has Completed    standard data science pipeline    ${pipeline_run_name}    timeout=5m
     [Teardown]    Verify Pipelines Integration With Elyra Teardown    ${img}
 
 Verify Pipelines Integration With Elyra Teardown

--- a/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
@@ -107,10 +107,10 @@ Verify Pipelines Integration With Elyra Running Hello World Pipeline Test     # 
     # We need to navigate to the page because the project name hold a state
     # In a fresh cluster, if not state found, it will select the first one
     # In this case, the first could not be the project created
-    Menu.Navigate To Page    Data Science Pipelines    Runs
+    Menu.Navigate To Page    Experiments    Experiments and runs
     Select Pipeline Project By Name    ${PRJ_TITLE}
     Log    ${pipeline_run_name}
-    Verify Pipeline Run Is Completed    ${pipeline_run_name}    timeout=5m
+    Verify Experiment Has Completed    "standard data science pipeline"    ${pipeline_run_name}    timeout=5m
     [Teardown]    Verify Pipelines Integration With Elyra Teardown    ${img}
 
 Verify Pipelines Integration With Elyra Teardown


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-9157

In RHOAISTRAT-110, the Dashboard implemented support for Pipeline experiments. This changed the UI somewhat, so we need to check for the result of the Elyra pipeline in a slightly different place.

Jenkins: /job/rhods/job/rhods-ci-pr-test/3058/console

and here's the screenshot that the test takes
![image](https://github.com/red-hat-data-services/ods-ci/assets/442720/fbcba58b-b6ca-45a8-8a1d-452335c726b9)
