### PR TITLE
Update to reflect changes in model-registry-operator config files.

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/example_istio.env
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/example_istio.env
@@ -1,4 +1,0 @@
-AUTH_PROVIDER=opendatahub-auth-provider
-ISTIO_INGRESS=ingressgateway
-REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
-GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential

--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/istio.env
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/istio.env
@@ -1,0 +1,5 @@
+AUTH_PROVIDER=opendatahub-auth-provider
+DOMAIN=
+ISTIO_INGRESS=ingressgateway
+REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential
+GRPC_CREDENTIAL_NAME=modelregistry-sample-grpc-credential

--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/modelregistry_v1alpha1_modelregistry.yaml
@@ -14,7 +14,7 @@ spec:
     port: 9090
   rest:
     port: 8080
-    serviceRoute: enabled
+    serviceRoute: disabled
   mysql:
     host: model-registry-db
     database: model_registry

--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/mysql-db.yaml
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/mysql-db.yaml
@@ -3,6 +3,11 @@ items:
 - apiVersion: v1
   kind: Service
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     annotations:
       template.openshift.io/expose-uri: mysql://{.spec.clusterIP}:{.spec.ports[?(.name==\mysql\)].port}
     name: model-registry-db
@@ -21,6 +26,11 @@ items:
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     name: model-registry-db
   spec:
     accessModes:
@@ -31,6 +41,11 @@ items:
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     annotations:
       template.alpha.openshift.io/wait-for-ready: "true"
     name: model-registry-db
@@ -113,6 +128,11 @@ items:
 - apiVersion: v1
   kind: Secret
   metadata:
+    labels:
+      app.kubernetes.io/name: model-registry-db
+      app.kubernetes.io/instance: model-registry-db
+      app.kubernetes.io/part-of: model-registry-db
+      app.kubernetes.io/managed-by: kustomize
     annotations:
       template.openshift.io/expose-database_name: '{.data[''database-name'']}'
       template.openshift.io/expose-password: '{.data[''database-password'']}'

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -13,7 +13,7 @@ Resource          ../../Resources/Common.robot
 
 
 *** Variables ***
-${PRJ_TITLE}=                        model-registry-project-tony
+${PRJ_TITLE}=                        model-registry-project-e2e
 ${PRJ_DESCRIPTION}=                  model resgistry test project
 ${AWS_BUCKET}=                       ${S3.BUCKET_2.NAME}
 ${WORKBENCH_TITLE}=                  registry-wb
@@ -43,21 +43,20 @@ ${SECRET_PART_NAME_3}=               model-registry-db
 # robocop: disable:line-too-long
 Verify Model Registry Integration With Secured-DB
     [Documentation]    Verifies the Integartion of Model Registry operator with Jupyter Notebook
-    [Tags]    OpenDataHub    MRMS1302
+    [Tags]    OpenDataHub    MRMS1302    Smoke    ExcludeOnRhoai
     Create Workbench    workbench_title=${WORKBENCH_TITLE}    workbench_description=Registry test
-    ...                 prj_title=${PRJ_TITLE}    image_name=Minimal Python  deployment_size=Small
+    ...                 prj_title=${PRJ_TITLE}    image_name=Minimal Python  deployment_size=${NONE}
     ...                 storage=Persistent   pv_existent=${NONE}
     ...                 pv_name=${NONE}  pv_description=${NONE}  pv_size=${NONE}
     Workbench Should Be Listed      workbench_title=${WORKBENCH_TITLE}
     Open Data Science Project Details Page       project_title=${PRJ_TITLE}
     ${workbenches}=    Create List    ${WORKBENCH_TITLE}
-    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE}
     # Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_S3_NAME}
     # ...            aws_access_key=${S3.AWS_ACCESS_KEY_ID}    aws_secret_access=${S3.AWS_SECRET_ACCESS_KEY}
     # ...            aws_bucket_name=${AWS_BUCKET}    connected_workbench=${workbenches}
     # Data Connection Should Be Listed    name=${DC_S3_NAME}    type=${DC_S3_TYPE}    connected_workbench=${workbenches}
     # Open Data Science Project Details Page       project_title=${prj_title}    tab_id=workbenches
-    # Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE}
+    Wait Until Workbench Is Started     workbench_title=registry-wb
     Upload File In The Workbench     filepath=${SAMPLE_ONNX_MODEL}    workbench_title=${WORKBENCH_TITLE}
     ...         workbench_namespace=${PRJ_TITLE}
     Upload File In The Workbench     filepath=${JUPYTER_NOTEBOOK_FILEPATH}    workbench_title=${WORKBENCH_TITLE}
@@ -84,10 +83,6 @@ Prepare Model Registry Test Setup
     Apply ServiceMeshMember Configuration
     Get Cluster Domain And Token
     Run Update Notebook Script
-    Copy File    ${EXAMPLE_ISTIO_ENV}    ${ISTIO_ENV}
-    Append Key Value To Env File    ${ISTIO_ENV}    DOMAIN    ${DOMAIN}
-    File Should Exist    ${ISTIO_ENV}
-    Log File Content    ${ISTIO_ENV}
     Generate ModelRegistry Certificates
     Apply Db Config Samples    namespace=${NAMESPACE_MODEL-REGISTRY}
     Create Model Registry Secrets
@@ -261,7 +256,6 @@ Run Update Notebook Script
 
 Remove Model Registry
     [Documentation]    Run multiple oc delete commands to remove model registry components
-    Run And Verify Command    oc delete smm default -n ${NAMESPACE_MODEL-REGISTRY}
     Run And Verify Command    oc delete -k ${MODELREGISTRY_BASE_FOLDER}/samples/secure-db/mysql-tls
     Run And Verify Command    oc delete secret modelregistry-sample-grpc-credential -n ${NAMESPACE_ISTIO}
     Run And Verify Command    oc delete secret modelregistry-sample-rest-credential -n ${NAMESPACE_ISTIO}

--- a/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1302_model_registry_model_serving.robot
@@ -56,7 +56,7 @@ Verify Model Registry Integration With Secured-DB
     # ...            aws_bucket_name=${AWS_BUCKET}    connected_workbench=${workbenches}
     # Data Connection Should Be Listed    name=${DC_S3_NAME}    type=${DC_S3_TYPE}    connected_workbench=${workbenches}
     # Open Data Science Project Details Page       project_title=${prj_title}    tab_id=workbenches
-    Wait Until Workbench Is Started     workbench_title=registry-wb
+    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE}
     Upload File In The Workbench     filepath=${SAMPLE_ONNX_MODEL}    workbench_title=${WORKBENCH_TITLE}
     ...         workbench_namespace=${PRJ_TITLE}
     Upload File In The Workbench     filepath=${JUPYTER_NOTEBOOK_FILEPATH}    workbench_title=${WORKBENCH_TITLE}


### PR DESCRIPTION
### This PR makes several changes.
- Updates the service route in 'modelregistry_v1alpha1_modelregistry.yaml' to disabled.
- Updates the 'mysql-db.yaml' with changes to reflect what has changed in model-registry-operator.
- In '1302_model_registry_model_serving.robot' the following changes have been made:
                1. hard coding workbench size
                2. adding tags to include test in ODH-Nightlies
                3. removing code referencing Istio.env as it is no longer needed
                4. removing the code to 'oc delete smm default -n odh-model-registries'

### Succesful pr-check
job/rhods-ci-pr-test/3347/