### PR TITLE
Refactor Codeflare sdk tests setup and teardown methods

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -5,9 +5,9 @@ Library          Process
 
 
 *** Variables ***
-${VIRTUAL_ENV_NAME}    venv3.9
+${VIRTUAL_ENV_NAME}                      venv3.9
 ${CODEFLARE-SDK-API_URL}                 %{CODEFLARE-SDK-API_URL=https://api.github.com/repos/project-codeflare/codeflare-sdk/releases/latest}
-${CODEFLARE-SDK_DIR}                     codeflare-sdk-upgrade
+${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/latest/download
 ${FMS_HF_TUNING_IMAGE}                   quay.io/modh/fms-hf-tuning:release-5e4e9441febdb5b2beb21eaecdda1103abd1db05
@@ -26,9 +26,8 @@ Clone Git Repository
         FAIL    Unable to clone DW repo ${DW_REPO_URL}:${DW_REPO_BRANCH}:${DW_DIR}
     END
 
-Run Codeflare Upgrade Tests
-    [Documentation]   Run codeflare upgrade tests by cloning codeflare-sdk repo
-    [Arguments]    ${TEST_NAME}
+Prepare Codeflare-SDK Test Setup
+    [Documentation]   Prepare codeflare-sdk tests by cloning codeflare-sdk repo and python virtual environmnet
     ${latest_tag} =    Run Process   curl -s "${CODEFLARE-SDK-API_URL}" | grep '"tag_name":' | cut -d '"' -f 4
     ...    shell=True    stderr=STDOUT
     Log To Console  codeflare-sdk latest tag is : ${latest_tag.stdout}
@@ -45,7 +44,11 @@ Run Codeflare Upgrade Tests
         FAIL    Unable to setup Python virtual environment
     END
 
-    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd ${CODEFLARE-SDK_DIR} && poetry env use 3.9 && poetry install --with test,docs && poetry run pytest -v -s ./tests/upgrade/raycluster_sdk_upgrade_test.py::${TEST_NAME} --timeout\=300 && deactivate
+Run Codeflare-SDK Test
+    [Documentation]   Run codeflare-sdk Test
+    [Arguments]    ${TEST_TYPE}    ${TEST_NAME}
+    Log To Console    "Running codeflare-sdk test: ${TEST_NAME}"
+    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd ${CODEFLARE-SDK_DIR} && poetry env use 3.9 && poetry install --with test,docs && poetry run pytest -v -s ./tests/${TEST_TYPE}/${TEST_NAME} --timeout\=300 && deactivate
     ...    shell=true
     ...    stderr=STDOUT
     Log To Console    ${result.stdout}
@@ -54,7 +57,7 @@ Run Codeflare Upgrade Tests
     END
 
 Codeflare Upgrade Tests Teardown
-    [Documentation]   Run codeflare upgrade tests by cloning codeflare-sdk repo
+    [Documentation]   cleanup codeflare-SDK upgrade tests resources created
     [Arguments]    ${project_name}    ${project_created}
     IF    ${project_created} == True    Run Keywords
     ...    Run   oc delete project ${project_name}    AND
@@ -62,21 +65,13 @@ Codeflare Upgrade Tests Teardown
     ...    oc delete ClusterQueue cluster-queue-mnist &
     ...    oc delete ResourceFlavor default-flavor-mnist    shell=True
 
-Cleanup Codeflare Setup
+Cleanup Codeflare-SDK Setup
     [Documentation]   cleanup codeflare repository cloned and python setup
-    ${result} =    Run Process  rm -rf ${VIRTUAL_ENV_NAME}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL   Unable to cleanup Python virtual environment
-    END
+    Log To Console     "Removing Python virtual environment directory ${VIRTUAL_ENV_NAME}"
+    Remove Directory        ${VIRTUAL_ENV_NAME}    recursive=True
 
-    ${result} =    Run Process  rm -rf ${CODEFLARE-SDK_DIR}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL   Unable to cleanup directory ${CODEFLARE-SDK_DIR}
-    END
+    Log To Console     "Removing directory ${CODEFLARE-SDK_DIR}"
+    Remove Directory        ${CODEFLARE-SDK_DIR}    recursive=True
 
 Restart Kueue
     Log To Console    "Rollout restart kueue-controller-manager"

--- a/ods_ci/tests/Tests/100__deploy/120__upgrades/120__pre_upgrades.robot
+++ b/ods_ci/tests/Tests/100__deploy/120__upgrades/120__pre_upgrades.robot
@@ -125,10 +125,11 @@ Verify User Can Deploy Custom Runtime For Upgrade
 
 Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     [Documentation]    Creates the Ray Cluster and verify resource usage
-    [Tags]  Upgrade
+    [Tags]    Upgrade
+    [Setup]    Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}    Set Variable    test-ns-rayupgrade
     ${JOB_NAME}    Set Variable    mnist
-    Run Codeflare Upgrade Tests    TestMNISTRayClusterUp
+    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMNISTRayClusterUp
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Launch Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
@@ -154,7 +155,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     Check Distributed Workload Resource Metrics Chart    ${PRJ_UPGRADE}    ${cpu_requested}
     ...    ${memory_requested}    RayCluster    ${JOB_NAME}
 
-    [Teardown]    Run Keywords    Cleanup Codeflare Setup    AND
+    [Teardown]    Run Keywords    Cleanup Codeflare-SDK Setup    AND
     ...    Run Keyword If Test Failed    Codeflare Upgrade Tests Teardown    ${PRJ_UPGRADE}    ${DW_PROJECT_CREATED}
 
 Run Training Operator ODH Setup PyTorchJob Test Use Case

--- a/ods_ci/tests/Tests/100__deploy/120__upgrades/122__post_ugrade.robot
+++ b/ods_ci/tests/Tests/100__deploy/120__upgrades/122__post_ugrade.robot
@@ -149,11 +149,12 @@ Verify Custom Runtime Exists After Upgrade
 
 Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job After Upgrade
     [Documentation]    check the Ray Cluster exists , submit ray job and  verify resource usage after upgrade
-    [Tags]  Upgrade
+    [Tags]    Upgrade
+    [Setup]    Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}    Set Variable    test-ns-rayupgrade
     ${LOCAL_QUEUE}    Set Variable    local-queue-mnist
     ${JOB_NAME}    Set Variable    mnist
-    Run Codeflare Upgrade Tests    TestMnistJobSubmit
+    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMnistJobSubmit
     Set Global Variable    ${DW_PROJECT_CREATED}    True
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
@@ -179,7 +180,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     Check Distributed Workload Resource Metrics Chart    ${PRJ_UPGRADE}    ${cpu_requested}
     ...    ${memory_requested}    RayCluster    ${JOB_NAME}
 
-    [Teardown]    Run Keywords    Cleanup Codeflare Setup    AND
+    [Teardown]    Run Keywords    Cleanup Codeflare-SDK Setup    AND
     ...    Codeflare Upgrade Tests Teardown    ${PRJ_UPGRADE}    ${DW_PROJECT_CREATED}
 
 Run Training Operator ODH Run PyTorchJob Test Use Case

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
@@ -9,13 +9,6 @@ Resource          ../../Resources/RHOSi.resource
 Resource          ../../../tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 
 
-*** Variables ***
-${CODEFLARE-SDK_DIR}                codeflare-sdk
-${CODEFLARE-SDK_REPO_URL}           %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
-${CODEFLARE-SDK-API_URL}            %{CODEFLARE-SDK-API_URL=https://api.github.com/repos/project-codeflare/codeflare-sdk/releases/latest}
-${VIRTUAL_ENV_NAME}                 venv3.9
-
-
 *** Test Cases ***
 Run TestRayClusterSDKOauth test
     [Documentation]    Run Python E2E test: TestRayClusterSDKOauth
@@ -23,7 +16,7 @@ Run TestRayClusterSDKOauth test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Codeflare-sdk
-    Run Codeflare-sdk E2E Test    mnist_raycluster_sdk_oauth_test.py
+    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py
 
 Run TestRayLocalInteractiveOauth test
     [Documentation]    Run Python E2E test: TestRayLocalInteractiveOauth
@@ -31,69 +24,18 @@ Run TestRayLocalInteractiveOauth test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Codeflare-sdk
-    Run Codeflare-sdk E2E Test    local_interactive_sdk_oauth_test.py
+    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py
 
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite
     [Documentation]    Prepare codeflare-sdk E2E Test Suite
     Log To Console    "Restarting kueue"
     Restart Kueue
-
-    ${latest_tag} =    Run Process   curl -s "${CODEFLARE-SDK-API_URL}" | grep '"tag_name":' | cut -d '"' -f 4
-    ...    shell=True    stderr=STDOUT
-    Log To Console  codeflare-sdk latest tag is : ${latest_tag.stdout}
-    IF    ${latest_tag.rc} != 0
-        FAIL    Unable to fetch codeflare-sdk latest tag
-    END
-    ${result} =    Run Process    git clone -b ${latest_tag.stdout} ${CODEFLARE-SDK_REPO_URL} ${CODEFLARE-SDK_DIR}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL    Unable to clone ${CODEFLARE-SDK_DIR} repo ${CODEFLARE-SDK_REPO_URL}:${latest_tag.stdout}
-    END
-
-    ${result} =    Run Process  virtualenv -p python3.9 ${VIRTUAL_ENV_NAME}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL    Unable to setup Python virtual environment
-    END
-
+    Prepare Codeflare-SDK Test Setup
     RHOSi Setup
 
 Teardown Codeflare-sdk E2E Test Suite
     [Documentation]    Teardown codeflare-sdk E2E Test Suite
-
-    ${result} =    Run Process  rm -rf ${VIRTUAL_ENV_NAME}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL   Unable to cleanup Python virtual environment
-    END
-
-    ${result} =    Run Process    poetry env use 3.11
-    ...    shell=true    stderr=STDOUT
-    IF    ${result.rc} != 0
-        FAIL   Unable to switch python environment 3.11
-    END
-
-    ${result} =    Run Process  rm -rf ${CODEFLARE-SDK_DIR}
-    ...    shell=true    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL   Unable to cleanup directory ${CODEFLARE-SDK_DIR}
-    END
-
+    Cleanup Codeflare-SDK Setup
     RHOSi Teardown
 
-Run Codeflare-sdk E2E Test
-    [Documentation]    Run codeflare-sdk E2E Test
-    [Arguments]    ${TEST_NAME}
-    Log To Console    "Running codeflare-sdk test: ${TEST_NAME}"
-    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd codeflare-sdk && poetry env use 3.9 && poetry install --with test,docs && poetry run pytest -v -s ./tests/e2e/${TEST_NAME} --timeout\=600 && deactivate
-    ...    shell=true
-    ...    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL    ${TEST_NAME} failed
-    END


### PR DESCRIPTION
Closes [RHOAIENG-8564](https://issues.redhat.com/browse/RHOAIENG-8564) 
Refactored Codeflare-sdk setup and cleanup methods to `DistributedWorkloads.resource` to use it for all codeflare-sdk related tests