### PR TITLE
Fix variable evaluation in "Verify Model Inference" and associated keywords

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -323,9 +323,9 @@ Get Model Inference
 Verify Model Inference
     [Documentation]    Verifies that the inference result of a model is equal to an expected output
     [Arguments]    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}=${FALSE}
-    ...    ${project_title}=${NONE}    ${deployment_mode}='UI'   ${kserve_mode}=Serverless
+    ...    ${project_title}=${NONE}    ${deployment_mode}=UI    ${kserve_mode}=Serverless
     ...    ${service_port}=${NONE}   ${end_point}=${NONE}
-    IF   ${deployment_mode} == 'UI'
+    IF   $deployment_mode == 'UI'
          Open Model Serving Home Page
          Switch Model Serving Project    ${project_title}
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -350,7 +350,7 @@ Verify Model Inference With Retries
     ...                endpoint exposed.
     ...                This is a temporary mitigation meanwhile we find a better way to check the model
     [Arguments]    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}=${FALSE}
-    ...            ${project_title}=${NONE}    ${retries}=${5}     ${deployment_mode}='UI'    ${kserve_mode}=Serverless
+    ...            ${project_title}=${NONE}    ${retries}=${5}     ${deployment_mode}=UI    ${kserve_mode}=Serverless
     ...            ${service_port}=${NONE}   ${end_point}=${NONE}
     ${status}=    Run Keyword And Return Status    Verify Model Inference
     ...    ${model_name}    ${inference_input}    ${expected_inference_output}    ${token_auth}    ${project_title}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -263,12 +263,13 @@ Get Model Inference
     ...    model endpoint. If token authentication is needed for the model, ${token_auth} should be
     ...    set to ${TRUE}.
     [Arguments]    ${model_name}    ${inference_input}    ${token_auth}=${FALSE}   ${project_title}=${NONE}
-    ...    ${kserve_mode}=Serverless   ${deployment_mode}='UI'   ${service_port}=8888   ${end_point}=${NONE}
+    ...    ${kserve_mode}=Serverless   ${deployment_mode}=UI   ${service_port}=8888   ${end_point}=${NONE}
     ${curl_cmd}=     Set Variable    ${NONE}
     ${self_managed}=    Is RHODS Self-Managed
-    IF  ${deployment_mode} == 'UI'
+    IF  $deployment_mode == 'UI'
         ${url}=    Get Model Route Via UI    ${model_name}
-        ${kserve}=    Run Keyword And Return Status    SeleniumLibrary.Page Should Contain    Single-model serving enabled
+        ${kserve}=    Run Keyword And Return Status    SeleniumLibrary.Page Should Contain
+        ...    Single-model serving enabled
         ${curl_cmd}=     Set Variable    curl -s ${url} -d ${inference_input}
         IF    ${token_auth}
             IF    "${project_title}" == "${NONE}"
@@ -289,18 +290,18 @@ Get Model Inference
         ${rc}   ${cmd_op}   Run And Return Rc And Output
         ...    oc get isvc ${model_name} -o jsonpath='{.metadata.annotations.serving\.kserve\.io/deploymentMode}' -n ${project_title}
         Should Be Equal As Integers    ${rc}    0
-         IF  "${cmd_op}" != "ModelMesh"
+        IF  "${cmd_op}" != "ModelMesh"
             Fetch Knative CA Certificate    filename=openshift_ca_istio_knative.crt
             ${cert}=    Set Variable    --cacert openshift_ca_istio_knative.crt
-         ELSE IF  ${self_managed}
+        ELSE IF  ${self_managed}
             Fetch Openshift CA Bundle
             ${cert}=   Set Variable   --cacert openshift_ca.crt
         END
         IF    '${kserve_mode}' == 'Serverless'
-               ${rc}    ${url}=    Run And Return Rc And Output    oc get ksvc ${model_name}-predictor -n ${project_title} -o jsonpath='{.status.url}'
-               Should Be Equal As Integers    ${rc}    0
-               ${curl_cmd}=    Set Variable    curl -s ${url}${end_point} -d ${inference_input}
-
+            ${rc}    ${url}=    Run And Return Rc And Output
+            ...    oc get ksvc ${model_name}-predictor -n ${project_title} -o jsonpath='{.status.url}'
+            Should Be Equal As Integers    ${rc}    0
+            ${curl_cmd}=    Set Variable    curl -s ${url}${end_point} -d ${inference_input}
         ELSE IF    '${kserve_mode}' == 'RawDeployment'
             ${url}=   Set Variable    http://localhost:${service_port}${end_point}
             ${curl_cmd}=    Set Variable    curl -s ${url} -d ${inference_input} --cacert openshift_ca_istio_knative.crt
@@ -308,8 +309,8 @@ Get Model Inference
             Log    "Modelmesh CLI mode only"
         END
         IF    ${token_auth}
-              ${token}=    Create Inference Access Token    ${project_title}    ${DEFAULT_BUCKET_SA_NAME}
-              ${curl_cmd}=    Catenate    ${curl_cmd}    -H "Authorization: Bearer ${token}"
+            ${token}=    Create Inference Access Token    ${project_title}    ${DEFAULT_BUCKET_SA_NAME}
+            ${curl_cmd}=    Catenate    ${curl_cmd}    -H "Authorization: Bearer ${token}"
         END
     END
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -266,7 +266,7 @@ Get Model Inference
     ...    ${kserve_mode}=Serverless   ${deployment_mode}=UI   ${service_port}=8888   ${end_point}=${NONE}
     ${curl_cmd}=     Set Variable    ${NONE}
     ${self_managed}=    Is RHODS Self-Managed
-    IF  $deployment_mode == 'UI'
+    IF    $deployment_mode == 'UI'
         ${url}=    Get Model Route Via UI    ${model_name}
         ${kserve}=    Run Keyword And Return Status    SeleniumLibrary.Page Should Contain
         ...    Single-model serving enabled
@@ -285,10 +285,9 @@ Get Model Inference
             Fetch Openshift CA Bundle
             ${curl_cmd}=     Catenate    ${curl_cmd}    --cacert openshift_ca.crt
         END
-    END
-    IF  ${deployment_mode} == 'Cli'
+    ELSE IF    $deployment_mode == 'Cli'
         ${rc}   ${cmd_op}   Run And Return Rc And Output
-        ...    oc get isvc ${model_name} -o jsonpath='{.metadata.annotations.serving\.kserve\.io/deploymentMode}' -n ${project_title}
+        ...    oc get isvc ${model_name} -o jsonpath='{.metadata.annotations.serving\.kserve\.io/deploymentMode}' -n ${project_title}    # robocop: disable
         Should Be Equal As Integers    ${rc}    0
         IF  "${cmd_op}" != "ModelMesh"
             Fetch Knative CA Certificate    filename=openshift_ca_istio_knative.crt
@@ -329,8 +328,9 @@ Verify Model Inference
          Open Model Serving Home Page
          Switch Model Serving Project    ${project_title}
     END
-    ${inference_output}=    Get Model Inference    model_name=${model_name}    inference_input=${inference_input}   token_auth=${token_auth}    kserve_mode=${kserve_mode}
-    ...    project_title=${project_title}   deployment_mode=${deployment_mode}   service_port=${service_port}   end_point=${end_point}
+    ${inference_output}=    Get Model Inference    model_name=${model_name}   inference_input=${inference_input}
+    ...    token_auth=${token_auth}    kserve_mode=${kserve_mode}    project_title=${project_title}
+    ...    deployment_mode=${deployment_mode}    service_port=${service_port}    end_point=${end_point}    # robocop: disable
     ${result}    ${list}=    Inference Comparison    ${expected_inference_output}    ${inference_output}
     Log    ${result}
     Log    ${list}

--- a/ods_ci/tests/Tests/1000__model_serving/1001__model_serving_modelmesh.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1001__model_serving_modelmesh.robot
@@ -122,7 +122,8 @@ Test Inference With Token Authentication
     [Tags]    Sanity    Tier1
     ...       ODS-1920
     Open Data Science Projects Home Page
-    Create Data Science Project    title=${SECOND_PROJECT}    description=${PRJ_DESCRIPTION}    existing_project=${FALSE}
+    Create Data Science Project    title=${SECOND_PROJECT}    description=${PRJ_DESCRIPTION}
+    ...    existing_project=${FALSE}
     Recreate S3 Data Connection    project_title=${SECOND_PROJECT}    dc_name=model-serving-connection
     ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     ...            aws_bucket_name=ods-ci-s3
@@ -130,7 +131,6 @@ Test Inference With Token Authentication
     Serve Model    project_name=${SECOND_PROJECT}    model_name=${SECURED_MODEL}    model_server=${SECURED_RUNTIME}
     ...    existing_data_connection=${TRUE}    data_connection_name=model-serving-connection    existing_model=${TRUE}
     ...    framework=onnx    model_path=mnist-8.onnx
-    # Run Keyword And Continue On Failure    Verify Model Inference    ${SECURED_MODEL}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_SECURED_OUTPUT}    token_auth=${TRUE}    # robocop: disable
     Run Keyword And Continue On Failure    Verify Model Inference With Retries
     ...    ${SECURED_MODEL}    ${INFERENCE_INPUT}    ${EXPECTED_INFERENCE_SECURED_OUTPUT}    token_auth=${TRUE}
     ...    project_title=${SECOND_PROJECT}


### PR DESCRIPTION
This if block used to fail like this

```
Invalid IF condition: Evaluating expression 'UI == 'UI'' failed: NameError: name 'UI' is not defined nor importable as module

Variables in the original expression '${deployment_mode} == 'UI'' were resolved before the expression was evaluated. Try using '$deployment_mode == 'UI'' syntax to avoid that. See Evaluating Expressions appendix in Robot Framework User Guide for more details.
```