### PR TITLE
Allow to install gpu-operator-certified in disconnected env

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -9,7 +9,7 @@ CHANNEL="$(oc get packagemanifest gpu-operator-certified -n openshift-marketplac
 
 CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r '.status.channels[] | select(.name == "'$CHANNEL'") | .currentCSV')"
 
-sed -i'' -e "0,/v1.11/s//$CHANNEL/g" -e "s/gpu-operator-certified.v1.11.0/$CSVNAME/g"  "$GPU_INSTALL_DIR/gpu_install.yaml"
+sed -i'' -e "0,/v1.11/s//$CHANNEL/g" "$GPU_INSTALL_DIR/gpu_install.yaml"
 
 oc apply -f "$GPU_INSTALL_DIR/gpu_install.yaml"
 oc apply -f "$GPU_INSTALL_DIR/../nfd_operator.yaml"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_install.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_install.yaml
@@ -27,7 +27,6 @@ spec:
   name: gpu-operator-certified
   source: certified-operators
   sourceNamespace: openshift-marketplace
-  startingCSV: "gpu-operator-certified.v1.11.1"
 
 ---
 apiVersion: operators.coreos.com/v1alpha1

--- a/ods_ci/tasks/Resources/Provisioning/GPU/nfd_deploy.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/nfd_deploy.yaml
@@ -7,7 +7,8 @@ spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
+    # Image digest for registry.redhat.io/openshift4/ose-node-feature-discovery:v4.11
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery@sha256:d6242132d2ddec00c46d22b63015a33af821eace0150ba47d185cd992fee317d
     imagePullPolicy: Always
   workerConfig:
     configData: |


### PR DESCRIPTION
Field 'startingCSV' is not needed and it causes problems in a disconnected env where we do not have all versions in the latest channel, e.g. in channel 'v24.3' we have only version '24.3.0'.