### PR TITLE
Fix snyk ignore configuration

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,13 +2,14 @@
 version: v1.25.0
 # ignores vulnerabilities until expiry date; change duration by modifying expiry date
 ignore:
-  CWE-295:
-    - ods_ci/ods_ci/libs/DataSciencePipelinesAPI.py:
+  8813971b-e775-4f65-bbdd-d493a1027c67:
+    - ods_ci/libs/DataSciencePipelinesAPI.py:
         reason: Internal endpoint used for testing
-        expires: 2026-07-16T00:00:00.000Z
-        created: 2024-07-17T08:53:17.144Z
-    - ods_ci/ods_ci/libs/Helpers.py:
+        expires: 2026-07-18T00:00:00.000Z
+        created: 2024-07-18T07:39:29.883Z
+  80053e48-aa71-4d90-8e76-c0ece5ca5304:
+    - ods_ci/libs/Helpers.py:
         reason: Internal endpoint used for testing
-        expires: 2026-07-16T00:00:00.000Z
-        created: 2024-07-17T08:54:00.137Z
+        expires: 2026-07-18T00:00:00.000Z
+        created: 2024-07-18T07:38:47.802Z
 patch: {}


### PR DESCRIPTION
Fixes path for files to ignore. IDs obtained from Snyk website, in the Reports menu, adding the PROBLEM ID column

```
snyk ignore --id=8813971b-e775-4f65-bbdd-d493a1027c67 --reason="Internal endpoint used for testing" --expiry=2026-07-18 --path=ods_ci/libs/DataSciencePipelinesAPI.py
snyk ignore --id=80053e48-aa71-4d90-8e76-c0ece5ca5304 --reason="Internal endpoint used for testing" --expiry=2026-07-18 --path=ods_ci/libs/Helpers.py
```