### PR TITLE
fix: increase dsci timeout

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0114__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0114__dsc_negative_dependant_operators_not_installed.robot
@@ -143,7 +143,7 @@ Reinstall Service Mesh Operator And Recreate DSC And DSCI
     Remove DSC And DSCI Resources
     Install Service Mesh Operator Via Cli
     Apply DSCInitialization CustomResource    dsci_name=${DSCI_NAME}
-    Wait For DSCInitialization CustomResource To Be Ready    timeout=180
+    Wait For DSCInitialization CustomResource To Be Ready    timeout=600
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Wait For DataScienceCluster CustomResource To Be Ready   timeout=600
     Set Service Mesh State To Managed And Wait For CR Ready
@@ -154,7 +154,7 @@ Reinstall Serverless Operator And Recreate DSC And DSCI
     Remove DSC And DSCI Resources
     Install Serverless Operator Via Cli
     Apply DSCInitialization CustomResource    dsci_name=${DSCI_NAME}
-    Wait For DSCInitialization CustomResource To Be Ready    timeout=180
+    Wait For DSCInitialization CustomResource To Be Ready    timeout=600
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Wait For DataScienceCluster CustomResource To Be Ready   timeout=600
     Set Service Mesh State To Managed And Wait For CR Ready
@@ -166,7 +166,7 @@ Reinstall Service Mesh And Serverless Operators And Recreate DSC And DSCI
     Install Serverless Operator Via Cli
     Install Service Mesh Operator Via Cli
     Apply DSCInitialization CustomResource    dsci_name=${DSCI_NAME}
-    Wait For DSCInitialization CustomResource To Be Ready    timeout=180
+    Wait For DSCInitialization CustomResource To Be Ready    timeout=600
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
     Wait For DataScienceCluster CustomResource To Be Ready   timeout=600
     Set Service Mesh State To Managed And Wait For CR Ready


### PR DESCRIPTION
Sometimes, the DSCI takes more that 3 minutes to get ready, so increasing the timeout to 10 minutes to avoid flaky timeout issues