### PR TITLE
Add automationBug tag to ODS2206

### DIFF
--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
@@ -29,8 +29,10 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     [Documentation]    Verifies users are able to create and execute Data Science Pipelines using the UI.
     ...    The pipeline to run will be using the values for pip_index_url and pip_trusted_host
     ...    availables in a ConfigMap created in the SuiteSetup.
+    ...    AutomationBug: RHOAIENG-10941
     [Tags]    Smoke
     ...       ODS-2206    ODS-2226    ODS-2633
+    ...       AutomationBug
 
     Open Data Science Project Details Page    ${PRJ_TITLE}
 


### PR DESCRIPTION
Add automation bug tag to **ODS-2206 : Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Page Using Custom Pip Mirror**
The test is failing in the smoke runs