### PR TITLE
RHOAIENG-10534: make branch name determination in run_robot_test.sh more reliable

### DIFF
--- a/ods_ci/run_robot_test.sh
+++ b/ods_ci/run_robot_test.sh
@@ -319,9 +319,18 @@ if command -v yq &> /dev/null
 fi
 
 if [[ ${SKIP_INSTALL} -eq 0 ]]; then
-  # look for pre-created poetry .venv
-  branch=$(git branch --show-current)
-  virtenv="${HOME}/.local/ods-ci/${branch%,*}/.venv"
+  # Look for pre-created poetry .venv
+  # NOTE: handle that checkout might happen through `git checkout -f somehash` and branch names may include `/` char
+  refname="$(git branch --remote --no-abbrev --format="%(refname:lstrip=3)" --contains "HEAD" | head -1)"
+  venvdir="${refname%,*}"
+  echo "Git revision refname='${refname}', venvdir='${venvdir}'."
+  for venvdir in "${venvdir}" "master"; do
+    virtenv="${HOME}/.local/ods-ci/${venvdir}/.venv"
+    echo "Checking whether '${virtenv}' exists."
+    if [[ -d "${virtenv}" ]]; then
+      break
+    fi
+  done
   if [[ -d "${virtenv}" ]]; then
     echo "Using a pre-created virtual environment in '${virtenv}' for poetry to save time."
     poetry config --local virtualenvs.in-project true


### PR DESCRIPTION
We need to handle checkout by hash and spaces and slashes in branch name

/job/rhoai/job/2.8/job/selfmanaged/job/disconnected/job/psi/job/rhoai-smoke/20/console

```
12:11:01  Cloning the remote Git repository
12:11:01  Using shallow clone with depth 1
12:11:07  Cloning repository https://github.com/red-hat-data-services/ods-ci.git
12:11:07   > git init /home/jenkins/workspace/rhoai/2.8/selfmanaged/disconnected/psi/rhoai-smoke/ods-ci # timeout=10
12:11:08  Fetching upstream changes from https://github.com/red-hat-data-services/ods-ci.git
12:11:08   > git --version # timeout=10
12:11:08   > git --version # 'git version 2.45.0'
12:11:08   > git fetch --tags --force --progress --depth=1 -- https://github.com/red-hat-data-services/ods-ci.git +refs/heads/*:refs/remotes/origin/* # timeout=10
12:11:10   > git config remote.origin.url https://github.com/red-hat-data-services/ods-ci.git # timeout=10
12:11:10   > git config --add remote.origin.fetch +refs/heads/*:refs/remotes/origin/* # timeout=10
12:11:11  Avoid second fetch
12:11:11  Checking out Revision 9c35af49916bad0e5dd8748c23ea27ee9507c5db (origin/jd_refname)
12:11:11   > git rev-parse origin/jd_refname^{commit} # timeout=10
12:11:11   > git config core.sparsecheckout # timeout=10
12:11:12   > git checkout -f 9c35af49916bad0e5dd8748c23ea27ee9507c5db # timeout=10
12:11:20  Commit message: "RHOAIENG-10534: make branch name determination in run_robot_test.sh more reliable"
12:11:21  First time build. Skipping changelog.
12:11:21  Cleaning workspace
[Pipeline] }
[Pipeline] // dir
[Pipeline] dir
12:11:21  Running in /home/jenkins/workspace/rhoai/2.8/selfmanaged/disconnected/psi/rhoai-smoke/ods-ci/ods_ci
[Pipeline] {
[Pipeline] sh
12:11:22  + ./run_robot_test.sh --skip-oclogin true --test-variables-file test-variables-odh-overwrite.yml --extra-robot-args '--runemptysuite --include []'
12:11:22  test-variables-odh-overwrite.yml
12:11:22  INFO: we found a yq executable
12:11:22  skipping OC login as per parameter --skip-oclogin
12:11:22  Git revision refname='jd_refname', venvdir='jd_refname'.
12:11:22  Checking whether '/home/build/.local/ods-ci/jd_refname/.venv' exists.
12:11:22  Checking whether '/home/build/.local/ods-ci/master/.venv' exists.
12:11:22  Pre-created virtual environment has not been found in '/home/build/.local/ods-ci/master/.venv'. All dependencies will be installed from scratch.
```