### PR TITLE
Remove ModelID update from Trusty as Model name is the model id now

### DIFF
--- a/ods_ci/tests/Resources/CLI/TrustyAI/trustyai_service.resource
+++ b/ods_ci/tests/Resources/CLI/TrustyAI/trustyai_service.resource
@@ -45,4 +45,4 @@ Verify Model Serving Pod Exists
     [Arguments]    ${PRJ_TITLE}     ${label_selector}
     ${return_code}    ${pod_number}    Run And Return Rc And Output   oc get pod -n ${PRJ_TITLE} -l ${label_selector} | tail -n +2 | wc -l       # robocop: disable
     ${pod_numbers}    Split String     ${pod_number}
-    Should Be Equal    ${pod_numbers}[0]   2
+    Should Be Equal    ${pod_numbers}[0]   1

--- a/ods_ci/tests/Tests/1200__ai_explainability/1202__saliency_explainers.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1202__saliency_explainers.robot
@@ -45,7 +45,7 @@ Verify Lime And SHAP Explainers Are Availble For A Model Deployed Via CLI
 
 Verify Lime And SHAP Explainers Are Availble For A Model Deployed Via UI
     [Documentation]    Verifies that the lime and shap Explainers are available on sending a request
-    [Tags]    OpenDataHub     Sanity    RHOAIENG-9628     ExcludeOnRHOAI       test2
+    [Tags]    OpenDataHub     Sanity    RHOAIENG-9628     ExcludeOnRHOAI
     Launch Data Science Project Main Page
     Create Data Science Project    title=${PRJ_TITLE1}    description=${PRJ_DESCRIPTION1}
     Create S3 Data Connection    project_title=${PRJ_TITLE1}    dc_name=model-serving-connection


### PR DESCRIPTION
Earlier the model id was updated by the TrustyAI service. Now the operator doesn't make any changes. So removing the unnecessary model id check now.

Also edit the pod numbers to 1.