### PR TITLE
Fix `Verify User Can Change The Minimum Number Of Replicas For A Model` test case in ods-ci

### DIFF
--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_tgis.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_tgis.robot
@@ -725,4 +725,4 @@ Wait For New Replica Set To Be Ready
     END
     Wait Until Keyword Succeeds    5 times    5s
     ...    Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${model_name}
-    ...    namespace=${test_namespace}    runtime=${TGIS_RUNTIME_NAME}    exp_replicas=${new_exp_replicas}
+    ...    namespace=${namespace}    runtime=${TGIS_RUNTIME_NAME}    exp_replicas=${new_exp_replicas}


### PR DESCRIPTION
Fixed a typo on the namespace variable name passed to `Wait For Model KServe Deployment To Be Ready` inside `Wait For New Replica Set To Be Ready`

Test Output (locally): 
`sh run_robot_test.sh --skip-oclogin true --extra-robot-args '-i ODS-2376'`
![ods-2376](https://github.com/user-attachments/assets/936f750f-49cc-47e6-93d3-776c3eef786c)

