### PR TITLE
General fixes for UI Keywords in RHOAI 2.12

### DIFF
--- a/ods_ci/tests/Resources/Page/LoginPage.robot
+++ b/ods_ci/tests/Resources/Page/LoginPage.robot
@@ -41,15 +41,12 @@ Login To Openshift
     ...    being automatically redirected to the destination app. Note: ${expected_text_list} should contain a
     ...    expected string in the destination app.
     [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
-
     # Wait until page is the Login page or the destination app
     ${expected_text_list} =    Create List    Log in with    Administrator    Developer    Data Science Projects
     Wait Until Page Contains A String In List    ${expected_text_list}
-
     # Return if page is not the Login page (no login required)
     ${should_login} =    Does Current Sub Domain Start With    https://oauth
     IF  not ${should_login}    RETURN
-
     # If here we need to login
     Wait Until Element is Visible  xpath://div[@class="pf-c-login"]  timeout=10s
     ${select_auth_type} =  Does Login Require Authentication Type
@@ -59,6 +56,7 @@ Login To Openshift
     Input Text  id=inputPassword  ${ocp_user_pw}
     Click Button   //*[@type="submit"]
     Maybe Skip Tour
+    Wait Until Page Does Not Contain    Log in to your account    timeout=30s
 
 Log In Should Be Requested
     [Documentation]    Passes if the login page appears and fails otherwise

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -76,7 +76,7 @@ Authorize rhods-dashboard service account
 Login To RHODS Dashboard
    [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
    # Wait until we are in the OpenShift auth page or already in Dashboard
-   ${expected_text_list}=    Create List    Log in with
+   ${expected_text_list}=    Create List    Log in with    Data Science Projects
    Wait Until Page Contains A String In List    ${expected_text_list}
    ${oauth_prompt_visible}=  Is OpenShift OAuth Login Prompt Visible
    IF  ${oauth_prompt_visible}  Click Button  Log in with OpenShift
@@ -84,7 +84,7 @@ Login To RHODS Dashboard
    IF  ${login-required}  Login To Openshift  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
    ${authorize_service_account}=  Is rhods-dashboard Service Account Authorization Required
    IF  ${authorize_service_account}  Authorize rhods-dashboard service account
-   Navigate To Page    Applications    Enabled
+   Navigate To Page    Applications    Enabled    timeout=10s
 
 Logout From RHODS Dashboard
     [Documentation]  Logs out from the current user in the RHODS dashboard

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
@@ -32,7 +32,6 @@ Create S3 Data Connection
     ...            ${S3_DC_ADD_BTN}    aws_s3_endpoint=${aws_s3_endpoint}    aws_region=${aws_region}
     ...            connected_workbench=${connected_workbench}    press_cancel=${press_cancel}
     ...            aws_bucket_name=${aws_bucket_name}
-    Wait Until Project Is Open    project_title=${project_title}
 
 Edit S3 Data Connection
     [Documentation]    Edits a S3 Data Connection from DS Project details page
@@ -44,7 +43,6 @@ Edit S3 Data Connection
     ...            ${S3_DC_EDIT_BTN}    aws_s3_endpoint=${aws_s3_endpoint}    aws_region=${aws_region}
     ...            connected_workbench=${connected_workbench}    press_cancel=${press_cancel}
     ...            aws_bucket_name=${aws_bucket_name}
-    Wait Until Project Is Open    project_title=${project_title}
 
 Set Connection Between Data Connection And Workbench
     [Documentation]    Connects a DataConnection to an existent workbench

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -8,7 +8,7 @@ Resource       ./Workbenches.resource
 ${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
-${RESOURCE_INPUT_XP}=    xpath=//input[@id="resource-manage-project-modal-name"]
+${RESOURCE_INPUT_XP}=    xpath=//input[@data-testid="resource-manage-project-modal-name"]
 ${GENERIC_CREATE_BTN_XP}=     xpath=//button[text()="Create"]
 ${GENERIC_CANCEL_BTN_XP}=     xpath=//button[text()="Cancel"]
 ${PROJECT_CREATE_BTN_XP}=     xpath=//button[text()="Create data science project"]
@@ -104,7 +104,8 @@ Project Should Be Listed
 
 Wait Until Project Is Listed
     [Documentation]    Waits until the DS projects appears in the list in DS project Home Page
-    [Arguments]     ${project_title}    ${timeout}=30s
+    [Arguments]     ${project_title}    ${timeout}=5s
+    Filter Projects By Name    ${project_title}
     Wait Until Page Contains Element    xpath=//div//a[text()="${project_title}"]
     ...    timeout=${timeout}
 
@@ -140,10 +141,11 @@ Create Data Science Project
         Input Text    ${TITLE_INPUT_XP}    ${title}
         Input Text    ${DESCR_INPUT_XP}    ${description}
         Run Keyword And Continue On Failure    Validate Generated Resource Name    project_title=${title}
-        IF    "${resource_name}" != "${NONE}"
-            Clear Element Text    ${RESOURCE_INPUT_XP}
-            Input Text    ${RESOURCE_INPUT_XP}    ${resource_name}
+        IF    "${resource_name}" == "${NONE}"
+            ${resource_name}=    Get Value  ${RESOURCE_INPUT_XP}
+            ${resource_name}=    Generate Unique Namespace    ${resource_name}
         END
+        Input Text    ${RESOURCE_INPUT_XP}    ${resource_name}
         Wait Until Element Is Enabled    ${GENERIC_CREATE_BTN_XP}
         Click Button    ${GENERIC_CREATE_BTN_XP}
         Wait Until Generic Modal Disappears
@@ -158,6 +160,18 @@ Create Data Science Project
             Fail
         END
     END
+
+Generate Unique Namespace
+    [Documentation]    If DS Project Namespace '${namespace}' already exists - Return the Namespace + Random Suffix.
+    ...                (DS Project Display Name does not need to be unique, but DS Project Namespace does).
+    [Arguments]    ${namespace}
+    ${rc}=    Run And Return Rc    oc get namespace ${namespace}
+    IF    "${rc}" == "${0}" and len("${namespace}") < 60
+        # Add unique string to Project resource name (max length is 63 chars)
+        ${suffix}=    Generate Random String    3   [LOWER]
+        ${namespace}=    Set Variable    ${namespace}-${suffix}
+    END
+    RETURN    ${namespace}
 
 Create Data Science Project From CLI
     [Documentation]    Creates a Data Science Project, adding the needed labels to be recognized by Dashboard.
@@ -214,34 +228,37 @@ Get Openshift Namespace From Data Science Project
     ${k8s_name}=    Replace String    ${k8s_name}    "    ${EMPTY}
     RETURN    ${k8s_name}
 
-Delete Data Science Projects From CLI
-    [Documentation]     Deletes the Openshift Projects using OpenshiftLibrary.
-    ...                 It expects to receive a list of project (i.e,${ocp_projects}) as argument
+Delete List Of Projects Via CLI
+    [Documentation]     Loop over the Project list and Delete all projects using OC command.
+    ...                 It expects to receive a list of projects (i.e. ${ocp_projects}) as argument
     [Arguments]     ${ocp_projects}
     FOR   ${displayed_name}    IN  @{ocp_projects}
-        Delete Data Science Project From CLI    displayed_name=${displayed_name}
+        Delete Project Via CLI By Display Name    displayed_name=${displayed_name}
     END
 
-Delete Data Science Project From CLI
-    [Documentation]    Deletes a single DS project usig CLI command by project display-name
+#robocop: disable: line-too-long
+Delete Project Via CLI By Display Name
+    [Documentation]    Find and delete namespaces by DS Project display name '${displayed_name}' using OC command.
+    ...                If specifying "ALL" - All Data Science user-defined projects will be deleted.
     [Arguments]     ${displayed_name}
-    ${project_k8s_name}=     Run     oc get projects -o json | jq '.items[] | select((.metadata.annotations."openshift.io/display-name" != null) and (.metadata.labels."opendatahub.io/dashboard"=="true") and (.metadata.annotations."openshift.io/display-name"=="${displayed_name}")) | .metadata.name'    # robocop: disable
-    ${project_k8s_name}=    Replace String    ${project_k8s_name}    "    ${EMPTY}
-    IF    "${project_k8s_name}" == "${EMPTY}"
-        Log    msg=There are probably no DS Projects with Display Name equal to ${displayed_name}
+    # DS Project Display name is not unique (i.e. multiple projects with same display name), but Project namespace is unique
+    IF    "${displayed_name}"=="ALL"
+        ${display_query}=    Set Variable   "openshift.io/display-name"!\=null
+    ELSE
+        ${display_query}=    Set Variable   "openshift.io/display-name"\=\="${displayed_name}"
+    END
+    ${project_k8s_name}=     Run     oc get projects -o json | jq -r '.items[] | select((.metadata.labels."opendatahub.io/dashboard"\=\="true") and (.metadata.annotations.${display_query})) | .metadata.name'
+    IF    """${project_k8s_name}""" == """${EMPTY}"""
+        Log    msg=Project '${displayed_name}' not found, or not a user-defined Data Science project
         ...    level=WARN
     ELSE
-        Delete Data Science Project From CLI By Name    name=${project_k8s_name}
-    END
-
-Delete Data Science Project From CLI By Name
-    [Documentation]    Deletes a single DS project usig CLI command by project resource name
-    [Arguments]     ${name}
-    Oc Delete    kind=Project   name=${name}
-    WHILE    ${TRUE}
-        ${exists}=    Run And Return Rc    oc get project ${name}
-        IF    "${exists}" == "1"    BREAK
-        Sleep    5s    reason=let's not overload the API
+        ${project_k8s_name}=    Replace String    ${project_k8s_name}    \n    ${SPACE}
+        ${project_names}=    Split String    string=${project_k8s_name}
+        ${counter}=    Get Length    ${project_names}
+        ${counter}=  Evaluate  ${counter} * 20
+        ${rc}=    Wait Until Keyword Succeeds    ${counter}s    5s
+        ...    Run And Return Rc    oc delete namespace ${project_k8s_name}
+        Should Be Equal As Integers    ${rc}    ${0}
     END
 
 #robocop: disable: line-too-long

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -260,17 +260,18 @@ Select Workbench Container Size
 
 Workbench Should Be Listed
     [Documentation]    Checks a workbench is listed in the DS Project details page
-    [Arguments]     ${workbench_title}    ${timeout}=5s
+    [Arguments]     ${workbench_title}    ${timeout}=10s
     Run keyword And Continue On Failure
     ...    Wait Until Page Contains Element
     ...    ${WORKBENCH_SECTION_XP}//td[@data-label="Name"]/*[div[text()="${workbench_title}"]]    timeout=${timeout}
 
 Workbench With Description Should Be Listed
     [Documentation]    Checks a workbench with particular name and description is listed in the DS Project details page
-    [Arguments]     ${workbench_title}  ${workbench_description}
+    [Arguments]     ${workbench_title}  ${workbench_description}    ${timeout}=10s
     Run keyword And Continue On Failure
     ...    Wait Until Page Contains Element
-    ...        ${WORKBENCH_SECTION_XP}//td[@data-label="Name"][//div[text()="${workbench_title}"] and //p[text()="${workbench_description}"]]
+    ...    ${WORKBENCH_SECTION_XP}//td[@data-label="Name"][//div[text()="${workbench_title}"] and //p[text()="${workbench_description}"]]
+    ...    timeout=${timeout}
 
 Workbench Should Not Be Listed
     [Documentation]    Checks a workbench is not listed in the DS Project details page

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -587,8 +587,7 @@ Clean Up DSP Page
         Click Element    //button[@aria-label="Close"]
     END
     Open Data Science Projects Home Page
-    ${projects}=    Get All Displayed Projects
-    Delete Data Science Projects From CLI    ${projects}
+    Delete Project Via CLI By Display Name    ALL
     Reload Page
     Wait For Dashboard Page Title    Data Science Projects    timeout=30s
 
@@ -598,9 +597,9 @@ Clean All Models Of Current User
     ...    controls how many retries are made.
     [Arguments]    ${retries}=5
     Open Model Serving Home Page
-    ${projects_empty}=    Run Keyword And Return Status    Page Should Contain    No data science projects
+    ${projects_empty}=    Run Keyword And Return Status    Page Should Contain    No deployed models
     IF    ${projects_empty}
-        Log    No Data Sciense projects exist, skipping cleanup    console=True
+        Log    No Models Deployed, Skipping Cleanup    console=True
     ELSE
         FOR    ${try}    IN RANGE    0    ${retries}
             ${status}=    Run Keyword And Return Status    Page Should Contain    Select a project

--- a/ods_ci/tests/Tests/1000__model_serving/1002__model_serving_modelmesh_gpu.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1002__model_serving_modelmesh_gpu.robot
@@ -89,7 +89,7 @@ Model Serving Suite Teardown
     IF    ${MODEL_CREATED}
         Run Keyword And Continue On Failure    Delete Model Via UI    ${MODEL_NAME}
         ${projects}=    Create List    ${PRJ_TITLE}
-        Delete Data Science Projects From CLI   ocp_projects=${projects}
+        Delete List Of Projects Via CLI   ocp_projects=${projects}
     ELSE
         Log    Model not deployed, skipping deletion step during teardown    console=true
     END

--- a/ods_ci/tests/Tests/1000__model_serving/1003__model_serving_customruntimes.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1003__model_serving_customruntimes.robot
@@ -100,7 +100,7 @@ Custom Serving Runtime Suite Setup
     Fetch CA Certificate If RHODS Is Self-Managed
 
 Custom Serving Runtime Suite Teardown
-    Delete Data Science Project From CLI    displayed_name=${PRJ_TITLE}
+    Delete Project Via CLI By Display Name    displayed_name=${PRJ_TITLE}
     Delete Serving Runtime Template From CLI    displayed_name=${UPLOADED_OVMS_DISPLAYED_NAME}
     SeleniumLibrary.Close All Browsers
     Remove File    openshift_ca.crt

--- a/ods_ci/tests/Tests/1000__model_serving/1004__model_serving_cluster_setting.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1004__model_serving_cluster_setting.robot
@@ -90,7 +90,7 @@ Model Serving Cluster Setting Test Setup
 
 Model Serving Cluster Setting Suite Teardown
     [Documentation]    Delete DS project and select both model serving options
-    Delete Data Science Project                 ${project_title}
+    Delete Project Via CLI By Display Name                 ${project_title}
     Wait Until Data Science Project Is Deleted  ${project_title}
     Open Dashboard Settings    settings_page=Cluster settings
     Wait Until Page Contains Element    //*[contains(text(), "Model serving platforms")]  timeout=20

--- a/ods_ci/tests/Tests/1000__model_serving/1005__model_serving_ovms_on_kserve.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1005__model_serving_ovms_on_kserve.robot
@@ -190,7 +190,7 @@ OVMS On Kserve Suite Teardown
         Log    Model not deployed, skipping deletion step during teardown    console=true
     END
     ${projects}=    Create List    ${PRJ_TITLE}
-    Delete Data Science Projects From CLI   ocp_projects=${projects}
+    Delete List Of Projects Via CLI   ocp_projects=${projects}
     # Will only be present on SM cluster runs, but keyword passes
     # if file does not exist
     Remove File    openshift_ca_istio_knative.crt

--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_other_runtimes_UI.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_other_runtimes_UI.robot
@@ -151,6 +151,6 @@ Non-Admin Setup Kserve UI Test
 Non-Admin Teardown Kserve UI Test
     Delete Data Science Project   project_title=${TEST_NS}
     # if UI deletion fails it will try deleting from CLI
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     SeleniumLibrary.Close All Browsers
     RHOSi Teardown

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
@@ -71,7 +71,7 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
 
     ODHDataSciencePipelines.Delete Pipeline           ${PIPELINE_TEST_NAME}
     ODHDataSciencePipelines.Delete Pipeline Server    ${PRJ_TITLE}
-    [Teardown]    Delete Data Science Project         ${PRJ_TITLE}
+    [Teardown]    Delete Project Via CLI By Display Name         ${PRJ_TITLE}
 
 
 *** Keywords ***
@@ -97,7 +97,7 @@ Pipelines Suite Setup
 Pipelines Suite Teardown
     [Documentation]    Deletes the test project which automatically triggers the
     ...                deletion of any pipeline resource contained in it
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 # robocop: disable:too-many-calls-in-keyword

--- a/ods_ci/tests/Tests/1200__ai_explainability/1201__model_serving_bias_metrics.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1201__model_serving_bias_metrics.robot
@@ -101,7 +101,7 @@ Bias Metrics Suite Setup
 
 Bias Metrics Suite Teardown
     [Documentation]     Bias Metrics Suite Teardown
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 Verify User Workload Monitoring Configuration

--- a/ods_ci/tests/Tests/1200__ai_explainability/1202__saliency_explainers.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1202__saliency_explainers.robot
@@ -79,7 +79,7 @@ Explainers Suite Setup
 Explainers Suite Teardown
     [Documentation]     Explainers Suite Teardown
     Set Library Search Order    SeleniumLibrary
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 Set Project And Serving Runtime

--- a/ods_ci/tests/Tests/400__ods_dashboard/405__ods_dashboard_user_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/405__ods_dashboard_user_mgmt.robot
@@ -16,7 +16,7 @@ Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
     [Tags]  ODS-1661    ODS-1555
     ...     Tier1
     # Login with RHOAI regular user (Settings should not be avaiable)
-    Launch Dashboard And Check User Management Option Is Available For The User   
+    Launch Dashboard And Check User Management Option Is Available For The User
     ...  ${TEST_USER_3.USERNAME}  ${TEST_USER_3.PASSWORD}  ${TEST_USER_3.AUTH_TYPE}  settings_should_be=${FALSE}
     # Login with RHOAI Admin user (Settings should be avaiable)
     Launch Dashboard And Check User Management Option Is Available For The User

--- a/ods_ci/tests/Tests/400__ods_dashboard/406__ods_dashboard_api.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/406__ods_dashboard_api.robot
@@ -938,4 +938,4 @@ Create User Test Projects
 
 Delete User Test Projects
     ${projects_to_delete}=    Create List    ${BASIC_USER_PRJ}    ${ADMIN_USER_PRJ}
-    Delete Data Science Projects From CLI   ocp_projects=${projects_to_delete}
+    Delete List Of Projects Via CLI   ocp_projects=${projects_to_delete}

--- a/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects.robot
@@ -517,7 +517,7 @@ Verify User Can Access Only Its Owned Projects
     [Setup]    Run Keywords
     ...    SeleniumLibrary.Close All Browsers
     ...    AND
-    ...    Delete Data Science Project From CLI    displayed_name=${PRJ_TITLE}
+    ...    Delete Project Via CLI By Display Name    displayed_name=${PRJ_TITLE}
     Launch Data Science Project Main Page    username=${TEST_USER_3.USERNAME}    password=${TEST_USER_3.PASSWORD}
     Open Data Science Projects Home Page
     Create Data Science Project    title=${PRJ_1_USER3}    description=${EMPTY}
@@ -573,7 +573,7 @@ Project Suite Setup
     Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
     Set Variables For User Access Test
     RHOSi Setup
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     Launch Data Science Project Main Page
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
     ...    resource_name=${PRJ_RESOURCE_NAME}
@@ -582,7 +582,7 @@ Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DS Projects. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
     SeleniumLibrary.Close All Browsers
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 Set Variables For User Access Test

--- a/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_additional.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_additional.robot
@@ -173,7 +173,7 @@ Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 Verify Workbench Has The Expected Tolerations
@@ -317,8 +317,5 @@ Create Multiple Data Science Projects
 Delete Multiple Data Science Projects
     [Arguments]    ${title}     ${number}
     FOR    ${counter}    IN RANGE    1    ${number}+1    1
-        ${rc}  ${output}=    Run And Return Rc And Output    oc delete project ${title}${counter}
-        IF  "${rc}" != "0"
-            Run Keyword And Continue On Failure    Fail    msg=${output}
-        END
+        Delete Project Via CLI By Display Name    ${title}${counter}
     END

--- a/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_edit.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_edit.robot
@@ -50,7 +50,7 @@ Verify User Can Edit A Data Science Project
     ...    project_title=${PRJ_TITLE_2}    new_title=${NEW_PRJ_TITLE}    new_description=${NEW_PRJ_DESCRIPTION}
     ${ns_newname}=    Get Openshift Namespace From Data Science Project   project_title=${NEW_PRJ_TITLE}
     Should Be Equal As Strings  ${ns_name}  ${ns_newname}
-    [Teardown]     Delete Data Science Projects From CLI    ${PROJECTS_TO_DELETE}
+    [Teardown]     Delete List Of Projects Via CLI    ${PROJECTS_TO_DELETE}
 
 Verify User Can Edit A Workbench
     [Documentation]    Verifies users can edit a workbench name and description
@@ -60,7 +60,7 @@ Verify User Can Edit A Workbench
     [Setup]    Open Data Science Project Details Page    project_title=${PRJ_TITLE}    tab_id=workbenches
     Create Workbench    workbench_title=${WORKBENCH_TITLE}  workbench_description=${WORKBENCH_DESCRIPTION}
     ...                 prj_title=${PRJ_TITLE}    image_name=${NB_IMAGE}   deployment_size=Small
-    ...                 storage=Persistent  pv_existent=${FALSE}
+    ...                 storage=Persistent  pv_existent=${NONE}
     ...                 pv_name=${PV_BASENAME}  pv_description=${PV_DESCRIPTION}  pv_size=${PV_SIZE}
     Workbench Should Be Listed      workbench_title=${WORKBENCH_TITLE}
     Workbench Status Should Be      workbench_title=${WORKBENCH_TITLE}      status=${WORKBENCH_STATUS_STARTING}
@@ -105,18 +105,17 @@ Project Suite Setup
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Launch Data Science Project Main Page
+    Delete List Of Projects Via CLI    ${PROJECTS_TO_DELETE}
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
-    ...    resource_name=${PRJ_RESOURCE_NAME}
+    ...    resource_name=${PRJ_RESOURCE_NAME}    existing_project=${TRUE}
     Open Data Science Projects Home Page
-    ${to_delete}=    Create List    ${PRJ_TITLE}
-    Set Suite Variable    ${PROJECTS_TO_DELETE}    ${to_delete}
 
 Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DS Projects. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    # Delete All Data Science Projects From CLI
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Append To List    ${PROJECTS_TO_DELETE}    ${PRJ_TITLE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
 
 Check Name And Description Should Be Editable

--- a/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_notebook_images.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_notebook_images.robot
@@ -77,5 +77,5 @@ Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DS Projects. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown

--- a/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_permissions_mgmt.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/410__ods_dashboard_projects/410__ods_dashboard_projects_permissions_mgmt.robot
@@ -25,16 +25,10 @@ ${PRJ_USER_C_TITLE}=            ${PRJ_BASE_TITLE}-${TEST_USER_4.USERNAME}
 
 
 *** Test Cases ***
-Verify User Can Access Permission Tab In Their Owned DS Project
-    [Documentation]    Verify user has access to "Permissions" tab in their DS Projects
-    [Tags]    Tier1    Smoke    OpenDataHub
-    ...       ODS-2194
-    Pass Execution    The Test is executed as part of Suite Setup
-
 Verify User Can Make Their Owned DS Project Accessible To Other Users    # robocop: disable
     [Documentation]    Verify user can give access permissions for their DS Projects to other users
-    [Tags]    Tier1    Sanity
-    ...       ODS-2201
+    [Tags]    Tier1    Smoke
+    ...       ODS-2194    ODS-2201
     Switch To User    ${USER_B}
     Move To Tab    Permissions
     Assign Contributor Permissions To User ${USER_C}
@@ -109,7 +103,8 @@ Project Permissions Mgmt Suite Setup    # robocop: disable
     RHOSi Setup
     Set Standard RHODS Groups Variables
     Set Default Access Groups Settings
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Close All Browsers
     Launch RHODS Dashboard Session With User A
     Launch RHODS Dashboard Session And Create A DS Project With User B
     Launch RHODS Dashboard Session With User C
@@ -120,7 +115,7 @@ Project Permissions Mgmt Suite Teardown
     [Documentation]    Suite teardown steps after testing DSG. It Deletes
     ...                all the DS projects created by the tests and run RHOSi teardown
     Close All Browsers
-    Delete Data Science Projects From CLI   ocp_projects=${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     RHOSi Teardown
     Remove User From Group    username=${USER_A}
     ...    group_name=rhods-users
@@ -217,6 +212,7 @@ Refresh Pages
 Reload Page If Project ${project_title} Is Not Listed
     ${is_listed} =    Set Variable    ${FALSE}
     WHILE   not ${is_listed}    limit=3m    on_limit_message=Timeout exceeded waiting for project ${project_title} to be listed    # robotcode: ignore
+        Filter Projects By Name    ${project_title}
         ${is_listed}=    Run Keyword And Return Status
         ...    Project Should Be Listed    project_title=${project_title}
         IF    ${is_listed} == ${FALSE}

--- a/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/500__ide/502__ide_elyra.robot
@@ -83,7 +83,7 @@ Elyra Pipelines Suite Setup    # robocop: off=too-many-calls-in-keyword
 
 Elyra Pipelines Suite Teardown
     [Documentation]    Closes the browser and performs RHOSi Teardown
-    Delete Data Science Project From CLI By Name    name=${PROJECT_TO_DELETE}
+    Delete Project Via CLI By Display Name    displayed_name=${PROJECT_TO_DELETE}
     Close All Browsers
     RHOSi Teardown
 

--- a/ods_ci/tests/Tests/600__ai_apps/680__starburst/682__starburst_enterprise_sm.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/680__starburst/682__starburst_enterprise_sm.robot
@@ -118,7 +118,7 @@ Starburst Enterprise Suite Setup    # robocop: disable
 Starburst Enterprise Suite Teardown
     [Documentation]    Uninstalls Starburst Enterprise operator
     Skip If RHODS Is Managed
-    Delete Data Science Projects From CLI    ${PROJECTS_TO_DELETE}
+    Delete List Of Projects Via CLI    ${PROJECTS_TO_DELETE}
     Delete Custom Resource    kind=StarburstEnterprise
     ...    namespace=${NAMESPACE}    name=starburstenterprise-sample
     Uninstall ISV Operator From OperatorHub Via CLI

--- a/ods_ci/tests/Tests/650__distributed_workloads/test-distributed-workloads-metrics-ui.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-distributed-workloads-metrics-ui.robot
@@ -81,7 +81,7 @@ Verify That Not Admin Users Can Access Distributed workload metrics default page
     [Teardown]    Run Keywords
     ...    Cleanup Kueue Resources    ${PRJ_TITLE_NONADMIN}    cluster-queue-user    resource-flavor-user    local-queue-user
     ...    AND
-    ...    Delete Data Science Project   ${PRJ_TITLE_NONADMIN}
+    ...    Delete Project Via CLI By Display Name   ${PRJ_TITLE_NONADMIN}
     ...    AND
     ...    Wait Until Data Science Project Is Deleted  ${PRJ_TITLE_NONADMIN}
     ...    AND
@@ -223,7 +223,7 @@ Project Suite Teardown
     [Documentation]    Suite teardown steps after testing Distributed Workload metrics .
     Cleanup Kueue Resources    ${PRJ_TITLE}    ${CLUSTER_QUEUE_NAME}    ${RESOURCE_FLAVOR_NAME}    ${LOCAL_QUEUE_NAME}
     IF  ${project_created} == True    Run Keywords
-    ...    Delete Data Science Project   ${PRJ_TITLE}    AND
+    ...    Delete Project Via CLI By Display Name   ${PRJ_TITLE}    AND
     ...    Wait Until Data Science Project Is Deleted  ${PRJ_TITLE}
     SeleniumLibrary.Close All Browsers
     RHOSi Teardown


### PR DESCRIPTION
- Fix Keywords `Delete Data Science Project From CLI` and `Delete Data Science Project From CLI By Name` for Tests Setup/Teardown, instead of the UI Keywords.
- New KW `Generate Unique Namespace` in `Create Data Science Project`.
- `Login To RHODS Dashboard` waits for Login page to disappear after login.
- Call `Filter Projects By Name` before `Wait Until Project Is Listed`.
- Add timeout to `Workbench With Description Should Be Listed`.
- Fix `Create/Edit S3 Data Connection`.
- Remove the Obsolete Test `Verify User Can Access Permission Tab`.


![image](https://github.com/user-attachments/assets/79101bb1-622b-49f3-92fb-eb03f294647a)
