### PR TITLE
fix: remove warns from rosa list versions command to avoid issues

### DIFF
--- a/ods_ci/utils/scripts/rosa/rosa.py
+++ b/ods_ci/utils/scripts/rosa/rosa.py
@@ -37,7 +37,9 @@ class RosaClusterManager:
             f"awk '{{print $1}}' | grep -w '^{re.escape(version)}*' | head -n1"
         )
         latest_version = execute_command(latest_version_cmd)
-        self.rosa_version = latest_version.strip()
+        # when rosa cli is not the latest one, we see WARN messages, and this is breaking the automations when
+        # picking up the retrieved version, so adding this spilitlines method to take the correct part of the output
+        self.rosa_version = latest_version.splitlines()[-1].strip()
         log.info(f"Using the latest rosa version: {self.rosa_version}")
 
     def create_rosa_cluster(self):


### PR DESCRIPTION
When deploying a ROSA managed cluster, if ROSA cli is not the latest version, we got some warnings:

```
13:09:58  ods-ci-ods_ci.utils.scripts.logger: INFO     CMD: rosa create cluster --cluster-name rosacesar24jul --replicas    2 --region us-east-2 --compute-machine-type m5.2xlarge --yes --version WARN: The current version (1.2.41) is not up to date with latest released version (1.2.42).
13:09:58  WARN: It is recommended that you update to the latest version.
13:09:58  4.15.21 --channel-group stable --sts
13:09:58  >: /bin/sh: -c: line 1: syntax error near unexpected token `('
13:09:58  >: /bin/sh: -c: line 1: `rosa create cluster --cluster-name rosacesar24jul --replicas    2 --region us-east-2 --compute-machine-type m5.2xlarge --yes --version WARN: The current version (1.2.41) is not up to date with latest released version (1.2.42).'
```

This is affecting the rosa create cluster because the version retrieved from rosa list versions command is not properly parsed