### PR TITLE
Bump kfp to 2.9.0 and kfp-kubernetes to 1.3.0

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesKfp.py
+++ b/ods_ci/libs/DataSciencePipelinesKfp.py
@@ -12,10 +12,6 @@ from robotlibcore import keyword
 
 
 class DataSciencePipelinesKfp:
-    base_image = (
-        "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
-    )
-
     # init should not have a call to external system, otherwise dry-run will fail
     def __init__(self):
         self.client = None

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/flip_coin.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/flip_coin.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 # source https://github.com/kubeflow/kfp-tekton/blob/master/samples/flip-coin/condition.py
-from kfp import dsl
-
-from ods_ci.libs.DataSciencePipelinesKfp import DataSciencePipelinesKfp
+from kfp import compiler, dsl
 
 
-@dsl.component(base_image=DataSciencePipelinesKfp.base_image)
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
+@dsl.component(base_image=common_base_image)
 def random_num(low: int, high: int) -> int:
     """Generate a random number between low and high."""
     import random
@@ -28,7 +29,7 @@ def random_num(low: int, high: int) -> int:
     return result
 
 
-@dsl.component(base_image=DataSciencePipelinesKfp.base_image)
+@dsl.component(base_image=common_base_image)
 def flip_coin() -> str:
     """Flip a coin and output heads or tails randomly."""
     import random
@@ -38,7 +39,7 @@ def flip_coin() -> str:
     return result
 
 
-@dsl.component(base_image=DataSciencePipelinesKfp.base_image)
+@dsl.component(base_image=common_base_image)
 def print_msg(msg: str):
     """Print a message."""
     print(msg)
@@ -63,3 +64,8 @@ def flipcoin_pipeline():
             print_msg(msg="tails and %s > 15!" % random_num_tail.output)
         with dsl.If(random_num_tail.output <= 15):
             print_msg(msg="tails and %s <= 15!" % random_num_tail.output)
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(flipcoin_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/flip_coin_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/flip_coin_compiled.yaml
@@ -282,7 +282,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -313,7 +313,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -342,7 +342,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -371,7 +371,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -400,7 +400,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -429,7 +429,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -459,7 +459,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -523,4 +523,4 @@ root:
         taskInfo:
           name: flip-coin
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/importer_pipeline_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/importer_pipeline_compiled.yaml
@@ -55,7 +55,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.8.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -123,4 +123,4 @@ root:
         isOptional: true
         parameterType: BOOLEAN
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.8.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline.py
@@ -152,4 +152,6 @@ def my_pipeline(
     )
 
 
-compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+if __name__ == "__main__":
+    compiler.Compiler().compile(my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_compiled.yaml
@@ -66,7 +66,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ && \"$0\" \"$@\"\n"
@@ -122,7 +122,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -159,7 +159,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -261,4 +261,4 @@ root:
           schemaTitle: system.ClassificationMetrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_without_cache.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_without_cache.py
@@ -152,4 +152,6 @@ def my_pipeline(
     ).set_caching_options(False)
 
 
-compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+if __name__ == "__main__":
+    compiler.Compiler().compile(my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_without_cache_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/iris_pipeline_without_cache_compiled.yaml
@@ -66,7 +66,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ && \"$0\" \"$@\"\n"
@@ -122,7 +122,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -159,7 +159,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -258,4 +258,4 @@ root:
           schemaTitle: system.ClassificationMetrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/metrics/metrics_visualization.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/metrics/metrics_visualization.py
@@ -22,10 +22,13 @@ from kfp.dsl import (component, Output, ClassificationMetrics, Metrics, HTML,
 _KFP_PACKAGE_PATH = os.getenv('KFP_PACKAGE_PATH')
 
 
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
+
+
 @component(
+    base_image=common_base_image,
     packages_to_install=['scikit-learn'],
-    base_image='registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61',
-    kfp_package_path=_KFP_PACKAGE_PATH,
+    kfp_package_path=_KFP_PACKAGE_PATH
 )
 def digit_classification(metrics: Output[Metrics]):
     from sklearn import model_selection
@@ -67,9 +70,9 @@ def digit_classification(metrics: Output[Metrics]):
 
 
 @component(
+    base_image=common_base_image,
     packages_to_install=['scikit-learn'],
-    base_image='python:3.9',
-    kfp_package_path=_KFP_PACKAGE_PATH,
+    kfp_package_path=_KFP_PACKAGE_PATH
 )
 def wine_classification(metrics: Output[ClassificationMetrics]):
     from sklearn.ensemble import RandomForestClassifier
@@ -98,9 +101,9 @@ def wine_classification(metrics: Output[ClassificationMetrics]):
 
 
 @component(
+    base_image=common_base_image,
     packages_to_install=['scikit-learn'],
-    base_image='python:3.9',
-    kfp_package_path=_KFP_PACKAGE_PATH,
+    kfp_package_path=_KFP_PACKAGE_PATH
 )
 def iris_sgdclassifier(test_samples_fraction: float,
                        metrics: Output[ClassificationMetrics]):
@@ -127,7 +130,8 @@ def iris_sgdclassifier(test_samples_fraction: float,
 
 
 @component(
-    kfp_package_path=_KFP_PACKAGE_PATH,)
+    base_image=common_base_image,
+    kfp_package_path=_KFP_PACKAGE_PATH)
 def html_visualization(html_artifact: Output[HTML]):
     html_content = '<!DOCTYPE html><html><body><h1>Hello world</h1></body></html>'
     with open(html_artifact.path, 'w') as f:
@@ -135,7 +139,8 @@ def html_visualization(html_artifact: Output[HTML]):
 
 
 @component(
-    kfp_package_path=_KFP_PACKAGE_PATH,)
+    base_image=common_base_image,
+    kfp_package_path=_KFP_PACKAGE_PATH)
 def markdown_visualization(markdown_artifact: Output[Markdown]):
     markdown_content = '## Hello world \n\n Markdown content'
     with open(markdown_artifact.path, 'w') as f:
@@ -150,4 +155,6 @@ def metrics_visualization_pipeline():
     html_visualization_op = html_visualization()
     markdown_visualization_op = markdown_visualization()
 
-compiler.Compiler().compile(pipeline_func=metrics_visualization_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(pipeline_func=metrics_visualization_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/metrics/metrics_visualization_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/metrics/metrics_visualization_compiled.yaml
@@ -63,7 +63,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'scikit-learn'\
           \ && \"$0\" \"$@\"\n"
@@ -106,7 +106,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -124,7 +124,7 @@ deploymentSpec:
           \ = '<!DOCTYPE html><html><body><h1>Hello world</h1></body></html>'\n  \
           \  with open(html_artifact.path, 'w') as f:\n        f.write(html_content)\n\
           \n"
-        image: python:3.7
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
     exec-iris-sgdclassifier:
       container:
         args:
@@ -137,7 +137,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'scikit-learn'\
           \ && \"$0\" \"$@\"\n"
@@ -165,7 +165,7 @@ deploymentSpec:
           \ 'Versicolour', 'Virginica'],\n        confusion_matrix(\n            train_y,\n\
           \            predictions).tolist()  # .tolist() to convert np array to list.\n\
           \    )\n\n"
-        image: python:3.9
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
     exec-markdown-visualization:
       container:
         args:
@@ -178,7 +178,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -196,7 +196,7 @@ deploymentSpec:
           \    markdown_content = '## Hello world \\n\\n Markdown content'\n    with\
           \ open(markdown_artifact.path, 'w') as f:\n        f.write(markdown_content)\n\
           \n"
-        image: python:3.7
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
     exec-wine-classification:
       container:
         args:
@@ -209,7 +209,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'scikit-learn'\
           \ && \"$0\" \"$@\"\n"
@@ -238,7 +238,7 @@ deploymentSpec:
           \ 1], pos_label=True)\n\n    # avoid inf thresholds\n    epsilon = 1e-6\n\
           \    thresholds = [1 - epsilon if t == float('inf') else t for t in thresholds]\n\
           \n    metrics.log_roc_curve(fpr, tpr, thresholds)\n\n"
-        image: python:3.9
+        image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
 pipelineInfo:
   name: metrics-visualization-pipeline
 root:
@@ -313,4 +313,4 @@ root:
           schemaTitle: system.ClassificationMetrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/flip_coin_pip_index_url.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/flip_coin_pip_index_url.py
@@ -33,8 +33,7 @@ from kfp import kubernetes
 common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
 
 
-@dsl.component(base_image=common_base_image,
-               pip_index_urls=['$PIP_INDEX_URL'])
+@dsl.component(base_image=common_base_image, pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST'])
 def random_num(low: int, high: int) -> int:
     """Generate a random number between low and high."""
     import random
@@ -44,8 +43,7 @@ def random_num(low: int, high: int) -> int:
     return result
 
 
-@dsl.component(base_image=common_base_image,
-               pip_index_urls=['$PIP_INDEX_URL'])
+@dsl.component(base_image=common_base_image, pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST'])
 def flip_coin() -> str:
     """Flip a coin and output heads or tails randomly."""
     import random
@@ -55,8 +53,7 @@ def flip_coin() -> str:
     return result
 
 
-@dsl.component(base_image=common_base_image,
-               pip_index_urls=['$PIP_INDEX_URL'])
+@dsl.component(base_image=common_base_image, pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST'])
 def print_msg(msg: str):
     """Print a message."""
     print(msg)
@@ -128,7 +125,5 @@ def flipcoin_pipeline():
             )
 
 
-
 if __name__ == "__main__":
-    compiler.Compiler().compile(flipcoin_pipeline,
-                                package_path=__file__.replace(".py", "_compiled.yaml"))
+    compiler.Compiler().compile(flipcoin_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/flip_coin_pip_index_url_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/flip_coin_pip_index_url_compiled.yaml
@@ -277,7 +277,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -308,7 +308,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -337,7 +337,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -366,7 +366,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -395,7 +395,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -424,7 +424,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -454,7 +454,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -516,7 +516,7 @@ root:
         taskInfo:
           name: flip-coin
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0
 ---
 platforms:
   kubernetes:

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/hello_world_pip_index_url.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/hello_world_pip_index_url.py
@@ -19,8 +19,7 @@ from kfp import kubernetes
 common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
 
 
-@dsl.component(base_image=common_base_image,
-               pip_index_urls=['$PIP_INDEX_URL'])
+@dsl.component(base_image=common_base_image, pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST'])
 def print_message(message: str):
     import os
     """Prints a message"""
@@ -43,5 +42,4 @@ def hello_world_pipeline(message: str = "Hello world"):
 
 
 if __name__ == "__main__":
-    compiler.Compiler().compile(hello_world_pipeline,
-                                package_path=__file__.replace(".py", "_compiled.yaml"))
+    compiler.Compiler().compile(hello_world_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/hello_world_pip_index_url_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/hello_world_pip_index_url_compiled.yaml
@@ -25,7 +25,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"' && \"$0\" \"$@\"\n"
         - sh
         - -ec
@@ -67,7 +67,7 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0
 ---
 platforms:
   kubernetes:

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/iris_pipeline_pip_index_url.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/iris_pipeline_pip_index_url.py
@@ -20,10 +20,9 @@ from kfp import kubernetes
 common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
 
 
-@dsl.component(base_image=common_base_image,
-               packages_to_install=["pandas==2.2.0"],
-               pip_index_urls=['$PIP_INDEX_URL']
-               )
+@dsl.component(base_image=common_base_image, packages_to_install=["pandas==2.2.0"],
+               pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST']
+)
 def create_dataset(iris_dataset: Output[Dataset]):
     import pandas as pd
     from io import StringIO
@@ -90,10 +89,8 @@ def create_dataset(iris_dataset: Output[Dataset]):
         df.to_csv(f)
 
 
-@dsl.component(
-    base_image=common_base_image,
-    packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
-    pip_index_urls=['$PIP_INDEX_URL']
+@dsl.component(base_image=common_base_image, packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
+    pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST']
 )
 def normalize_dataset(
     input_iris_dataset: Input[Dataset],
@@ -116,10 +113,8 @@ def normalize_dataset(
         df.to_csv(f)
 
 
-@dsl.component(
-    base_image=common_base_image,
-    packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
-    pip_index_urls=['$PIP_INDEX_URL']
+@dsl.component(base_image=common_base_image, packages_to_install=["pandas==2.2.0", "scikit-learn==1.4.0"],
+    pip_index_urls=['$PIP_INDEX_URL'], pip_trusted_hosts=['$PIP_TRUSTED_HOST']
 )
 def train_model(
     normalized_iris_dataset: Input[Dataset],
@@ -190,4 +185,5 @@ def my_pipeline(
     )
 
 
-compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))
+if __name__ == "__main__":
+    compiler.Compiler().compile(pipeline_func=my_pipeline, package_path=__file__.replace(".py", "_compiled.yaml"))

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/iris_pipeline_pip_index_url_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pip_index_url/iris_pipeline_pip_index_url_compiled.yaml
@@ -67,7 +67,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location\
           \ --index-url $PIP_INDEX_URL --trusted-host $PIP_TRUSTED_HOST 'pandas==2.2.0'\
           \ && \"$0\" \"$@\"\n"
@@ -124,7 +124,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location\
           \ --index-url $PIP_INDEX_URL --trusted-host $PIP_TRUSTED_HOST 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -162,7 +162,7 @@ deploymentSpec:
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
           \ python3 -m pip install --quiet --no-warn-script-location --index-url $PIP_INDEX_URL\
-          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.7.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
+          \ --trusted-host $PIP_TRUSTED_HOST 'kfp==2.9.0' '--no-deps' 'typing-extensions>=3.7.4,<5;\
           \ python_version<\"3.9\"'  &&  python3 -m pip install --quiet --no-warn-script-location\
           \ --index-url $PIP_INDEX_URL --trusted-host $PIP_TRUSTED_HOST 'pandas==2.2.0'\
           \ 'scikit-learn==1.4.0' && \"$0\" \"$@\"\n"
@@ -261,7 +261,7 @@ root:
           schemaTitle: system.ClassificationMetrics
           schemaVersion: 0.0.1
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0
 ---
 platforms:
   kubernetes:

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_compiled.yaml
@@ -24,7 +24,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -39,7 +39,7 @@ deploymentSpec:
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
           \ *\n\ndef print_message(message: str):\n    \"\"\"Prints a message\"\"\"\
-          \n    print(message)\n\n"
+          \n    print(message + \" (step 1)\")\n\n"
         image: registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61
 pipelineInfo:
   description: Pipeline that prints a hello message
@@ -65,4 +65,4 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v2_compiled.yaml
@@ -34,7 +34,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -63,7 +63,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -119,4 +119,4 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/pipeline-versions/version_test_v3_compiled.yaml
@@ -44,7 +44,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -73,7 +73,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -102,7 +102,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -173,4 +173,4 @@ root:
         isOptional: true
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration.py
@@ -1,10 +1,11 @@
-from kfp import dsl
+from kfp import dsl, compiler
 
-from ods_ci.libs.DataSciencePipelinesKfp import DataSciencePipelinesKfp
+
+common_base_image = "registry.redhat.io/ubi8/python-39@sha256:3523b184212e1f2243e76d8094ab52b01ea3015471471290d011625e1763af61"
 
 
 # image and the sdk has a fixed value because the version matters
-@dsl.component(packages_to_install=["codeflare-sdk==0.16.4"], base_image=DataSciencePipelinesKfp.base_image)
+@dsl.component(packages_to_install=["codeflare-sdk==0.16.4"], base_image=common_base_image)
 def ray_fn() -> int:
     import ray
     from codeflare_sdk.cluster.cluster import Cluster, ClusterConfiguration
@@ -67,3 +68,8 @@ def ray_fn() -> int:
 )
 def ray_integration():
     ray_fn()
+
+
+if __name__ == "__main__":
+    compiler.Compiler().compile(ray_integration, package_path=__file__.replace(".py", "_compiled.yaml"))
+

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/ray_integration_compiled.yaml
@@ -22,7 +22,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'codeflare-sdk==0.16.4'\
           \ && \"$0\" \"$@\"\n"
@@ -75,4 +75,4 @@ root:
         taskInfo:
           name: ray-fn
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_compiled.yaml
@@ -34,7 +34,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -65,7 +65,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -121,4 +121,4 @@ root:
         isOptional: true
         parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_pipeline_root_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/take_nap_pipeline_root_compiled.yaml
@@ -35,7 +35,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -66,7 +66,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -122,4 +122,4 @@ root:
         isOptional: true
         parameterType: NUMBER_INTEGER
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/upload_download_compiled.yaml
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/upload_download_compiled.yaml
@@ -59,7 +59,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -73,8 +73,8 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef receive_file(\n    incomingfile: kfp.dsl.InputPath(),\n    saveartifact:\
-          \ kfp.dsl.OutputPath(),\n):\n    import os\n    import shutil\n\n    print(\"\
+          \ *\n\ndef receive_file(\n    incomingfile: dsl.InputPath(),\n    saveartifact:\
+          \ dsl.OutputPath(),\n):\n    import os\n    import shutil\n\n    print(\"\
           reading %s, size is %s\" % (incomingfile, os.path.getsize(incomingfile)))\n\
           \n    with open(incomingfile, \"rb\") as f:\n        b = f.read(1)\n   \
           \     print(\"read byte: %s\" % b)\n        f.close()\n\n    print(\"copying\
@@ -93,7 +93,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"' && \"\
           $0\" \"$@\"\n"
         - sh
@@ -107,7 +107,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef send_file(\n    file_size_bytes: int,\n    outgoingfile: kfp.dsl.OutputPath(),\n\
+          \ *\n\ndef send_file(\n    file_size_bytes: int,\n    outgoingfile: dsl.OutputPath(),\n\
           ):\n    import os\n    import zipfile\n\n    def create_large_file(file_path,\
           \ size_in_bytes):\n        with open(file_path, \"wb\") as f:\n        \
           \    f.write(os.urandom(size_in_bytes))\n\n    def zip_file(input_file_path,\
@@ -130,7 +130,7 @@ deploymentSpec:
         - -c
         - "\nif ! [ -x \"$(command -v pip)\" ]; then\n    python3 -m ensurepip ||\
           \ python3 -m ensurepip --user || apt-get install python3-pip\nfi\n\nPIP_DISABLE_PIP_VERSION_CHECK=1\
-          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.7.0'\
+          \ python3 -m pip install --quiet --no-warn-script-location 'kfp==2.9.0'\
           \ '--no-deps' 'typing-extensions>=3.7.4,<5; python_version<\"3.9\"'  &&\
           \  python3 -m pip install --quiet --no-warn-script-location 'minio' && \"\
           $0\" \"$@\"\n"
@@ -145,7 +145,7 @@ deploymentSpec:
 
           '
         - "\nimport kfp\nfrom kfp import dsl\nfrom kfp.dsl import *\nfrom typing import\
-          \ *\n\ndef test_uploaded_artifact(\n    previous_step: kfp.dsl.InputPath(),\n\
+          \ *\n\ndef test_uploaded_artifact(\n    previous_step: dsl.InputPath(),\n\
           \    file_size_bytes: int,\n    mlpipeline_minio_artifact_secret: str,\n\
           \    bucket_name: str,\n):\n    import base64\n    import json\n\n    from\
           \ minio import Minio\n\n    def inner_decode(my_str):\n        return base64.b64decode(my_str).decode(\"\
@@ -228,4 +228,4 @@ root:
       mlpipeline_minio_artifact_secret:
         parameterType: STRING
 schemaVersion: 2.1.0
-sdkVersion: kfp-2.7.0
+sdkVersion: kfp-2.9.0

--- a/poetry.lock
+++ b/poetry.lock
@@ -1612,12 +1612,12 @@ test = ["PyYAML (>=3.12)", "bandit (>=1.7.6,<1.8.0)", "betamax (>=0.7.0)", "cove
 
 [[package]]
 name = "kfp"
-version = "2.8.0"
+version = "2.9.0"
 description = "Kubeflow Pipelines SDK"
 optional = false
 python-versions = "<3.13.0,>=3.8.0"
 files = [
-    {file = "kfp-2.8.0.tar.gz", hash = "sha256:06ad584eecbe80318c6cd0231c95a432e91fec56f201def9d511b6e6664235ce"},
+    {file = "kfp-2.9.0.tar.gz", hash = "sha256:936b34261d7356f5f1960d07d12632a84f36f928e14a72cea7c092f2a224de7d"},
 ]
 
 [package.dependencies]
@@ -1626,9 +1626,9 @@ docstring-parser = ">=0.7.3,<1"
 google-api-core = ">=1.31.5,<2.0.dev0 || >2.3.0,<3.0.0dev"
 google-auth = ">=1.6.1,<3"
 google-cloud-storage = ">=2.2.1,<3"
-kfp-pipeline-spec = "0.3.0"
-kfp-server-api = ">=2.0.0,<2.1.0"
-kubernetes = ">=8.0.0,<27"
+kfp-pipeline-spec = "0.4.0"
+kfp-server-api = ">=2.1.0,<2.4.0"
+kubernetes = ">=8.0.0,<31"
 protobuf = ">=4.21.1,<5"
 PyYAML = ">=5.3,<7"
 requests-toolbelt = ">=0.8.0,<1"
@@ -1641,12 +1641,12 @@ kubernetes = ["kfp-kubernetes (<2)"]
 
 [[package]]
 name = "kfp-kubernetes"
-version = "1.2.0"
+version = "1.3.0"
 description = "Kubernetes platform configuration library and generated protos."
 optional = false
-python-versions = "<3.13.0,>=3.7.0"
+python-versions = "<3.13.0,>=3.8.0"
 files = [
-    {file = "kfp-kubernetes-1.2.0.tar.gz", hash = "sha256:5f1bf4e7a3b768e36f865e429535ef5362e8cdc59cc2941007033361e4d67fa1"},
+    {file = "kfp-kubernetes-1.3.0.tar.gz", hash = "sha256:f0fb5f70c77d0948cba0a4ef7c5820811e9de6b2c6251fae6e0291431e994e64"},
 ]
 
 [package.dependencies]
@@ -1658,12 +1658,12 @@ dev = ["docformatter (==1.4)", "isort (==5.10.1)", "mypy (==0.941)", "pre-commit
 
 [[package]]
 name = "kfp-pipeline-spec"
-version = "0.3.0"
+version = "0.4.0"
 description = "Kubeflow Pipelines pipeline spec"
 optional = false
-python-versions = ">=3.7.0,<3.13.0"
+python-versions = "<3.13.0,>=3.7.0"
 files = [
-    {file = "kfp_pipeline_spec-0.3.0-py3-none-any.whl", hash = "sha256:1db84524a0a2d6c9d36e7e87e6fa0e181bf1ba1513d29dcd54f7b8822e7a52a2"},
+    {file = "kfp_pipeline_spec-0.4.0-py3-none-any.whl", hash = "sha256:5384e710aef8268eb20ee147b2a0a6cfc3b0cbeef037cad89f46ab877375e1aa"},
 ]
 
 [package.dependencies]
@@ -1671,12 +1671,12 @@ protobuf = ">=4.21.1,<5"
 
 [[package]]
 name = "kfp-server-api"
-version = "2.0.5"
+version = "2.3.0"
 description = "Kubeflow Pipelines API"
 optional = false
 python-versions = "*"
 files = [
-    {file = "kfp-server-api-2.0.5.tar.gz", hash = "sha256:c9cfbf0e87271d3bfe96e5ecc9ffbdd6ab566bc1c9a9ddc2a39d7698a16e26ff"},
+    {file = "kfp_server_api-2.3.0.tar.gz", hash = "sha256:504aa9f0ca047790aca67b306350aac717ae956c59450a04cf1901c9ed4dca9f"},
 ]
 
 [package.dependencies]
@@ -5571,4 +5571,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = ">=3.11.5, <3.12.0"
-content-hash = "fa78073c401b2eb9f8f0455aedd518e8c11e45b53fee0813691c7d3d74c77350"
+content-hash = "74429e0f3bc254a56e4a8269b348f98a69f6543a4869c3252457f095971264a6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,8 +29,12 @@ rpaframework = "^27.2.0"
 pexpect = "^4.8.0"
 python-openstackclient = "^6.2.0"
 awscli = "^1.27.100"
-kfp = "==2.8.0"
-kfp-kubernetes = "^1.2.0"
+# When you update the kfp or kfp-kubernetes execute the following in the terminal:
+# poetry lock --no-update
+# poetry install
+# find ods_ci/tests/Resources/Files/pipeline-samples/v2 -type f -name "*.py" -print0 | xargs -0 -I {} python {}
+kfp = "==2.9.0"
+kfp-kubernetes = "==1.3.0"
 pyyaml = "^6.0.1"
 junitparser = "3.1.2"
 python-terraform = "0.10.1"


### PR DESCRIPTION
Bump kfp to 2.9.0 and kfp-kubernetes to 1.3.0

How to review the PR:
* The YAML files were automatically generated by the command described in `pyproject.toml`. The command is calling the python file and the output of that call is the YAML.
* An instruction was added to  `pyproject.toml` to ensure no one will forget to generate the YAML files. As you can see, we forgot from 2.7 to 2.8
* `base_image` is now under each file. You can generate the YAML super easy by just running the `py` file
* Added the `if __name__ == "__main__":` method where it was not presented
* Add the `main` and the `compile` instructions where it was missing

Job used for testing: `job/devops/job/rhoai-test-flow/184`
* **IDE is failing because the server was unavailable. Tested locally**
* * ODS-2197 passed locally running on the same cluster `sh run_robot_test.sh --set-urls-variables true --extra-robot-args '-L DEBUG -i ODS-2197' --skip-oclogin`
* * ODS-2271 passed locally running on the same cluster `sh run_robot_test.sh --set-urls-variables true --extra-robot-args '-L DEBUG -i ODS-2271' --skip-oclogin`
* E2E is expected to be failing - AutomationBug