### PR TITLE
Move kueue restart workaround to Codeflare-SDK setup

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -28,6 +28,10 @@ Clone Git Repository
 
 Prepare Codeflare-SDK Test Setup
     [Documentation]   Prepare codeflare-sdk tests by cloning codeflare-sdk repo and python virtual environmnet
+
+    Log To Console    "Restarting kueue"
+    Restart Kueue
+
     ${latest_tag} =    Run Process   curl -s "${CODEFLARE-SDK-API_URL}" | grep '"tag_name":' | cut -d '"' -f 4
     ...    shell=True    stderr=STDOUT
     Log To Console  codeflare-sdk latest tag is : ${latest_tag.stdout}

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-sdk-e2e-tests.robot
@@ -29,8 +29,6 @@ Run TestRayLocalInteractiveOauth test
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite
     [Documentation]    Prepare codeflare-sdk E2E Test Suite
-    Log To Console    "Restarting kueue"
-    Restart Kueue
     Prepare Codeflare-SDK Test Setup
     RHOSi Setup
 


### PR DESCRIPTION
 Moved kueue restart workaround step for codeflare-sdk tests to `Prepare Codeflare-SDK Test Setup` to avoid errors in Ray cluster upgrade tests scenarios