### PR TITLE
Fix Test `Verify Resource Link HTTP Status Code`

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardResources.resource
@@ -126,7 +126,7 @@ Wait Until Resource Page Is Loaded
 Get Link Web Elements From Resource Page
     [Documentation]    Returns the link web elements from Resources page which redirects users to
     ...                external websites. It excludes Quick Starts items
-    ${link_elements}=    Get WebElements    //a[@class="odh-card__footer__link" and not(starts-with(@href, '#'))]
+    ${link_elements}=    Get WebElements     //a[contains(@class,"odh-card__footer__link") and not(starts-with(@href, '#'))]
     ${len}=    Get Length    ${link_elements}
     Log To Console    ${len} Links found\n
     RETURN    ${link_elements}


### PR DESCRIPTION
Invalid Xpath caused the test to list zero links.
After fixing the Xpath the test could verify Resources Links, including bad links as follow:

![image](https://github.com/red-hat-data-services/ods-ci/assets/9913945/6ec8c440-41f7-4947-a175-85a36177aff4)
