### PR TITLE
Fix KW `Clean Up DSP Page`

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -568,17 +568,9 @@ Clean Up DSP Page
     END
     Open Data Science Projects Home Page
     ${projects}=    Get All Displayed Projects
-    ${projects_count}=    Get Length    ${projects}
-    WHILE    ${projects_count} > 0    limit=${projects_count}m
-    ...    on_limit_message=Timeout exceeded waiting for all DS projects deletion
-        Delete Data Science Projects From CLI    ${projects}
-        Reload Page
-        ${reloaded}=    Run Keyword And Return Status
-        ...    SeleniumLibrary.Wait Until Page Contains    Data science projects    timeout=30s
-        IF  ${reloaded}==${FALSE}    SeleniumLibrary.Capture Page Screenshot
-        ${projects}=    Get All Displayed Projects
-        ${projects_count}=    Get Length    ${projects}
-    END
+    Delete Data Science Projects From CLI    ${projects}
+    Reload Page
+    Wait For Dashboard Page Title    Data Science Projects    timeout=30s
 
 Clean All Models Of Current User
     [Documentation]    Tries to clean up DSP and Model Serving pages


### PR DESCRIPTION
This is required with the recent change of RHOAIENG-9576: Remove the DS Projects List Toggle

The KW `Clean Up DSP Page` should not loop on all projects in UI, but only on those which have DS project annotation in its namespace. In addition, fix the DS Project title element XPath.

Before the fix:
![image](https://github.com/user-attachments/assets/6cc0e845-05bf-4958-9d4a-9c14e99035ab)

After the fix:
![image](https://github.com/user-attachments/assets/e36d8929-3561-4833-ae65-a8d6a0f59241)
