### PR TITLE
Fix keyword to watch SM cluster provisioning logs and increase timeout

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -155,7 +155,7 @@ Watch Hive Install Log
     IF    ${use_cluster_pool}
         ${label_selector} =    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}
     END
-    ${label_selector}=    Catenate    SEPARATOR=    ${label_selector}    ,hive.openshift.io/job-type=provision
+    ${label_selector} =    Catenate    SEPARATOR=    ${label_selector}    ,hive.openshift.io/job-type=provision
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
     TRY

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -151,10 +151,11 @@ Create Floating IPs
 
 Watch Hive Install Log
     [Arguments]    ${pool_name}    ${namespace}    ${hive_timeout}=60m
-    ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name},hive.openshift.io/job-type=provision
+    ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
     IF    ${use_cluster_pool}
         ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}        
     END
+    ${label_selector}=    Catenate    ${label_selector}    ,hive.openshift.io/job-type=provision
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     TRY
         Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -151,20 +151,21 @@ Create Floating IPs
 
 Watch Hive Install Log
     [Arguments]    ${pool_name}    ${namespace}    ${hive_timeout}=60m
-    ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
+    ${label_selector} =    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
     IF    ${use_cluster_pool}
-        ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}        
+        ${label_selector} =    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}
     END
     ${label_selector}=    Catenate    SEPARATOR=    ${label_selector}    ,hive.openshift.io/job-type=provision
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     TRY
         Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
-        ${return_code}=    Run and Watch Command    ${logs_cmd}    timeout=${hive_timeout}
+        ${return_code} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
     EXCEPT
         Log To Console    ERROR: Fail to capture Hive pod logs.
     END
     Run Keyword And Continue On Failure    Should Be Equal As Integers    ${return_code}    ${0}
-    ${hive_pods_status} =    Run And Return Rc    oc get pod -n ${namespace} --no-headers | awk '{print $3}' | grep -v 'Completed'
+    ${hive_pods_status} =    Run And Return Rc
+    ...    oc get pod -n ${namespace} --no-headers | awk '{print $3}' | grep -v 'Completed'
     IF    ${hive_pods_status} != 0
         Log    All Hive pods in ${namespace} have completed    console=True
     END

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -151,9 +151,8 @@ Create Floating IPs
 
 Watch Hive Install Log
     [Arguments]    ${pool_name}    ${namespace}    ${install_log_file}    ${hive_timeout}=50m
-    # WHILE   True    limit=${hive_timeout}    on_limit_message=Hive Install ${hive_timeout} Timeout Exceeded    # robotcode: ignore
-    # ${old_log_data} = 	Get File 	${install_log_file}
-    # ${last_line_index} =    Get Line Count    ${old_log_data}
+    Wait Until Keyword Succeeds    5 min    5 sec
+    ...    Run And Verify Command    oc get namespace ${namespace}
     IF    ${use_cluster_pool}
         # ${pod} =    Oc Get    kind=Pod    namespace=${namespace}
         ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}
@@ -173,7 +172,7 @@ Watch Hive Install Log
         # Sleep   10s
         # CONTINUE
     END
-    Run Keyword And Continue On Failure    ${return_code}    ${0}
+    Run Keyword And Continue On Failure    Should Be Equal As Integers    ${return_code}    ${0}
     ${hive_pods_status} =    Run And Return Rc    oc get pod -n ${namespace} --no-headers | awk '{print $3}' | grep -v 'Completed'
     IF    ${hive_pods_status} != 0
         Log    All Hive pods in ${namespace} have completed    console=True
@@ -214,7 +213,7 @@ Wait For Cluster To Be Ready
     END
     ${install_log_file} =    Set Variable    ${artifacts_dir}/${cluster_name}_install.log
     Create File    ${install_log_file}
-    Run Keyword And Ignore Error    Watch Hive Install Log    ${pool_name}    ${pool_namespace}    ${install_log_file}
+    Run Keyword And Continue On Failure    Watch Hive Install Log    ${pool_name}    ${pool_namespace}    ${install_log_file}
     Log    Verifying that Cluster '${cluster_name}' has been provisioned and is running according to Hive Pool namespace '${pool_namespace}'      console=True    # robocop: disable:line-too-long
     ${provision_status} =    Run Process
     ...    oc -n ${pool_namespace} wait --for\=condition\=ProvisionFailed\=False cd ${clusterdeployment_name} --timeout\=15m    # robocop: disable:line-too-long

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -162,8 +162,10 @@ Watch Hive Install Log
     # ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace} --pod-running-timeout=5m
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     TRY
-        Wait Until Keyword Succeeds    5 min    5 sec
-        ...    Run And Verify Command    ${logs_cmd}
+        # Wait Until Keyword Succeeds    5 min    5 sec
+        # ...    Run And Verify Command    ${logs_cmd}
+        Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    ${timeout}=5m
+        # Run And Verify Command    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=5m
         ${return_code}=    Run and Watch Command    ${logs_cmd}    timeout=${hive_timeout}
         # ${new_log_data} =    Oc Get Pod Logs    name=${pod[0]['metadata']['name']}    container=installer   namespace=${namespace}
     EXCEPT

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -151,8 +151,6 @@ Create Floating IPs
 
 Watch Hive Install Log
     [Arguments]    ${pool_name}    ${namespace}    ${install_log_file}    ${hive_timeout}=50m
-    Wait Until Keyword Succeeds    5 min    5 sec
-    ...    Run And Verify Command    oc get namespace ${namespace}
     IF    ${use_cluster_pool}
         # ${pod} =    Oc Get    kind=Pod    namespace=${namespace}
         ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}
@@ -161,8 +159,11 @@ Watch Hive Install Log
         # ...    label_selector=hive.openshift.io/cluster-deployment-name=${cluster_name}
         ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
     END
-    ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace} --pod-running-timeout=5m
+    # ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace} --pod-running-timeout=5m
+    ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     TRY
+        Wait Until Keyword Succeeds    5 min    5 sec
+        ...    Run And Verify Command    ${logs_cmd}
         ${return_code}=    Run and Watch Command    ${logs_cmd}    timeout=${hive_timeout}
         # ${new_log_data} =    Oc Get Pod Logs    name=${pod[0]['metadata']['name']}    container=installer   namespace=${namespace}
     EXCEPT

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -157,13 +157,13 @@ Watch Hive Install Log
     END
     ${label_selector}=    Catenate    SEPARATOR=    ${label_selector}    ,hive.openshift.io/job-type=provision
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
+    Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
     TRY
-        Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
-        ${return_code} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
+        ${return_code}    ${output}    ${err} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
     EXCEPT
-        Log To Console    ERROR: Fail to capture Hive pod logs.
+        Log To Console    ERROR: Check Hive Logs if present or you may have hit timeout ${hive_timeout}.
     END
-    Run Keyword And Continue On Failure    Should Be Equal As Integers    ${return_code}    ${0}
+    Should Be Equal As Integers    ${return_code}    ${0}
     ${hive_pods_status} =    Run And Return Rc
     ...    oc get pod -n ${namespace} --no-headers | awk '{print $3}' | grep -v 'Completed'
     IF    ${hive_pods_status} != 0

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -155,7 +155,7 @@ Watch Hive Install Log
     IF    ${use_cluster_pool}
         ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}        
     END
-    ${label_selector}=    Catenate    ${label_selector}    ,hive.openshift.io/job-type=provision
+    ${label_selector}=    Catenate    SEPARATOR=    ${label_selector}    ,hive.openshift.io/job-type=provision
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     TRY
         Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -160,6 +160,7 @@ Watch Hive Install Log
     Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
     TRY
         ${return_code}    ${output}    ${err} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
+        ...    output_should_contain=install completed successfully
     EXCEPT
         Log To Console    ERROR: Check Hive Logs if present or you may have hit timeout ${hive_timeout}.
     END

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -190,11 +190,9 @@ Wait For Cluster To Be Ready
     ${provision_status} =    Run Process
     ...    oc -n ${pool_namespace} wait --for\=condition\=ProvisionFailed\=False cd ${clusterdeployment_name} --timeout\=15m    # robocop: disable:line-too-long
     ...    shell=yes
-    Run Keyword And Continue On Failure    Log    ${provision_status.stdout}
     ${web_access} =    Run Process
     ...    oc -n ${pool_namespace} get cd ${clusterdeployment_name} -o json | jq -r '.status.webConsoleURL' --exit-status    # robocop: disable:line-too-long
     ...    shell=yes
-    Run Keyword And Continue On Failure    Log    ${web_access.stdout}
     IF    ${use_cluster_pool}
         ${custer_status} =    Run Process
         ...    oc -n ${hive_namespace} wait --for\=condition\=ClusterRunning\=True clusterclaim ${claim_name} --timeout\=15m    shell=yes    # robocop: disable:line-too-long
@@ -208,7 +206,6 @@ Wait For Cluster To Be Ready
         ${custer_status} =    Run Process
         ...	oc -n ${hive_namespace} get clusterclaim ${claim_name} -o json | jq '.status.conditions[] | select(.type\=\="ClusterRunning" and (.reason\=\="Resuming" or .reason\=\="Running"))' --exit-status    shell=yes    # robocop: disable:line-too-long
     END
-    Run Keyword And Continue On Failure    Log    ${custer_status.stdout}
     IF    ${provision_status.rc} != 0 or ${web_access.rc} != 0 or ${custer_status.rc} != 0
         ${provision_status} =    Run Process    oc -n ${pool_namespace} get cd ${clusterdeployment_name} -o json    shell=yes    # robocop: disable:line-too-long
         ${custer_status} =    Run Process    oc -n ${hive_namespace} get clusterclaim ${claim_name} -o json    shell=yes

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -164,7 +164,7 @@ Watch Hive Install Log
     TRY
         # Wait Until Keyword Succeeds    5 min    5 sec
         # ...    Run And Verify Command    ${logs_cmd}
-        Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    ${timeout}=5m
+        Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
         # Run And Verify Command    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=5m
         ${return_code}=    Run and Watch Command    ${logs_cmd}    timeout=${hive_timeout}
         # ${new_log_data} =    Oc Get Pod Logs    name=${pod[0]['metadata']['name']}    container=installer   namespace=${namespace}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -150,7 +150,7 @@ Create Floating IPs
     Export Variables From File    ${fips_file_to_export}
 
 Watch Hive Install Log
-    [Arguments]    ${pool_name}    ${namespace}    ${hive_timeout}=60m
+    [Arguments]    ${pool_name}    ${namespace}    ${hive_timeout}=70m
     ${label_selector} =    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
     IF    ${use_cluster_pool}
         ${label_selector} =    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -159,7 +159,7 @@ Watch Hive Install Log
     ${logs_cmd} =     Set Variable    oc logs -f -l ${label_selector} -n ${namespace}
     Wait For Pods To Be Ready    label_selector=${label_selector}    namespace=${namespace}    timeout=5m
     TRY
-        ${return_code}    ${output}    ${err} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
+        ${return_code} =    Run And Watch Command    ${logs_cmd}    timeout=${hive_timeout}
         ...    output_should_contain=install completed successfully
     EXCEPT
         Log To Console    ERROR: Check Hive Logs if present or you may have hit timeout ${hive_timeout}.

--- a/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/provision.robot
@@ -151,7 +151,7 @@ Create Floating IPs
 
 Watch Hive Install Log
     [Arguments]    ${pool_name}    ${namespace}    ${hive_timeout}=60m
-    ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name}
+    ${label_selector}=    Set Variable    hive.openshift.io/cluster-deployment-name=${cluster_name},hive.openshift.io/job-type=provision
     IF    ${use_cluster_pool}
         ${label_selector}=    Set Variable    hive.openshift.io/clusterpool-name=${pool_name}        
     END

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -477,7 +477,7 @@ Run And Watch Command
 Check Process Output and Status
   [Documentation]    Helper keyward for 'Run And Watch Command', to tail proccess and check its status
   [Arguments]    ${process_id}    ${process_log}    ${temp_log}
-  Log To Console    .    no_newline=true
+  # Log To Console    .    no_newline=true
   ${log_data} = 	Get File 	${process_log}
   ${temp_log_data} = 	Get File 	${temp_log}
   ${last_line_index} =    Get Line Count    ${temp_log_data}

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -477,7 +477,6 @@ Run And Watch Command
 Check Process Output and Status
   [Documentation]    Helper keyward for 'Run And Watch Command', to tail proccess and check its status
   [Arguments]    ${process_id}    ${process_log}    ${temp_log}
-  # Log To Console    .    no_newline=true
   ${log_data} = 	Get File 	${process_log}
   ${temp_log_data} = 	Get File 	${temp_log}
   ${last_line_index} =    Get Line Count    ${temp_log_data}

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -477,6 +477,7 @@ Run And Watch Command
 Check Process Output and Status
   [Documentation]    Helper keyward for 'Run And Watch Command', to tail proccess and check its status
   [Arguments]    ${process_id}    ${process_log}    ${temp_log}
+  Log To Console    .    no_newline=true
   ${log_data} = 	Get File 	${process_log}
   ${temp_log_data} = 	Get File 	${temp_log}
   ${last_line_index} =    Get Line Count    ${temp_log_data}


### PR DESCRIPTION
Content of the PR:
1. change logic of `Watch Hive Install Log` keyword to avoid RHOAIENG-10829 bug
2. increase timeout to 60m

This won't necessarily fix some of the failures we have seen in CI while provisioning clusters, but would:
1. ensure to provide provisioning logs when available
2. reduce the chance of failure in case provisioning takes more than the fixed timeout


PR validation:
1. PSI provisioning  OK
![image](https://github.com/user-attachments/assets/42f8c4c2-411a-4e9c-af0d-e0353dd0a91b)


2. IBM Cloud provisioning OK
![image](https://github.com/user-attachments/assets/7be81aff-8770-4cb4-baeb-b1429f853f53)
