### PR TITLE
fix: use common vars in the operator dependant tests to be able to run in both ODH/RHOAI

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -91,6 +91,7 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_APPNAME}     Red Hat OpenShift AI
         Set Suite Variable    ${OPERATOR_NAME}    Red Hat OpenShift AI
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
+        Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  rhods-operator
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
         Set Suite Variable    ${AUTHORINO_CR_NS}    redhat-ods-applications-auth-provider
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
@@ -100,6 +101,7 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_APPNAME}  Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_NAME}    Open Data Hub Operator
         Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
+        Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  manager
         Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
         Set Suite Variable    ${AUTHORINO_CR_NS}    opendatahub-auth-provider
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard

--- a/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/143__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/100__deploy/130__operators/130__rhods_operator/143__dsc_negative_dependant_operators_not_installed.robot
@@ -122,6 +122,7 @@ Validate DSC and DSCI Created With No Errors When Kserve Serving Is Unmanaged An
 Suite Setup
     [Documentation]    Suite Setup
     Set Library Search Order    SeleniumLibrary
+    RHOSi Setup
 
 Suite Teardown
     [Documentation]    Suite Teardown
@@ -208,7 +209,7 @@ DataScienceCluster Should Fail Because Service Mesh Operator Is Not Installed
     Should Contain    ${output}    operator servicemeshoperator not found. Please install the operator before enabling kserve component    #robocop:disable
 
     ${rc}    ${logs}=    Run And Return Rc And Output
-    ...    oc logs -l name=rhods-operator -c rhods-operator -n ${OPERATOR_NS} --ignore-errors
+    ...    oc logs -l ${OPERATOR_LABEL_SELECTOR} -c ${OPERATOR_POD_CONTAINER_NAME} -n ${OPERATOR_NS} --ignore-errors
 
     Should Contain    ${logs}    failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed.    #robocop:disable
 


### PR DESCRIPTION
These tests were initially thought to be run in RHOAI, but we want to add the ability to pass in ODH, so adding the needed changes to point to the proper pods/containers 