### PR TITLE
Fix fetching of Dashboard URL

### DIFF
--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -174,8 +174,10 @@ def get_dashboard_url():
     """
     Get dashboard url for the open data science.
     """
-    cmd = "(oc get route -n opendatahub-operators -o json  | jq '.items[].spec.host' | grep odh-dashboard) || " + \
-          "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
+    cmd = (
+        "(oc get route -n opendatahub-operators -o json  | jq '.items[].spec.host' | grep odh-dashboard) || "
+        + "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
+    )
     dashboard_url = execute_command(cmd)
     return "https://" + dashboard_url.strip('"').strip("\n")
 

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -175,7 +175,7 @@ def get_dashboard_url():
     Get dashboard url for the open data science.
     """
     cmd = (
-        "(oc get route -n opendatahub-operators -o json  | jq '.items[].spec.host' | grep odh-dashboard) || "
+        "(oc get route -n opendatahub -o json  | jq '.items[].spec.host' | grep odh-dashboard) || "
         "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
     )
     dashboard_url = execute_command(cmd)

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -176,7 +176,7 @@ def get_dashboard_url():
     """
     cmd = (
         "(oc get route -n opendatahub-operators -o json  | jq '.items[].spec.host' | grep odh-dashboard) || "
-        + "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
+        "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
     )
     dashboard_url = execute_command(cmd)
     return "https://" + dashboard_url.strip('"').strip("\n")

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -174,8 +174,8 @@ def get_dashboard_url():
     """
     Get dashboard url for the open data science.
     """
-    cmd = "oc get route -A -o json  | jq '.items[].spec.host' | grep 'dashboard'"
-
+    cmd = "(oc get route -n opendatahub-operators -o json  | jq '.items[].spec.host' | grep odh-dashboard) || " + \
+          "(oc get route -n redhat-ods-applications -o json  | jq '.items[].spec.host' | grep rhods-dashboard)"
     dashboard_url = execute_command(cmd)
     return "https://" + dashboard_url.strip('"').strip("\n")
 


### PR DESCRIPTION
if there are other routes using "dashboard", the code fetches all the routes together breaking the UI tests accessing the Dashboard

PR validation:
- RHOAI: `rhods-smoke/6191` url fetched correctly, the checks in the test failed for reasons not related to this PR
- ODH: `rhods-smoke/6207/` url fetched correctly, the checks in the test failed for reasons not related to this PR