### PR TITLE
Add Azure OCP cluster provisioning support

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
@@ -73,4 +73,4 @@ items:
     name: {{ image_set|default("rhods-openshift") }}
     namespace: {{ hive_claim_ns }}
   spec:
-    releaseImage: {{ openshift_image|default("quay.io/openshift-release-dev/ocp-release:4.10.42-x86_64") }}
+    releaseImage: {{ openshift_image|default("quay.io/openshift-release-dev/ocp-release:4.15.25-x86_64") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/AZURE/azure-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AZURE/azure-cluster.yaml
@@ -1,0 +1,89 @@
+apiVersion: v1
+kind: List
+items:
+- apiVersion: hive.openshift.io/v1
+  kind: ClusterPool
+  metadata:
+    name: {{ hive_cluster_name|default("rhodsazure") }}-pool
+    namespace: {{ hive_claim_ns }}
+  spec:
+    baseDomain: {{ base_domain }}
+    imageSetRef:
+      name: {{ image_set|default("rhods-openshift") }}
+    platform:
+      azure:
+        baseDomainResourceGroupName: {{ azure_domainresourcegroup }}
+        cloudName: AzurePublicCloud
+        region: {{ azure_region|default("eastus") }}
+        credentialsSecretRef:
+          name: azure-creds
+    installConfigSecretTemplateRef:
+      name: azure-sno-install-config
+    size: 0
+    skipMachinePools: true
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: azure-sno-install-config
+    namespace: {{ hive_claim_ns }}
+  type: Opaque
+  stringData:
+    install-config.yaml: |
+      apiVersion: v1
+      baseDomain: {{ base_domain }}
+      compute:
+      - name: worker
+        platform:
+          azure:
+            type: {{ worker_node_instance_type|default("Standard_D8s_v3") }}
+            osDisk:
+              diskSizeGB: 128
+        replicas: {{ worker_node_replicas|default("3") }}
+      controlPlane:
+        name: master
+        platform:
+          azure:
+            type: {{ master_node_instance_type|default("Standard_D8s_v3") }}
+            osDisk:
+              diskSizeGB: 128
+        replicas: {{ master_node_replicas|default("3") }}
+      metadata:
+        name: azure-sno
+      networking:
+        clusterNetwork:
+        - cidr: 10.128.0.0/14
+          hostPrefix: 23
+        machineNetwork:
+        - cidr: 10.0.0.0/16
+        networkType: {{ ocp_network_type|default("OVNKubernetes") }}
+        serviceNetwork:
+        - 172.30.0.0/16
+      fips: {{ fips_validation|default("false") }}
+      platform:
+        azure:
+          baseDomainResourceGroupName: {{ azure_domainresourcegroup }}
+          cloudName: AzurePublicCloud
+          region: {{ azure_region|default("eastus") }}
+      pullSecret: {{ pull_secret|default("") }}
+      sshKey: {{ ssh_key|default("") }}
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: azure-creds
+    namespace: {{ hive_claim_ns }}
+  type: Opaque
+  stringData:
+    osServicePrincipal.json: |
+      {
+        "subscriptionId": {{ '\"' + azure_subscriptionId + '\"' }},
+        "clientId": {{ '\"' + azure_clientId + '\"' }},
+        "clientSecret": {{ '\"' + azure_clientSecret + '\"' }},
+        "tenantId": {{ '\"' + azure_tenantId + '\"' }}
+      }
+- apiVersion: hive.openshift.io/v1
+  kind: ClusterImageSet
+  metadata:
+    name: {{ image_set|default("rhods-openshift") }}
+    namespace: {{ hive_claim_ns }}
+  spec:
+    releaseImage: {{ openshift_image|default("quay.io/openshift-release-dev/ocp-release:4.10.42-x86_64") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/AZURE/azure-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/AZURE/azure-cluster.yaml
@@ -86,4 +86,4 @@ items:
     name: {{ image_set|default("rhods-openshift") }}
     namespace: {{ hive_claim_ns }}
   spec:
-    releaseImage: {{ openshift_image|default("quay.io/openshift-release-dev/ocp-release:4.10.42-x86_64") }}
+    releaseImage: {{ openshift_image|default("quay.io/openshift-release-dev/ocp-release:4.15.25-x86_64") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
@@ -85,4 +85,4 @@ items:
     name: {{ image_set|default("rhods-openshift") }}
     namespace: {{ hive_claim_ns }}
   spec:
-    releaseImage: {{ release_image|default("quay.io/openshift-release-dev/ocp-release:4.10.18-x86_64") }}
+    releaseImage: {{ release_image|default("quay.io/openshift-release-dev/ocp-release:4.15.25-x86_64") }}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -81,10 +81,7 @@ Handle Already Existing Cluster
 
 Create Provider Resources
     Log    Creating Hive resources for cluster ${cluster_name} on ${provider_type} according to: ${template}   console=True
-    IF    "${provider_type}" == "AWS"
-        Oc Apply    kind=List    src=${template}    api_version=v1
-        ...    template_data=${infrastructure_configurations}
-    ELSE IF    "${provider_type}" == "GCP"
+    IF    "${provider_type}" in ["AWS", "GCP", "AZURE"]
         Oc Apply    kind=List    src=${template}    api_version=v1
         ...    template_data=${infrastructure_configurations}
     ELSE IF    "${provider_type}" == "OSP"
@@ -103,19 +100,18 @@ Select Provisioner Template
     [Arguments]    ${provider_type}
     IF    "${provider_type}" == "AWS"
         Set Task Variable    ${template}    tasks/Resources/Provisioning/Hive/AWS/aws-cluster.yaml
-        Log    Setting AWS Hive Template ${template}   console=True
     ELSE IF    "${provider_type}" == "GCP"
         Set Task Variable    ${template}    tasks/Resources/Provisioning/Hive/GCP/gcp-cluster.yaml
-        Log    Setting GCP Hive Template ${template}    console=True
     ELSE IF    "${provider_type}" == "OSP"
         Set Task Variable    ${template}    tasks/Resources/Provisioning/Hive/OSP/hive_osp_cluster_template.yaml
-        Log    Setting OSP Hive Template ${template}    console=True
     ELSE IF    "${provider_type}" == "IBM"
         Set Task Variable    ${template}    tasks/Resources/Provisioning/Hive/IBM/ibmcloud-cluster.yaml
-        Log    Setting IBM Hive Template ${template}    console=True
+    ELSE IF    "${provider_type}" == "AZURE"
+        Set Task Variable    ${template}    tasks/Resources/Provisioning/Hive/AZURE/azure-cluster.yaml
     ELSE
         FAIL    Invalid provider name
     END
+    Log    Setting ${provider_type} Hive Template ${template}    console=True
     RETURN    ${template}
 
 Create Openstack Resources


### PR DESCRIPTION
Extend RF task to provision self-managed OCP clusters on Azure.
In addition it applies some code optimization to reduce lines of code.

Regression tests:
1. Selfmanaged AWS provisioning: `rhods-ci-pr-test/3195` OK - the provisioning failed because of some quota reached, but the test was mainly to check it was able to start.
2. Selfmanaged GCP provisioning: `rhods-ci-pr-test/3197` OK
3. Provisioning: PASSED locally, CI not yet supported.