### PR TITLE
fix: add rhosi setup as a requirement for post-upgrade setup

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -287,6 +287,7 @@ Managed RHOAI Upgrade Test Teardown
 
 Upgrade Suite Setup
     [Documentation]    Set of action to run as Suite setup
+    RHOSi Setup
     ${IS_SELF_MANAGED}=    Is RHODS Self-Managed
     Set Suite Variable    ${IS_SELF_MANAGED}
     Gather Release Attributes From DSC And DSCI


### PR DESCRIPTION
There is a post upgrade test failing due to a missing RHOSi Setup call in the setup method:

<html><body>
<!--StartFragment-->
TEST CASE: | Verify That DSC And DSCI Release.Version Attribute matches the value in the subscription (non-critical)
-- | --
Upgrade
Tests the release.version attribute from the DSC and DSCI matches the value in the subscription.
0:00:00.008 (±0)
FAIL (non-critical)
Variable '${OPERATOR_SUBSCRIPTION_LABEL}' not found.

<!--EndFragment-->
</body>
</html>