### PR TITLE
fix: using opendatahub-operator for odh-nightlies

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -80,7 +80,7 @@ Verify RHODS Installation
   Log To Console    Waiting for all RHODS resources to be up and running
   Wait For Pods Numbers  1
   ...                   namespace=${OPERATOR_NAMESPACE}
-  ...                   label_selector=name=${OPERATOR_NAME}
+  ...                   label_selector=name=${OPERATOR_NAME_LABEL}
   ...                   timeout=2000
   Wait For Pods Status  namespace=${OPERATOR_NAMESPACE}  timeout=1200
   Log  Verified ${OPERATOR_NAMESPACE}  console=yes

--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -23,6 +23,7 @@ Can Install RHODS Operator
   [Tags]  install
   IF  "${PRODUCT}" == "ODH"
       Set Global Variable  ${OPERATOR_NAMESPACE}  opendatahub-operators
+      Set Global Variable  ${OPERATOR_NAME_LABEL}  opendatahub-operator
       IF  "${UPDATE_CHANNEL}" == "odh-nightlies"
           Set Global Variable  ${OPERATOR_NAME}  rhods-operator
       ELSE
@@ -30,6 +31,7 @@ Can Install RHODS Operator
       END
   ELSE
       Set Global Variable  ${OPERATOR_NAME}  rhods-operator
+      Set Global Variable  ${OPERATOR_NAME_LABEL}  rhods-operator
   END
   Given Selected Cluster Type ${cluster_type}
   When Installing RHODS Operator ${image_url}


### PR DESCRIPTION
We switched last week to use opendatahub-operator tag in the ODH nightlies build, and not using rhods-operator anymore. Aligning the changes to unblock the ODH installation