### PR TITLE
Update codeflare-sdk test suit to use python environment for 2.8.4 re…

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
@@ -12,7 +12,8 @@ Resource          ../../Resources/RHOSi.resource
 ${CODEFLARE-SDK_DIR}                codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}           %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${CODEFLARE-SDK_REPO_BRANCH}        %{CODEFLARE-SDK_REPO_BRANCH=vv0.14.1}
-${VIRTUAL_ENV_NAME}                 venv3.9
+${PYTHON_VERSION}                   3.9
+${VIRTUAL_ENV_NAME}                 venv${PYTHON_VERSION}
 
 
 *** Test Cases ***
@@ -37,7 +38,7 @@ Prepare Codeflare-sdk E2E Test Suite
     Enable Component    codeflare
     Enable Component    ray
 
-     ${result} =    Run Process  virtualenv -p python3.9 ${VIRTUAL_ENV_NAME}
+     ${result} =    Run Process  virtualenv -p python${PYTHON_VERSION} ${VIRTUAL_ENV_NAME}
     ...    shell=true    stderr=STDOUT
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
@@ -77,10 +78,10 @@ Run Codeflare-sdk E2E Test
     [Documentation]    Run codeflare-sdk E2E Test
     [Arguments]    ${test_name}
     Log To Console    Running codeflare-sdk test: ${test_name}
-    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd codeflare-sdk && poetry env use 3.9 && poetry install --with test,docs && poetry run pytest -v -s ./tests/e2e/${TEST_NAME} --timeout\=600 && deactivate
+    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd codeflare-sdk && poetry env use ${PYTHON_VERSION} && poetry install --with test,docs && poetry run pytest -v -s ./tests/e2e/${test_name} --timeout\=600 && deactivate
     ...    shell=true
     ...    stderr=STDOUT
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
-        FAIL    ${TEST_NAME} failed
+        FAIL    ${test_name} failed
     END

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
@@ -11,7 +11,7 @@ Resource          ../../Resources/RHOSi.resource
 *** Variables ***
 ${CODEFLARE-SDK_DIR}                codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}           %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
-${CODEFLARE-SDK_REPO_BRANCH}        %{CODEFLARE-SDK_REPO_BRANCH=vv0.14.1}
+${CODEFLARE-SDK_REPO_BRANCH}        %{CODEFLARE-SDK_REPO_BRANCH=adjustments-release-v0.14.1}
 ${PYTHON_VERSION}                   3.9
 ${VIRTUAL_ENV_NAME}                 venv${PYTHON_VERSION}
 

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
@@ -9,7 +9,7 @@ Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 
 *** Variables ***
 ${CODEFLARE_DIR}                codeflare-operator
-${CODEFLARE_RELEASE_ASSETS}     %{CODEFLARE_RELEASE_ASSETS=https://github.com/opendatahub-io/codeflare-operator/releases/latest/download}
+${CODEFLARE_RELEASE_ASSETS}     %{CODEFLARE_RELEASE_ASSETS=https://github.com/opendatahub-io/codeflare-operator/releases/download/v1.2.0}
 ${ODH_NAMESPACE}                %{ODH_NAMESPACE=redhat-ods-applications}
 ${NOTEBOOK_IMAGE_STREAM_NAME}   %{NOTEBOOK_IMAGE_STREAM_NAME=s2i-generic-data-science-notebook}
 


### PR DESCRIPTION
Updated Codeflare-SDK test suit to use python test environment instead of golang tests

Related PR : https://github.com/project-codeflare/codeflare-sdk/pull/635