### PR TITLE
fix: add pod ready conditions when installing dependant operators to solve flaky issues in SNO scenarios

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -22,6 +22,7 @@ ${DSCI_NAME} =    default-dsci
 ${SERVERLESS_OP_NAME}=     serverless-operator
 ${SERVERLESS_SUB_NAME}=    serverless-operator
 ${SERVERLESS_NS}=    openshift-serverless
+${OPENSHIFT_OPERATORS_NS}=    openshift-operators
 ${SERVICEMESH_OP_NAME}=     servicemeshoperator
 ${SERVICEMESH_SUB_NAME}=    servicemeshoperator
 ${AUTHORINO_OP_NAME}=     authorino-operator
@@ -407,6 +408,10 @@ Install Authorino Operator Via Cli
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${AUTHORINO_SUB_NAME}
           ...    retry=150
+    Wait For Pods To Be Ready    label_selector=control-plane=authorino-operator
+          ...    namespace=${OPENSHIFT_OPERATORS_NS}
+    Wait For Pods To Be Ready    label_selector=authorino-component=authorino-webhooks
+          ...    namespace=${OPENSHIFT_OPERATORS_NS}
 
 Install Service Mesh Operator Via Cli
     [Documentation]    Install Service Mesh Operator Via CLI
@@ -417,6 +422,8 @@ Install Service Mesh Operator Via Cli
           ...    type=CatalogSourcesUnhealthy    status=False
           ...    reason=AllCatalogSourcesHealthy    subcription_name=${SERVICEMESH_SUB_NAME}
           ...    retry=150
+    Wait For Pods To Be Ready    label_selector=name=istio-operator
+          ...    namespace=${OPENSHIFT_OPERATORS_NS}
 
 Install Serverless Operator Via Cli
     [Documentation]    Install Serverless Operator Via CLI

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0114__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0114__dsc_negative_dependant_operators_not_installed.robot
@@ -36,13 +36,13 @@ Validate DSC and DSCI Created With Errors When Service Mesh Operator Is Not Inst
     Log To Console    message=Creating DSCInitialization CR via CLI
     Apply DSCInitialization CustomResource    dsci_name=${DSCI_NAME}
     Log To Console    message=Checking DSCInitialization conditions
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DSCInitialization Should Fail Because Service Mesh Operator Is Not Installed
 
     Log To Console    message=Creating DataScienceCluster CR via CLI
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Log To Console    message=Checking DataScienceCluster conditions
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DataScienceCluster Should Fail Because Service Mesh Operator Is Not Installed
 
     [Teardown]    Reinstall Service Mesh Operator And Recreate DSC And DSCI
@@ -62,7 +62,7 @@ Validate DSC and DSCI Created With Errors When Serverless Operator Is Not Instal
     Log To Console    message=Creating DataScienceCluster CR via CLI
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Log To Console    message=Checking DataScienceCluster conditions
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DataScienceCluster Should Fail Because Serverless Operator Is Not Installed
 
     [Teardown]    Reinstall Serverless Operator And Recreate DSC And DSCI
@@ -79,15 +79,15 @@ Validate DSC and DSCI Created With Errors When Service Mesh And Serverless Opera
     Log To Console    message=Creating DSCInitialization CR via CLI
     Apply DSCInitialization CustomResource    dsci_name=${DSCI_NAME}
     Log To Console    message=Checking DSCInitialization conditions
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DSCInitialization Should Fail Because Service Mesh Operator Is Not Installed
 
     Log To Console    message=Creating DataScienceCluster CR via CLI
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Log To Console    message=Checking DataScienceCluster conditions
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DataScienceCluster Should Fail Because Service Mesh Operator Is Not Installed
-    Wait Until Keyword Succeeds    6 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    DataScienceCluster Should Fail Because Serverless Operator Is Not Installed
 
     [Teardown]    Reinstall Service Mesh And Serverless Operators And Recreate DSC And DSCI


### PR DESCRIPTION
There are some scenarios like SNO clusters that the Service Mesh operator does not reconcile on time to run the operator tests, and we are getting failures. Adding pod waiting conditions for the dependant operators to avoid this race condition