### PR TITLE
fix: DSProjects view wrong xpath (#1801) (BP to 2.13)

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -104,9 +104,8 @@ Project Should Be Listed
 
 Wait Until Project Is Listed
     [Documentation]    Waits until the DS projects appears in the list in DS project Home Page
-    [Arguments]     ${project_title}    ${timeout}=5s
-    Filter Projects By Name    ${project_title}
-    Wait Until Page Contains Element    xpath=//div//a[text()="${project_title}"]
+    [Arguments]     ${project_title}    ${timeout}=30s
+    Wait Until Page Contains Element    xpath=//table[@data-testid="project-view-table"]//td[@data-label="Name"]//a[text()="${project_title}"]
     ...    timeout=${timeout}
 
 Project Should Not Be Listed


### PR DESCRIPTION
Origin: #1801 
Backport to 2.13 