### PR TITLE
Store KubeRay logs into workspace folder

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-kuberay-e2e.robot
@@ -65,6 +65,7 @@ Prepare Kuberay E2E Test Suite
     IF    ${result.rc} != 0
         FAIL    Unable to retrieve e2e compiled binary
     END
+    Create Directory    %{WORKSPACE}/kuberay-logs
     RHOSi Setup
 
 Teardown Kuberay E2E Test Suite
@@ -87,6 +88,7 @@ Run Kuberay E2E Test
     ...    env:KUBERAY_TEST_TIMEOUT_MEDIUM=7m
     ...    env:KUBERAY_TEST_TIMEOUT_LONG=10m
     ...    env:KUBERAY_TEST_RAY_IMAGE=quay.io/project-codeflare/ray:latest-py39-cu118@sha256:72b9972b4c9fd39bfd8a1450d8227890fbda75425859a710f3514f17412ae20f
+    ...    env:KUBERAY_TEST_OUTPUT_DIR=%{WORKSPACE}/kuberay-logs
     ...    shell=true
     ...    stderr=STDOUT
     ...    timeout=20m


### PR DESCRIPTION
Tested manually by running Kuberay tests.