### PR TITLE
Update NFD operator files in releases/2.8.0

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/nfd_deploy.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/nfd_deploy.yaml
@@ -2,7 +2,7 @@ apiVersion: nfd.openshift.io/v1
 kind: NodeFeatureDiscovery
 metadata:
   name: nfd-instance
-  namespace: nvidia-gpu-operator
+  namespace: openshift-nfd
 spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default

--- a/ods_ci/tasks/Resources/Provisioning/GPU/nfd_operator.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/nfd_operator.yaml
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-nfd
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-nfd-og
+  namespace: openshift-nfd
+spec:
+  targetNamespaces:
+    - openshift-nfd
+  upgradeStrategy: Default
+
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: nfd
+  namespace: openshift-nfd
+spec:
+  channel: "stable"
+  installPlanApproval: Automatic
+  name: nfd
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
Something went wrong during the backport PR https://github.com/red-hat-data-services/ods-ci/pull/1581. Fixing it

PR validation:
- nvidia: `rhods-smoke/5984` PASS
- amd:  `rhods-smoke/5985` PASS