### PR TITLE
Exclude drift tests from disconnected

### DIFF
--- a/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
@@ -20,7 +20,7 @@ ${LOG_OUTPUT_FILE}                    drift_test.txt
 *** Test Cases ***
 Run Drift Metrics Tests
     [Documentation]    Verifies that the Drift metrics are available for a deployed model
-    [Tags]    RHOAIENG-8163     Smoke
+    [Tags]    RHOAIENG-8163     Smoke     ExcludeOnDisconnected
     Run Drift Pytest Framework
 
 


### PR DESCRIPTION
Drift tests are currently pulling images directly from quay, and those images are not present in disconnected clusters. We need to exclude drift tests from disconnected runs until we adapt them.