### PR TITLE
Add support for provisioning GPUs on Azure

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AZURE/gpu.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AZURE/gpu.yaml
@@ -1,0 +1,6 @@
+- op: replace
+  path: /spec/template/spec/providerSpec/value/vmSize
+  value: INSTANCE_TYPE
+- op: remove
+  path: /spec/template/spec/providerSpec/value/zone
+

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AZURE/kustomization.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AZURE/kustomization.yaml
@@ -1,0 +1,10 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+metadata:
+  name: add-gpu
+resources:
+  - ../../base/
+patches:
+  - path: gpu.yaml
+    target:
+      kind: MachineSet


### PR DESCRIPTION
Add GPU overlay file to enable ODS-CI to provision GPUs on Azure. 

CI support will follow

Locally verified