### PR TITLE
The default dashboard page is now the landing/home page

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -61,7 +61,7 @@ ${LOGOUT_BTN}=    //button[.="Log out"]
 *** Keywords ***
 Launch Dashboard
   [Arguments]  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}  ${dashboard_url}  ${browser}  ${browser_options}
-  ...          ${expected_page}=Enabled    ${wait_for_cards}=${TRUE}    ${browser_alias}=${NONE}
+  ...          ${expected_page}=${NONE}    ${wait_for_cards}=${TRUE}    ${browser_alias}=${NONE}
   Open Browser  ${dashboard_url}  browser=${browser}  options=${browser_options}
   ...    alias=${browser_alias}
   Login To RHODS Dashboard  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
@@ -84,7 +84,6 @@ Login To RHODS Dashboard
    IF  ${login-required}  Login To Openshift  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
    ${authorize_service_account}=  Is rhods-dashboard Service Account Authorization Required
    IF  ${authorize_service_account}  Authorize rhods-dashboard service account
-   Navigate To Page    Applications    Enabled    timeout=10s
 
 Logout From RHODS Dashboard
     [Documentation]  Logs out from the current user in the RHODS dashboard
@@ -97,11 +96,13 @@ Logout From RHODS Dashboard
 
 Wait For RHODS Dashboard To Load
     [Arguments]  ${dashboard_title}="${ODH_DASHBOARD_PROJECT_NAME}"    ${wait_for_cards}=${TRUE}
-    ...          ${expected_page}=Enabled    ${timeout}=60
+    ...          ${expected_page}=${NONE}    ${timeout}=60
     ${half_timeout}=   Evaluate    int(${timeout}) / 2
     Wait For Condition    return document.title == ${dashboard_title}    timeout=${half_timeout}
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=${half_timeout}
-    IF    "${expected_page}" != "${NONE}"
+    IF    "${expected_page}" == "${NONE}"
+        Wait Until Page Contains Element    //div[@data-testid="home-page"]    timeout=${half_timeout}
+    ELSE
         Wait For Dashboard Page Title    ${expected_page}    timeout=${timeout}
     END
     IF    ${wait_for_cards} == ${TRUE}
@@ -816,7 +817,7 @@ Maybe Wait For Dashboard Loading Spinner Page
 Reload RHODS Dashboard Page
     [Documentation]    Reload the web page and wait for RHODS Dashboard
     ...    to be loaded
-    [Arguments]    ${expected_page}=Enabled    ${wait_for_cards}=${TRUE}
+    [Arguments]    ${expected_page}=${NONE}    ${wait_for_cards}=${TRUE}
     Reload Page
     Wait For RHODS Dashboard To Load    expected_page=${expected_page}
     ...    wait_for_cards=${wait_for_cards}

--- a/ods_ci/tests/Tests/400__ods_dashboard/401__ods_dashboard.robot
+++ b/ods_ci/tests/Tests/400__ods_dashboard/401__ods_dashboard.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library           OpenShiftLibrary
+Resource          ../../Resources/Page/Components/Components.resource
 Resource          ../../Resources/Page/OCPDashboard/OperatorHub/InstallODH.robot
 Resource          ../../Resources/RHOSi.resource
 Resource          ../../Resources/ODS.robot
@@ -59,7 +60,7 @@ Verify Content In RHODS Explore Section
     # TODO: In ODH there are only 2 Apps, we excpect 7 Apps according to:
     # tests/Resources/Files/AppsInfoDictionary_latest.json
     ${EXP_DATA_DICT}=    Load Expected Data Of RHODS Explore Section
-    Click Link    Explore
+    Menu.Navigate To Page    Applications    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
     Check Number Of Displayed Cards Is Correct    expected_data=${EXP_DATA_DICT}
     Check Cards Details Are Correct    expected_data=${EXP_DATA_DICT}
@@ -73,7 +74,7 @@ Verify RHODS Explore Section Contains Only Expected ISVs
     # TODO: In ODH there are only 2 Apps, we excpect 7 Apps according to:
     # tests/Resources/Files/AppsInfoDictionary_latest.json
     ${EXP_DATA_DICT}=    Load Expected Data Of RHODS Explore Section
-    Click Link    Explore
+    Menu.Navigate To Page    Applications    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
     Check Number Of Displayed Cards Is Correct    expected_data=${EXP_DATA_DICT}
     Check Dashboard Diplayes Expected ISVs    expected_data=${EXP_DATA_DICT}
@@ -121,7 +122,7 @@ Verify CSS Style Of Getting Started Descriptions
     [Documentation]    Verifies the CSS style is not changed. It uses JupyterHub card as sample
     [Tags]    Tier1
     ...       ODS-1165
-    Click Link    Explore
+    Menu.Navigate To Page    Applications    Explore
     Wait For RHODS Dashboard To Load    expected_page=Explore
     ${status}=    Open Get Started Sidebar And Return Status    card_locator=${JUPYTER_CARD_XP}
     Should Be Equal    ${status}    ${TRUE}

--- a/ods_ci/tests/Tests/600__ai_apps/680__starburst/680__starburst_galaxy.robot
+++ b/ods_ci/tests/Tests/600__ai_apps/680__starburst/680__starburst_galaxy.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Library             SeleniumLibrary
 Resource            ../../../Resources/ODS.robot
+Resource            ../../../Resources/Page/Components/Components.resource
 Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource            ../../../Resources/RHOSi.resource
 
@@ -20,7 +21,7 @@ Verify if the Starburst Beta text has been removed from Getting Started
     [Tags]  Tier2
     ...     ODS-1158    ODS-605
 
-    Click Link    Explore
+    Menu.Navigate To Page    Applications    Explore
     Wait Until Cards Are Loaded
     Open Get Started Sidebar And Return Status    card_locator=${SB_CARDS_XP}
     Check Beta Description

--- a/ods_ci/tests/Tests/700__sandbox/700__sandbox.robot
+++ b/ods_ci/tests/Tests/700__sandbox/700__sandbox.robot
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation    Test Suite for Sandbox Test cases
 Resource        ../../Resources/Common.robot
+Resource        ../../Resources/Page/Components/Components.resource
 Resource        ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.resource
 Resource        ../../Resources/Page/ODH/JupyterHub/ODHJupyterhub.resource
 Library         String
@@ -22,7 +23,7 @@ Verify ISV Integration Enablement Is Disabled
     ...   components are disabled in the Dashboard
     [Tags]     ODS-530
     ...        Sandbox
-    Click Link    Explore
+    Menu.Navigate To Page    Applications    Explore
     Capture Page Screenshot   explor.png
     Wait Until Cards Are Loaded
     Sleep    5s


### PR DESCRIPTION
This removes the workaround added in [1,2] and expects the default dashboard page to be the landing/home page now.

[1] https://github.com/red-hat-data-services/ods-ci/pull/1432
[2] f9dfc88c6e9eba212b06f72eb210e17312967b8c

---

CI: `rhods-smoke/6651` :white_check_mark:  T49; P38; F5; S6 - the failures seem irrelevant to changes in this PR; executed against RHOAI 2.12RC1.