### PR TITLE
Fix "SKIPPED" status in Post upgrade suite

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -242,6 +242,7 @@ Delete OOTB Image
    IF    not ${IS_SELF_MANAGED}    Managed RHOAI Upgrade Test Teardown
 
 Managed RHOAI Upgrade Test Teardown
+    [Documentation]    Check rhods_aggregate_availability metric when RHOAI is installed as managed
     ${expression} =    Set Variable    rhods_aggregate_availability&step=1
     ${resp} =    Prometheus.Run Query    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    ${expression}
     Log    rhods_aggregate_availability: ${resp.json()["data"]["result"][0]["value"][-1]}
@@ -259,5 +260,6 @@ Managed RHOAI Upgrade Test Teardown
     Run Keyword And Warn On Failure    Should Contain    ${list_values}    ${resp.json()["data"]["result"][0]["value"][-1]}
 
 Upgrade Suite Setup
+    [Documentation]    Set of action to run as Suite setup
     ${IS_SELF_MANAGED}=    Is RHODS Self-Managed
     Set Suite Variable    ${IS_SELF_MANAGED}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -20,6 +20,8 @@ Resource           ../../Resources/Page/HybridCloudConsole/OCM.robot
 Resource           ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 Resource           ../../Resources/Page/DistributedWorkloads/WorkloadMetricsUI.resource
 Resource           ../../Resources/CLI/MustGather/MustGather.resource
+Suite Setup    Upgrade Suite Setup
+
 
 *** Variables ***
 ${S_SIZE}       25
@@ -218,7 +220,7 @@ Dashboard Suite Setup
 
 Dashboard Test Teardown
     [Documentation]  Basic suite Teradown
-    Upgrade Test Teardown
+    IF    not ${IS_SELF_MANAGED}    Managed RHOAI Upgrade Test Teardown
     Close All Browsers
 
 Get Dashboard Config Data
@@ -231,16 +233,15 @@ Set Default Users
     [Documentation]  Set Default user settings
     Set Standard RHODS Groups Variables
     Set Default Access Groups Settings
-    Upgrade Test Teardown
+    IF    not ${IS_SELF_MANAGED}    Managed RHOAI Upgrade Test Teardown
 
 Delete OOTB Image
    [Documentation]  Delete the Custom notbook create
    ${status}  Run Keyword And Return Status     Oc Delete  kind=ImageStream  name=byon-upgrade  namespace=${APPLICATIONS_NAMESPACE}  #robocop:disable
    IF    not ${status}   Fail    Notebook image is deleted after the upgrade
-   Upgrade Test Teardown
+   IF    not ${IS_SELF_MANAGED}    Managed RHOAI Upgrade Test Teardown
 
-Upgrade Test Teardown
-    Skip If RHODS Is Self-Managed
+Managed RHOAI Upgrade Test Teardown
     ${expression} =    Set Variable    rhods_aggregate_availability&step=1
     ${resp} =    Prometheus.Run Query    ${RHODS_PROMETHEUS_URL}    ${RHODS_PROMETHEUS_TOKEN}    ${expression}
     Log    rhods_aggregate_availability: ${resp.json()["data"]["result"][0]["value"][-1]}
@@ -256,3 +257,7 @@ Upgrade Test Teardown
     Log    rhods_aggregate_availability: ${resp.json()["data"]["result"][0]["value"][-1]}
     @{list_values} =    Create List    1
     Run Keyword And Warn On Failure    Should Contain    ${list_values}    ${resp.json()["data"]["result"][0]["value"][-1]}
+
+Upgrade Suite Setup
+    ${IS_SELF_MANAGED}=    Is RHODS Self-Managed
+    Set Suite Variable    ${IS_SELF_MANAGED}


### PR DESCRIPTION
Currently, some tests in post upgrade suite have "SKIPPED" status because a piece of the teardown gets skipped if RHOAI operator is not Managed. 
This PR replaces the call to SKIP keyword with IF statement so to avoid the SKIPPED status which doesn't reflect the right test status

PR validation:
- pre-upgrade suite + post-upgrade suite (without actual upgrade): `rhods-ci-pr-test/3270` OK - 1 failure expected for automation issue

![image](https://github.com/user-attachments/assets/69b55b8e-4635-49b3-857a-858e04ce1bdf)
