### PR TITLE
Fix: ODS 2206 wrong xpaths

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -861,4 +861,5 @@ Click Action From Actions Menu
         ${action}=    Catenate    ${action}    ${item_type}
     END
     Wait Until Page Contains Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]//td//li//*[text()="${action}"]    # robocop: disable
+    Sleep    0.5    msg=Avoid element missclicking
     Click Element       xpath=//tr[td[@data-label="Name"]//*[text()="${item_title}"]]//td//li//*[text()="${action}"]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -147,8 +147,8 @@ Delete Pipeline Server
     Wait Until Page Contains Element    xpath://button[contains(span/text(), 'Pipeline server actions')]
     Wait Until Element Is Enabled       xpath://button[contains(span/text(), 'Pipeline server actions')]
     Click Element                       xpath://button[contains(span/text(), 'Pipeline server actions')]
-    Wait Until Page Contains Element    xpath://li[contains(a/text(), 'Delete pipeline server')]
-    Click Element    //li[contains(a/text(), 'Delete pipeline server')]
+    Wait Until Page Contains Element    xpath://button/span/span[text()='Delete pipeline server']
+    Click Element    xpath://button/span/span[text()='Delete pipeline server']
     Handle Deletion Confirmation Modal    ${data_science_project_name} pipeline server    pipeline server
     Wait Until Page Contains     text=Configure pipeline server    timeout=120s
     Pipelines.Wait Until Pipeline Server Is Deleted    ${data_science_project_name}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -44,8 +44,8 @@ Select Data Connection
     ...                in the modal for Pipeline Server creation
     [Arguments]    ${dc_name}
     # robocop: off=line-too-long
-    Wait Until Page Contains Element    xpath://div[@class="pf-v5-c-form__group"][.//label//*[text()="Access key"]]//div[@data-ouia-component-type="PF5/Dropdown"]
-    Click Element                       xpath://div[@class="pf-v5-c-form__group"][.//label//*[text()="Access key"]]//div[@data-ouia-component-type="PF5/Dropdown"]
+    Wait Until Page Contains Element    xpath://button[@data-testid="select-data-connection"]
+    Click Button                        xpath://button[@data-testid="select-data-connection"]
     Wait Until Page Contains Element    xpath://button//*[text()="${dc_name}"]
     Click Element    xpath://button//*[text()="${dc_name}"]
 
@@ -53,7 +53,7 @@ Wait Until Pipeline Is Not Listed
     [Documentation]    Waits until pipeline is no longer listed in the pipelines table
     [Arguments]    ${pipeline_name}    ${timeout}=60s
     Maybe Wait For Dashboard Loading Spinner Page
-    ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title" and text()="${pipeline_name}"])[1]/../..
+    ${pipeline_row_xp}=    Set Variable    //*[@data-testid="table-row-title"]/a/span[text()="${pipeline_name}"]/ancestor::tr
     Wait Until Page Does Not Contain Element    ${pipeline_row_xp}    timeout=${timeout}
 
 Import Pipeline
@@ -106,10 +106,11 @@ Expand Pipeline Details
     [Documentation]    Expands a pipeline row in the dashboard UI
     [Arguments]    ${pipeline_name}
 
-    ${pipeline_row_xp}=                 Set Variable    (//*[@data-testid="table-row-title" and text()="${pipeline_name}"])[1]/../..
+    ${pipeline_row_xp}=                 Set Variable    //*[@data-testid="table-row-title"]/a/span[text()="${pipeline_name}"]/ancestor::tr
     ${pipeline_details_xp}=             Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Details"]
     ${expanded_pipeline_details_xp}=    Set Variable    ${pipeline_row_xp}/td/button[@aria-expanded="true"]
 
+    Sleep    2    reason=Sometimes it takes ~1sec to render the row
     ${is_expanded}=  Run Keyword And Return Status
     ...  Page Should Contain Element  xpath:${expanded_pipeline_details_xp}
     IF  not ${is_expanded}    Click Button  xpath:${pipeline_details_xp}
@@ -117,7 +118,7 @@ Expand Pipeline Details
 Collapse Pipeline Details
     [Documentation]    Collapses a pipeline row in the dashboard UI
     [Arguments]    ${pipeline_name}
-    ${pipeline_row_xp}=                 Set Variable    (//*[@data-testid="table-row-title" and text()="${pipeline_name}"])[1]/../..
+    ${pipeline_row_xp}=                 Set Variable    //*[@data-testid="table-row-title"]/a/span[text()="${pipeline_name}"]/ancestor::tr
     ${pipeline_details_xp}=             Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Details"]
     ${expanded_pipeline_details_xp}=    Set Variable    ${pipeline_row_xp}/td/button[@aria-expanded="true"]
 
@@ -129,7 +130,7 @@ Click Action From Pipeline Actions Menu
     [Documentation]    Click an action from Pipeline Actions menu (3-dots menu on the right)
     [Arguments]    ${pipeline_name}    ${action}
     # robocop: off=line-too-long
-    ${pipeline_row_xp}=    Set Variable    (//*[@data-testid="table-row-title" and text()="${pipeline_name}"])[1]/../..
+    ${pipeline_row_xp}=    Set Variable    //*[@data-testid="table-row-title"]//span[text()="${pipeline_name}"]/ancestor::tr
     ${kebab_xp}=           Set Variable    ${pipeline_row_xp}/td/button[@aria-label="Kebab toggle"]
     ${kebap_action_xp}=    Set Variable    ${pipeline_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
     Wait Until Page Contains Element    ${kebab_xp}
@@ -141,7 +142,7 @@ Click Action From Pipeline Version Actions Menu
     [Documentation]    Click an action from Pipeline Version Actions menu (3-dots menu on the right)
     [Arguments]    ${pipeline_version_name_contains}    ${action}
     # robocop: off=line-too-long
-    ${version_row_xp}=    Set Variable     (//*[@data-testid="table-row-title"]/a[contains(text(),"${pipeline_version_name_contains}")])/../../..
+    ${version_row_xp}=    Set Variable     //*[@data-testid="table-row-title"]/span/a[contains(text(),"${pipeline_version_name_contains}")]/ancestor::tr
     ${kebab_xp}=           Set Variable    ${version_row_xp}/td/button[@aria-label="Kebab toggle"]
     ${kebap_action_xp}=    Set Variable    ${version_row_xp}/td/div/div/ul/li/button[.//*[contains(text(), '${action}')]]
     Wait Until Page Contains Element    ${kebab_xp}
@@ -193,13 +194,13 @@ Pipeline Should Be Listed
     [Arguments]     ${pipeline_name}    ${pipeline_description}=${EMPTY}
 
     Projects.Move To Tab    Pipelines
-    ${pipeline_title_xp}=    Set Variable      (//*[@data-testid="table-row-title" and text()="${pipeline_name}"])[1]
+    ${pipeline_title_xp}=    Set Variable      //*[@data-testid="table-row-title"]/a/span[text()="${pipeline_name}"]
     Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_title_xp}
 
     IF    "${pipeline_description}" != "${EMPTY}"
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
-        ...        ${pipeline_title_xp}/following-sibling::*[p[text()="${pipeline_description}"]]
+        ...        ${pipeline_title_xp}/ancestor::b/following-sibling::*[p[text()="${pipeline_description}"]]
     END
 
 Pipeline Should Not Be Listed


### PR DESCRIPTION
During the lasts nightlies 2.12 executions a test has been failing due a modification in some of the dashboard paths.

Test Case: Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Page Using Custom Pip Mirror
ODS-2206    ODS-2226    ODS-2633

Test results:
![image](https://github.com/user-attachments/assets/cde723f0-b2b9-42c6-87ac-dacda773d380)



About the 2s wait: 
Sometimes it takes a little bit more to render the row (check the screenshot below). Andwe cannot wait the element, because the element can not be there.

![Screenshot from 2024-07-25 00-46-06](https://github.com/user-attachments/assets/5977185f-4638-4689-8a2e-0f2983790708)


