### PR TITLE
Fix `Verify User Can Validate Scale To Zero` test case

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/llm.resource
@@ -332,6 +332,7 @@ Query Model Multiple Times
     ...            ${validate_response}=${TRUE}
     ...            ${string_check_only}=${FALSE}
     ...            ${protocol}=grpc
+    ...            ${connect_timeout}=10
     ...            ${port_forwarding}=${FALSE}
     ...            ${port}=443
     ...            ${body_params}=&{EMPTY}
@@ -378,7 +379,7 @@ Query Model Multiple Times
             ...    endpoint=${endpoint}
             ...    json_body=${body}    json_header=${header}
             ...    insecure=${insecure}    plaintext=${plaintext}    skip_res_json=${skip_json_load_response}
-            ...    cert=${cert}    &{args}
+            ...    cert=${cert}    connect_timeout=${connect_timeout}    &{args}
          ELSE IF    "${protocol}" == "http"
             ${payload}=     ODHDashboardAPI.Prepare Payload     body=${body}    str_to_json=${TRUE}
             Log Dictionary    ${args}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -277,6 +277,7 @@ Query Model With GRPCURL
     ${cmd}=    Catenate    ${cmd}    ${endpoint}
     IF   '${background}' == '${NONE}'
           # ${rc}    ${response}=    Run And Return Rc And Output    ${cmd}
+          Log    ${cmd}    console=yes
           ${query_process}=    Run Process    command=${cmd}    stderr=STDOUT  shell=yes
           # Run Keyword And Continue On Failure    Should Be Equal As Integers    ${query_process.rc}    ${0}
           ${rc}=    Set Variable    ${query_process.rc}
@@ -284,8 +285,9 @@ Query Model With GRPCURL
           # Log    ${query_process.stdout}    console=yes
           ${response}=    Set Variable    ${query_process.stdout}
           Log    ${response}    console=yes
+          Log    ${rc}    console=yes
           # ${json_res}=    Load Json String    ${query_process.stdout}
-          IF    ${skip_res_json} == ${TRUE}
+          IF    ${rc} != ${0} or ${skip_res_json} == ${TRUE}
             Log    ${response}
             RETURN    ${response}
           ELSE

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -250,8 +250,9 @@ Query Model With GRPCURL
     ...            ${background}=${NONE}
     ...            ${skip_res_json}=${FALSE}
     ...            ${cert}=${False}
+    ...            ${connect_timeout}=10
     ...            &{args}
-    ${cmd}=    Set Variable    grpcurl -d ${json_body}
+    ${cmd}=    Set Variable    grpcurl -connect-timeout ${connect_timeout} -d ${json_body}
     IF    $json_header != None
         ${cmd}=    Catenate    ${cmd}    -H ${json_header}
     END

--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm.robot
@@ -282,23 +282,16 @@ Verify User Can Validate Scale To Zero    # robocop: off=too-long-test-case,too-
     ...    namespace=${test_namespace}
     Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}    runtime=${CAIKIT_TGIS_RUNTIME_NAME}
-    ${host}=    Get KServe Inference Host Via CLI    isvc_name=${flan_model_name}   namespace=${test_namespace}
-    ${body}=    Set Variable    '{"text": "At what temperature does liquid Nitrogen boil?"}'
-    ${header}=    Set Variable    'mm-model-id: ${flan_model_name}'
-    Query Model With GRPCURL   host=${host}    port=443
-    ...    endpoint="caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict"
-    ...    json_body=${body}    json_header=${header}
-    ...    insecure=${TRUE}
+    Query Model Multiple Times    model_name=${flan_model_name}    n_times=1    connect_timeout=300
+    ...    namespace=${test_namespace}    runtime=${CAIKIT_TGIS_RUNTIME_NAME}
     Set Minimum Replicas Number    n_replicas=0    model_name=${flan_model_name}
     ...    namespace=${test_namespace}
     Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}    runtime=${CAIKIT_TGIS_RUNTIME_NAME}    exp_replicas=${2}
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    Query Model With GRPCURL   host=${host}    port=443
-    ...    endpoint="caikit.runtime.Nlp.NlpService/TextGenerationTaskPredict"
-    ...    json_body=${body}    json_header=${header}
-    ...    insecure=${TRUE}
+    Query Model Multiple Times    model_name=${flan_model_name}    n_times=1    connect_timeout=300
+    ...    namespace=${test_namespace}    runtime=${CAIKIT_TGIS_RUNTIME_NAME}
     Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}    runtime=${CAIKIT_TGIS_RUNTIME_NAME}
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}

--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_tgis.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_tgis.robot
@@ -335,8 +335,8 @@ Verify User Can Validate Scale To Zero    # robocop: off=too-long-test-case,too-
     ...    namespace=${test_namespace}    runtime=${TGIS_RUNTIME_NAME}    exp_replicas=${2}
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}
-    Query Model Multiple Times    model_name=${flan_model_name}    runtime=${TGIS_RUNTIME_NAME}    n_times=1
-    ...    namespace=${test_namespace}
+    Query Model Multiple Times    model_name=${flan_model_name}    n_times=1    connect_timeout=300
+    ...    namespace=${test_namespace}    runtime=${TGIS_RUNTIME_NAME}
     Wait For Model KServe Deployment To Be Ready    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}
     ...    namespace=${test_namespace}    runtime=${TGIS_RUNTIME_NAME}
     Wait For Pods To Be Terminated    label_selector=serving.kserve.io/inferenceservice=${flan_model_name}


### PR DESCRIPTION
Add the `-connect-timeout` flag to the grpcurl command in `Query Model With GRPCURL`

Pass connect_timeout=300 for ODS-2379 in order to address [RHOAIENG-10717](https://issues.redhat.com/browse/RHOAIENG-10717)

Tested and passed [here](https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/devops/job/rhoai-test-flow/326)