### PR TITLE
Remove two Model Serving tests from Smoke

### DIFF
--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_caikit_embeddings.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_caikit_embeddings.robot
@@ -53,7 +53,7 @@ Verify User Can Serve And Query An Embeddings Model On Raw Kserve Via CLI     # 
 Verify User Can Serve And Query An Embeddings Model On Serverless Kserve Using GRPC     # robocop: disable
     [Documentation]    Basic tests for preparing, deploying and querying an embeddings LLM model
     ...                using Kserve and Caikit standalone runtime
-    [Tags]    Smoke     RHOAIENG-11749
+    [Tags]    Tier1     RHOAIENG-11749
     [Setup]    Set Project And Runtime    runtime=${RUNTIME_NAME}     namespace=${TEST_NS1}    protocol=grpc
     ${test_namespace}=    Set Variable     ${TEST_NS1}
     ${model_id}=       Set Variable   all-MiniLM-L12-v2-caikit

--- a/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_UI.robot
+++ b/ods_ci/tests/Tests/1000__model_serving/1007__model_serving_llm/1007__model_serving_llm_UI.robot
@@ -32,7 +32,7 @@ Verify User Can Serve And Query A Model Using The UI
     [Documentation]    Basic tests for preparing, deploying and querying a LLM model
     ...                using Kserve and Caikit runtime
     ...                Intermittently failing: RHOAIENG-3148
-    [Tags]    Smoke    ODS-2519    ODS-2522    FlakyTest
+    [Tags]    Sanity    ODS-2519    ODS-2522    FlakyTest
     [Setup]    Set Up Project    namespace=${TEST_NS}
     ${test_namespace}=    Set Variable     ${TEST_NS}
     ${flan_model_name}=    Set Variable    flan-t5-small-caikit


### PR DESCRIPTION
Bring the model serving suite runtime in Smoke from ~30 mins to ~15 mins