### PR TITLE
Fix "Verify User Can Access Model Metrics From UWM" test in "Model Serving Llm" suite

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -534,9 +534,9 @@ Check Query Response Values    # robocop:disable
             Log    message=Metrics source namespaced succesfully checked. Going to next step.
         END
         IF    "${exp_model_name}" != "${EMPTY}"
-            ${source_model}=    Set Variable    ${result["metric"]["job"]}
-            ${checked}=    Run Keyword And Return Status    Should Be Equal As Strings    ${source_model}
-            ...    ${exp_model_name}-metrics
+            ${source_pod}=    Set Variable    ${result["metric"]["pod"]}
+            ${checked}=    Run Keyword And Return Status    Should Start With    ${source_pod}
+            ...    ${exp_model_name}
             IF    ${checked} == ${FALSE}
                 Continue For Loop
             ELSE

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/base/isvc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/base/isvc.yaml
@@ -5,6 +5,8 @@ metadata:
     serving.knative.openshift.io/enablePassthrough: "true"
     sidecar.istio.io/inject: "true"
     sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    prometheus.io/path: /metrics
+    prometheus.io/port: "3000"
   name: ${isvc_name}
 spec:
   predictor:


### PR DESCRIPTION
- [RHOAIENG-11062](https://issues.redhat.com/browse/RHOAIENG-11062): Fix "keyword `TGI Caikit And Istio Metrics Should Exist`" failure by adding missing prometheus annotations to the ISVC 
- [RHOAIENG-11064](https://issues.redhat.com/browse/RHOAIENG-11064): Fix "`User Can Fetch Number Of Requests Over Defined Time`" failure by changing the model_name comparison to use the pod name 

Test Output:
`sh run_robot_test.sh --skip-oclogin true --extra-robot-args '-i ODS-2401'`
    
![ods-2401](https://github.com/user-attachments/assets/ff754c78-8163-4452-9933-8d36b5a5f700)