### PR TITLE
Check if trusty is installed or not

### DIFF
--- a/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
@@ -28,6 +28,8 @@ Run Drift Metrics Tests
 Prepare TrustyAi-tests Test Suite
     [Documentation]    Prepare trustyai-tests E2E Test Suite
     Log To Console    "Prepare Test Suite"
+    ${TRUSTY} =    Is Component Enabled    trustyai    ${DSC_NAME}
+    IF    "${TRUSTY}" == "false"    Enable Component    trustyai
     Drift Setup
     RHOSi Setup
 


### PR DESCRIPTION
Upgrade tests for drift seem to be failing in 2.12 Jenkins. By default trustyai component is in Removed state as it is a tech preview. After upgrade we need to enable it.