### PR TITLE
Update to allow installation of the Python Client without external access

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelRegistry/MRMS_TEST_RUNNER.ipynb
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/MRMS_TEST_RUNNER.ipynb
@@ -3,41 +3,13 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c76fa56-07ef-4238-9f8b-faab2ad33f64",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "!pip install python-dotenv"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "62280df3-74a4-48d8-be64-5b4b73f0eb4b",
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "!pip install --pre model-registry=='0.2.3a1'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "9c27045c-68f7-423e-9f29-8b865fbe8388",
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from dotenv import load_dotenv\n",
-    "load_dotenv(dotenv_path='istio.env')\n",
-    "DOMAIN = os.getenv('DOMAIN')\n",
-    "print(DOMAIN)"
+    "!pip install --no-index --find-links . model_registry-0.2.5a1-py3-none-any.whl"
    ]
   },
   {


### PR DESCRIPTION
This commit will :
add keywords to download the python client binaries. 

- Upload the binaries to a running jupyter notebook. 
- Install Python Client on any cluster, including a disconnected cluster. 
- Delete the binaries when tearing down after test has completed.
- It will not push any binary files to the repository

There are commented out lines of code. This is required as the 'Create S3 Data Connection' keyword is currently broken due to changes in ODH-17. It is subject to another PR.

