### PR TITLE
Fix for selectors in DataConnections.resource.

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
@@ -50,8 +50,10 @@ Set Connection Between Data Connection And Workbench
     Log    ${workbench_title}
     Wait Until Element Is Enabled    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
     Click Element    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
-    Wait Until Page Contains Element    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]  
-    Click Element                       xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
+    Wait Until Page Contains Element
+    ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
+    Click Element
+    ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
     
 Data Connection Should Be Listed
     [Documentation]    Checks a Data Connection is listed in DS Project details page

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
@@ -54,7 +54,7 @@ Set Connection Between Data Connection And Workbench
     ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
     Click Element
     ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
-    
+
 Data Connection Should Be Listed
     [Documentation]    Checks a Data Connection is listed in DS Project details page
     [Arguments]     ${name}   ${type}   ${connected_workbench}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
@@ -47,11 +47,12 @@ Edit S3 Data Connection
 Set Connection Between Data Connection And Workbench
     [Documentation]    Connects a DataConnection to an existent workbench
     [Arguments]    ${workbench_title}
-    Wait Until Element Is Enabled    xpath=//button[@aria-label="Options menu"]
-    Click Element    xpath=//button[@aria-label="Options menu"]
-    Wait Until Page Contains Element    ${DC_WORKBENCH_SELECTOR_XP}/button[text()="${workbench_title}"]
-    Click Element                       ${DC_WORKBENCH_SELECTOR_XP}/button[text()="${workbench_title}"]
-
+    Log    ${workbench_title}
+    Wait Until Element Is Enabled    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
+    Click Element    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
+    Wait Until Page Contains Element    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]  
+    Click Element                       xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
+    
 Data Connection Should Be Listed
     [Documentation]    Checks a Data Connection is listed in DS Project details page
     [Arguments]     ${name}   ${type}   ${connected_workbench}
@@ -103,7 +104,7 @@ Fill Data Connection Form
         Log    msg=you are not connecting any workbenchs to ${dc_name} DataConnection
     ELSE
         Run Keyword And Continue On Failure
-        ...    Element Should Be Enabled    xpath=//div[contains(@class,"modal")]//button[@aria-label="Options menu"]
+        ...    Element Should Be Enabled    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
         FOR    ${workbench_title}    IN    @{connected_workbench}
             Set Connection Between Data Connection And Workbench    ${workbench_title}
             Run Keyword And Continue On Failure     Element Should Be Enabled    ${S3_DC_ADD_BTN}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
@@ -47,13 +47,10 @@ Edit S3 Data Connection
 Set Connection Between Data Connection And Workbench
     [Documentation]    Connects a DataConnection to an existent workbench
     [Arguments]    ${workbench_title}
-    Log    ${workbench_title}
-    Wait Until Element Is Enabled    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
-    Click Element    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
-    Wait Until Page Contains Element
-    ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
-    Click Element
-    ...    xpath=//span[contains(@class, "pf-v5-c-menu__item-text") and text()="registry-wb"]
+    Wait Until Element Is Enabled    xpath=//button[@aria-label="Notebook select"]
+    Click Element    xpath=//button[@aria-label="Notebook select"]
+    Wait Until Page Contains Element    xpath=//ul/li/button//*[text()="${workbench_title}"]
+    Click Element                       xpath=//ul/li/button//*[text()="${workbench_title}"]
 
 Data Connection Should Be Listed
     [Documentation]    Checks a Data Connection is listed in DS Project details page
@@ -106,7 +103,7 @@ Fill Data Connection Form
         Log    msg=you are not connecting any workbenchs to ${dc_name} DataConnection
     ELSE
         Run Keyword And Continue On Failure
-        ...    Element Should Be Enabled    xpath=//span[contains(@class, "pf-v5-c-text-input-group__text")]
+        ...    Element Should Be Enabled    xpath=//input[@aria-label="Type to filter"]
         FOR    ${workbench_title}    IN    @{connected_workbench}
             Set Connection Between Data Connection And Workbench    ${workbench_title}
             Run Keyword And Continue On Failure     Element Should Be Enabled    ${S3_DC_ADD_BTN}

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -255,7 +255,7 @@ Run Update Notebook Script
 Remove Model Registry
     [Documentation]    Run multiple oc delete commands to remove model registry components
     Run And Verify Command    oc delete smm default -n ${NAMESPACE_MODEL-REGISTRY}
-    Run And Verify Command    oc delete -k ${MODELREGISTRY_BASE_FOLDER}/samples/secure-db/mysql-tls
+    Run And Verify Command    oc delete -k ${MODELREGISTRY_BASE_FOLDER}/samples/secure-db/mysql-tls -n ${NAMESPACE_MODEL-REGISTRY}
     Run And Verify Command    oc delete secret modelregistry-sample-grpc-credential -n ${NAMESPACE_ISTIO}
     Run And Verify Command    oc delete secret modelregistry-sample-rest-credential -n ${NAMESPACE_ISTIO}
     Run And Verify Command    oc delete namespace ${NAMESPACE_MODEL-REGISTRY} --force

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -48,12 +48,12 @@ Verify Model Registry Integration With Secured-DB
     Workbench Should Be Listed      workbench_title=registry-wb
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}
     ${workbenches}=    Create List    ${WORKBENCH_TITLE}
+    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_S3_NAME}
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=${AWS_BUCKET}    connected_workbench=${workbenches}
     Data Connection Should Be Listed    name=${DC_S3_NAME}    type=${DC_S3_TYPE}    connected_workbench=${workbenches}
     Open Data Science Project Details Page       project_title=${prj_title}    tab_id=workbenches
-    Wait Until Workbench Is Started     workbench_title=registry-wb
     Upload File In The Workbench     filepath=${SAMPLE_ONNX_MODEL}    workbench_title=${WORKBENCH_TITLE}
     ...         workbench_namespace=${PRJ_TITLE}
     Upload File In The Workbench     filepath=${JUPYTER_NOTEBOOK_FILEPATH}    workbench_title=${WORKBENCH_TITLE}

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Test suite for Model Registry Integration
 Suite Setup       Prepare Model Registry Test Setup
-# Suite Teardown    Teardown Model Registry Test Setup
+Suite Teardown    Teardown Model Registry Test Setup
 Library           OperatingSystem
 Library           Process
 Library           OpenShiftLibrary

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -1,7 +1,7 @@
 *** Settings ***
 Documentation     Test suite for Model Registry Integration
 Suite Setup       Prepare Model Registry Test Setup
-Suite Teardown    Teardown Model Registry Test Setup
+# Suite Teardown    Teardown Model Registry Test Setup
 Library           OperatingSystem
 Library           Process
 Library           OpenShiftLibrary
@@ -13,7 +13,7 @@ Resource          ../../Resources/Common.robot
 
 
 *** Variables ***
-${PRJ_TITLE}=                        model-registry-project-tony
+${PRJ_TITLE}=                        model-registry-project-e2e
 ${PRJ_DESCRIPTION}=                  model resgistry test project
 ${AWS_BUCKET}=                       ${S3.BUCKET_2.NAME}
 ${WORKBENCH_TITLE}=                  registry-wb


### PR DESCRIPTION
This commit fixes issues caused in the DataConnections.resource file. After upgrading from ODH-16 to ODH-17 the selectors for 'Fill Data Connection Form' and 'Set Connection Between Data Connection And Workbench' keywords have been changed. This commit updates the selectors to reflect this change. 

This commit also changes the name of the project being created in 1302 model-registry test