### PR TITLE
Backport ROSA HCP support in releases/2.10.0

### DIFF
--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -11,7 +11,7 @@ Library          String
 ${cluster_type}                 selfmanaged
 ${image_url}                    ${EMPTY}
 ${RHODS_OSD_INSTALL_REPO}       None
-@{SUPPORTED_TEST_ENV}           AWS   AWS_DIS   GCP   PSI   PSI_DIS   ROSA   IBM_CLOUD   CRC
+@{SUPPORTED_TEST_ENV}           AWS   AWS_DIS   GCP   PSI   PSI_DIS   ROSA   IBM_CLOUD   CRC    AZURE	ROSA_HCP
 ${TEST_ENV}                     AWS
 ${INSTALL_TYPE}                 OperatorHub
 ${UPDATE_CHANNEL}               odh-nightlies

--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -263,6 +263,16 @@ class OpenshiftClusterManager:
             sys.exit(1)
         return cluster_console_url.strip("\n")
 
+    def get_osd_cluster_api_url(self):
+        """Gets osd cluster api url"""
+
+        filter_str = "--json | jq -r '.api.url'"
+        cluster_api_url = self.ocm_describe(jq_filter=filter_str)
+        if cluster_api_url in [None, ""]:
+            log.error(f"Unable to retrieve cluster api url for cluster name {self.cluster_name}. EXITING")
+            sys.exit(1)
+        return cluster_api_url.strip("\n")
+
     def get_osd_cluster_info(self, config_file="cluster_config.yaml"):
         """Gets osd cluster information and stores in config file"""
 
@@ -271,6 +281,8 @@ class OpenshiftClusterManager:
         cluster_info["OCP_CONSOLE_URL"] = console_url
         cluster_version = self.get_osd_cluster_version()
         cluster_info["CLUSTER_VERSION"] = cluster_version
+        api_url = self.get_osd_cluster_api_url()
+        cluster_info["OCP_API_URL"] = api_url
         odh_dashboard_url = console_url.replace(
             "console-openshift-console",
             "rhods-dashboard-redhat-ods-applications",

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -224,6 +224,7 @@ def generate_test_config_file(
     data["S3"]["BUCKET_5"]["ENDPOINT"] = config_data["S3"]["BUCKET_5"]["ENDPOINT"]
     data["ANACONDA_CE"]["ACTIVATION_KEY"] = config_data["ANACONDA_CE"]["ACTIVATION_KEY"]
     data["OCP_CONSOLE_URL"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_CONSOLE_URL"]
+    data["OCP_API_URL"] = config_data["TEST_CLUSTERS"][test_cluster]["OCP_API_URL"]
     data["ODH_DASHBOARD_URL"] = config_data["TEST_CLUSTERS"][test_cluster]["ODH_DASHBOARD_URL"]
     data["TEST_USER"]["AUTH_TYPE"] = config_data["TEST_CLUSTERS"][test_cluster]["TEST_USER"]["AUTH_TYPE"]
     data["TEST_USER"]["USERNAME"] = config_data["TEST_CLUSTERS"][test_cluster]["TEST_USER"]["USERNAME"]
@@ -287,7 +288,7 @@ def generate_test_config_file(
 
     # Login to test cluster using oc command
     oc_login(
-        data["OCP_CONSOLE_URL"],
+        data["OCP_API_URL"],
         data["OCP_ADMIN_USER"]["USERNAME"],
         data["OCP_ADMIN_USER"]["PASSWORD"],
     )

--- a/ods_ci/utils/scripts/util.py
+++ b/ods_ci/utils/scripts/util.py
@@ -81,13 +81,11 @@ def execute_command(cmd: str, print_stdout: bool = True) -> str | None:
     return None
 
 
-def oc_login(ocp_console_url, username, password, timeout=600):
+def oc_login(ocp_api_url, username, password, timeout=600):
     """
     Login to test cluster using oc cli command
     """
-    cluster_api_url = ocp_console_url.replace("console-openshift-console.apps", "api")
-    cluster_api_url = re.sub(r"/$", "", cluster_api_url) + ":6443"
-    cmd = "oc login -u {} -p {} {} --insecure-skip-tls-verify=true".format(username, password, cluster_api_url)
+    cmd = f"oc login -u {username} -p {password} {ocp_api_url} --insecure-skip-tls-verify=true"
     count = 0
     chk_flag = 0
     while count <= timeout:


### PR DESCRIPTION
Add suport to create ROSA HCP in managed env and fetch the cluster api url from cluster - backporting https://github.com/red-hat-data-services/ods-ci/pull/1708