### PR TITLE
Check that the URL list is not empty before verifying HTTP status

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -223,6 +223,7 @@ URLs HTTP Status Code Should Be Equal To
     [Documentation]    Given a list of link web elements, extracts the URLs and
     ...                checks if the http status code expected one is equal to the
     [Arguments]    ${link_elements}    ${expected_status}=200    ${timeout}=20
+    Should Not Be Empty    ${link_elements}    msg=The list of URLs to validate is empty (Maybe an invalid Xpath caused it).
     FOR    ${idx}    ${ext_link}    IN ENUMERATE    @{link_elements}    start=1
         ${href}=    Get Element Attribute    ${ext_link}    href
         ${text}=    Get Text    ${ext_link}


### PR DESCRIPTION
KW `URLs HTTP Status Code Should Be Equal To` receives a list of links to verify that no link is broken. 
However, if the list is empty (most likely due to invalid XPATH), then no URL validation is executed. 
This would cause a false positive (as if all links are working), instead of failing the calling test (expected link elements are missing).