### PR TITLE
[fix] Expected string of the final results

### DIFF
--- a/ods_ci/tests/Tests/500__ide/501__ide_jupyterhub/test-minimal-image.robot
+++ b/ods_ci/tests/Tests/500__ide/501__ide_jupyterhub/test-minimal-image.robot
@@ -78,7 +78,7 @@ Can Launch Python3 Smoke Test Notebook
     ${output} =   Get Text    (//div[contains(@class,"jp-OutputArea-output")])[last()]
     Should Not Match    ${output}    ERROR*
     Should Be Equal As Strings    ${output}
-    ...    [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, 0.9116818405511811]
+    ...    [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, np.float64(0.9116818405511811)]
 
 Verify Tensorflow Can Be Installed In The Minimal Python Image Via Pip
     [Documentation]    Verify Tensorflow Can Be Installed In The Minimal Python image via pip


### PR DESCRIPTION
After some of the package update, there is now preserved numpy float64 data format in the printed results which in earler version weren't.

----

CI:
![image](https://github.com/user-attachments/assets/04545010-10e7-4f30-a457-b585d0d45719)
