### PR TITLE
[fix] xpaths to couple of elements in dashboard data science projects

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -403,7 +403,7 @@ Filter Projects By ${Type}
     ...    Page Should Contain Element    xpath:${PROJECT_SEARCH_BAR}
     IF    ${searchbar_exists}
         Click Element    xpath:${PROJECT_FILTER_TYPE}
-        Click Element    xpath:${PROJECT_SEARCH_BAR}//li[@data-testid="dropdown-item ${Type}"]
+        Click Element    xpath:${PROJECT_SEARCH_BAR}//li[@data-testid="${Type}"]
         Input Text    ${PROJECT_SEARCH_INPUT}    ${text}
     ELSE
         Log    No projects are listed

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -193,9 +193,9 @@ Select An Existent PV
     Run Keyword And Continue On Failure
     ...    Wait Until Element Is Enabled    xpath=//input[@placeholder="Select a persistent storage"]
     Click Element    xpath=//input[@placeholder="Select a persistent storage"]
-    Wait Until Page Contains Element    xpath=//ul/li/button[text()="${name}"]
-    Wait Until Page Contains Element    xpath=//ul[@aria-label="Persistent storage select"]//button[text()="${name}"]
-    Click Element   xpath=//ul/li/button[text()="${name}"]
+    ${existing_pv_xpath}=    Set Variable    xpath=//ul/li/button[string()="${name}"]
+    Wait Until Page Contains Element    ${existing_pv_xpath}
+    Click Element   ${existing_pv_xpath}
 
 Select Workbench Jupyter Image
     [Documentation]    Selects a Jupyter image in the workbench creation page
@@ -255,8 +255,9 @@ Select Workbench Container Size
     Click Element    ${WORKBENCH_SIZE_SIDE_MENU_BTN}
     Wait Until Page Contains Element    ${WORKBENCH_SIZE_MENU_BTN_XP}
     Click Element    ${WORKBENCH_SIZE_MENU_BTN_XP}
-    Wait Until Page Contains Element    ${WORKBENCH_SIZE_ITEM_BTN_XP}/span[text()="${size_name}"]
-    Click Element    ${WORKBENCH_SIZE_ITEM_BTN_XP}/span[text()="${size_name}"]
+    ${workbench_size_button_click}=    Set Variable    ${WORKBENCH_SIZE_ITEM_BTN_XP}//span[text()="${size_name}"]
+    Wait Until Page Contains Element    ${workbench_size_button_click}
+    Click Element    ${workbench_size_button_click}
 
 Workbench Should Be Listed
     [Documentation]    Checks a workbench is listed in the DS Project details page


### PR DESCRIPTION
This fixes following failing tests run in our smoke suite:
* Verify User Can Delete A Data Science Project
* Verify Users Can Start, Stop, Launch And Delete A Workbench
* Verify User Can Create And Start A Workbench With Existent PV Storage

These xpaths changes were introduced for RHOAI 2.13.

---

CI:
![image](https://github.com/user-attachments/assets/48761a23-5232-4ac3-b068-9fb9c321b2d6)
