### PR TITLE
Ignore snyk cert validation

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,14 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.0
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  CWE-295:
+    - ods_ci/ods_ci/libs/DataSciencePipelinesAPI.py:
+        reason: Internal endpoint used for testing
+        expires: 2024-08-16T08:43:59.751Z
+        created: 2024-07-17T08:43:59.752Z
+    - ods_ci/ods_ci/libs/Helpers.py:
+        reason: Internal endpoint used for testing
+        expires: 2024-08-16T08:44:46.841Z
+        created: 2024-07-17T08:44:46.850Z
+patch: {}

--- a/.snyk
+++ b/.snyk
@@ -5,10 +5,10 @@ ignore:
   CWE-295:
     - ods_ci/ods_ci/libs/DataSciencePipelinesAPI.py:
         reason: Internal endpoint used for testing
-        expires: 2024-08-16T08:43:59.751Z
-        created: 2024-07-17T08:43:59.752Z
+        expires: 2026-07-16T00:00:00.000Z
+        created: 2024-07-17T08:53:17.144Z
     - ods_ci/ods_ci/libs/Helpers.py:
         reason: Internal endpoint used for testing
-        expires: 2024-08-16T08:44:46.841Z
-        created: 2024-07-17T08:44:46.850Z
+        expires: 2026-07-16T00:00:00.000Z
+        created: 2024-07-17T08:54:00.137Z
 patch: {}


### PR DESCRIPTION
As agreed on [Slack](https://redhat-internal.slack.com/archives/C03V3J222D7/p1721145765482469?thread_ts=1721131848.508929&cid=C03V3J222D7), these two issues flagged by Snyk can be ignored, as they are used only for testing and they are connecting to internal endpoints.

I've generated the file with the snyk cli:
```
snyk ignore --id=CWE-295 --reason="Internal endpoint used for testing" --expiry=2026-07-16 --path=ods_ci/ods_ci/libs/DataSciencePipelinesAPI.py  
snyk ignore --id=CWE-295 --reason="Internal endpoint used for testing" --expiry=2026-07-16 --path=ods_ci/ods_ci/libs/Helpers.py 
```