### PR TITLE
DataSciencePipelines tag in the test cases

### DIFF
--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-api.robot
@@ -22,7 +22,7 @@ ${URL_TEST_PIPELINE_RUN_YAML}=                 https://raw.githubusercontent.com
 *** Test Cases ***
 Verify Pipeline Server Creation With S3 Object Storage
     [Documentation]    Creates a pipeline server using S3 object storage and verifies that all components are running
-    [Tags]    Smoke
+    [Tags]    Smoke    DataSciencePipelines
     Projects.Create Data Science Project From CLI    name=dsp-s3
     DataSciencePipelinesBackend.Create Pipeline Server    namespace=dsp-s3
     ...    object_storage_access_key=${S3.AWS_ACCESS_KEY_ID}
@@ -37,18 +37,18 @@ Verify Pipeline Server Creation With S3 Object Storage
 Verify Admin Users Can Create And Run a Data Science Pipeline Using The Api
     [Documentation]    Creates, runs pipelines with admin user. Double check the pipeline result and clean
     ...    the pipeline resources.
-    [Tags]      Sanity    ODS-2083
+    [Tags]      Sanity    ODS-2083    DataSciencePipelines
     End To End Pipeline Workflow Via Api    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    pipelinesapi1
 
 Verify Regular Users Can Create And Run a Data Science Pipeline Using The Api
     [Documentation]    Creates, runs pipelines with regular user. Double check the pipeline result and clean
     ...    the pipeline resources.
-    [Tags]      Tier1    ODS-2677
+    [Tags]      Tier1    ODS-2677    DataSciencePipelines
     End To End Pipeline Workflow Via Api    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    pipelinesapi2
 
 Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     [Documentation]    Verify Ods Users Can Do Http Request That Must Be Redirected to Https
-    [Tags]        Tier1    ODS-2234
+    [Tags]        Tier1    ODS-2234    DataSciencePipelines
     Projects.Create Data Science Project From CLI    name=project-redirect-http
     DataSciencePipelinesBackend.Create PipelineServer Using Custom DSPA    project-redirect-http
     ${status}    Login And Wait Dsp Route    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
@@ -60,7 +60,7 @@ Verify Ods Users Can Do Http Request That Must Be Redirected to Https
 
 Verify DSPO Operator Reconciliation Retry
     [Documentation]    Verify DSPO Operator is able to recover from missing components during the initialization
-    [Tags]      Sanity    ODS-2477
+    [Tags]      Sanity    ODS-2477    DataSciencePipelines
 
     ${local_project_name} =    Set Variable    dsp-reconciliation-test
     Projects.Create Data Science Project From CLI    name=${local_project_name}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-general.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-general.robot
@@ -30,8 +30,7 @@ Verify Ods User Can Bind The Route Role
     ...         Test with user3 can access the dsp route for user4, it should fail because it doesn't have the permission    # robocop: disable:line-too-long
     ...         Add the permission using a role binding
     ...         Test with user3 can access the dsp route for user4, it should work because it has the permission
-    [Tags]      Tier1
-    ...         ODS-2209
+    [Tags]      Tier1    ODS-2209    DataSciencePipelines
     Create A Pipeline Server And Wait For Dsp Route    ${TEST_USER_3.USERNAME}    ${TEST_USER_3.PASSWORD}
     ...         ${TEST_USER_3.AUTH_TYPE}    ${PROJECT_USER3}
     Create A Pipeline Server And Wait For Dsp Route    ${TEST_USER_4.USERNAME}    ${TEST_USER_4.PASSWORD}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-kfp.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-kfp.robot
@@ -27,7 +27,7 @@ Verify Users Can Create And Run A Pipeline That Uses Only Packages From Base Ima
     [Documentation]    Creates and runs flip_coin pipeline as regular user, verifiying the run results
     ...   This is a simple pipeline, where the tasks doesn't have any packages_to_install and just needs
     ...   the python packages included in the base_image
-    [Tags]      Smoke    ODS-2203
+    [Tags]      Smoke    ODS-2203    DataSciencePipelines
     ${emtpy_dict}=    Create Dictionary
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}
@@ -46,7 +46,7 @@ Verify Users Can Create And Run A Pipeline That Uses Custom Python Packages To I
     ...   In this pipeline there are tasks defining with packages_to_install some custom python packages to
     ...   be installed at execution time
     ...   ProductBugOnDisconnected: RHOAIENG-6376
-    [Tags]      Smoke    ProductBugOnDisconnected
+    [Tags]      Smoke    ProductBugOnDisconnected    DataSciencePipelines
     ${emtpy_dict}=    Create Dictionary
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}
@@ -63,7 +63,7 @@ Verify Users Can Create And Run A Pipeline That Uses Custom Python Packages To I
 Verify Upload Download In Data Science Pipelines Using The kfp Python Package
     [Documentation]    Creates, runs pipelines with regular user. Double check the pipeline result and clean
     ...    the pipeline resources.
-    [Tags]    Sanity    ODS-2683
+    [Tags]    Sanity    ODS-2683    DataSciencePipelines
     ${upload_download_dict}=    Create Dictionary    mlpipeline_minio_artifact_secret=value    bucket_name=value
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}
@@ -81,7 +81,7 @@ Verify Ods Users Can Create And Run A Data Science Pipeline With Ray Using The k
     [Documentation]    Creates, runs pipelines with regular user. Double check the pipeline result and clean
     ...    the pipeline resources.
     ...    AutomationBugOnDisconnected: RHOAIENG-12514
-    [Tags]      Tier1    AutomationBugOnDisconnected
+    [Tags]      Tier1    AutomationBugOnDisconnected    DataSciencePipelines
     Skip If Component Is Not Enabled    ray
     Skip If Component Is Not Enabled    codeflare
     ${ray_dict}=    Create Dictionary

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-ui.robot
@@ -31,11 +31,8 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    The pipeline to run will be using the values for pip_index_url and pip_trusted_host
     ...    availables in a ConfigMap created in the SuiteSetup.
     ...    AutomationBug: RHOAIENG-10941
-    [Tags]    Smoke
-    ...       ODS-2206    ODS-2226    ODS-2633
-
+    [Tags]    SmokeODS-2206    ODS-2226    ODS-2633    DataSciencePipelines
     Open Data Science Project Details Page    ${PRJ_TITLE}
-
     Pipelines.Create Pipeline Server    dc_name=${DC_NAME}    project_title=${PRJ_TITLE}
     Verify There Is No "Error Displaying Pipelines" After Creating Pipeline Server
     Verify That There Are No Sample Pipelines After Creating Pipeline Server

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__test-run-data-science-pipelines-operator-e2e-tests.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__test-run-data-science-pipelines-operator-e2e-tests.robot
@@ -21,10 +21,7 @@ ${KUBECONFIGPATH}                                         %{HOME}/.kube/config
 *** Test Cases ***
 Run Data Science Pipelines Operator Integration Tests
     [Documentation]    Run Data Science Pipelines Operator Integration Tests
-    [Tags]
-    ...     DataSciencePipelines-Backend
-    ...     Tier1
-    ...     ODS-2632    AutomationBug
+    [Tags]    DataSciencePipelines-Backend    Tier1    ODS-2632    AutomationBug    DataSciencePipelines
     ${openshift_api}    Get Openshift Server
     Log    ${openshift_api}
     ${return_code}    ${output}    Run And Return Rc And Output    cd ${DATA-SCIENCE-PIPELINES-OPERATOR-SDK_DIR} && make integrationtest K8SAPISERVERHOST=${openshift_api} DSPANAMESPACE=${DSPANAMESPACE} KUBECONFIGPATH=${KUBECONFIGPATH}


### PR DESCRIPTION
Introducing the DataSciencePipelines tag because we are doing a migration to the next major version of Argo-Workflow and I need to run all tests that are related to Pipelines