### PR TITLE
(2.13 backport)  RHOAIENG-12725 - Trusted CA Bundle Namespace Exclusion

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0111__trusted_ca_bundles.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0111__trusted_ca_bundles.robot
@@ -26,18 +26,18 @@ Validate Trusted CA Bundles State Managed
     ...    each non-reserved namespace.
     [Tags]    Operator    Smoke    ODS-2638    TrustedCABundle-Managed
 
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Is Resource Present    project    ${TEST_NS}    ${TEST_NS}    ${IS_PRESENT}
 
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_PRESENT}
 
     # Check that ConfigMap contains key "ca-bundle.crt"
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Check ConfigMap Contains CA Bundle Key    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ca-bundle.crt    ${TEST_NS}
 
     Set Custom CA Bundle Value In DSCI    ${DSCI_NAME}   ${CUSTOM_CA_BUNDLE}    ${OPERATOR_NS}
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${CUSTOM_CA_BUNDLE}    ${TEST_NS}    ${IS_PRESENT}
 
     [Teardown]     Restore DSCI Trusted CA Bundle Settings    ${SAVED_CUSTOM_CA_BUNDLE}
@@ -52,7 +52,7 @@ Validate Trusted CA Bundles State Unmanaged
     # Trusted CA Bundle managementStatus 'Unmanaged' should NOT result in bundle being overwirtten by operator
     Set Custom CA Bundle Value On ConfigMap
     ...    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${TEST_NS}    5s
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Is CA Bundle Value Present    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    random-ca-bundle-value    ${TEST_NS}    ${IS_PRESENT}
 
     [Teardown]     Restore DSCI Trusted CA Bundle Settings    ${SAVED_CUSTOM_CA_BUNDLE}
@@ -65,8 +65,32 @@ Validate Trusted CA Bundles State Removed
     Set Trusted CA Bundle Management State    ${DSCI_NAME}    Removed    ${OPERATOR_NS}
 
     # Check that odh-trusted-ca-bundle has been 'Removed'
-    Wait Until Keyword Succeeds    5 min    0 sec
+    Wait Until Keyword Succeeds    10 min    0 sec
     ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_NOT_PRESENT}
+
+    [Teardown]     Restore DSCI Trusted CA Bundle Settings    ${SAVED_CUSTOM_CA_BUNDLE}
+
+Validate Trusted CA Bundles Exclude Namespace
+    [Documentation]  The purpose of this test case is to validate Trusted CA Bundles can be excluded from a namespace.
+    [Tags]    Operator    ODS-2638    TrustedCABundle-Exclude-Namespace
+
+    Set Trusted CA Bundle Management State    ${DSCI_NAME}    Managed    ${OPERATOR_NS}
+
+    # Check that namespace does contain Trusted CA Bundle ConfigMap prior to excluding.
+    Wait Until Keyword Succeeds    10 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_PRESENT}
+
+    # Exclude the namespace
+    Trusted CA Bundle Include Namespace    ${TEST_NS}    False
+
+    # Trusted CA Bundle ConfigMap should not exist in namespace
+    Wait Until Keyword Succeeds    10 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_NOT_PRESENT}
+
+    # Enable Trusted CA Bundles on namespace, ConfigMap is expected to be created.
+    Trusted CA Bundle Include Namespace    ${TEST_NS}    True
+    Wait Until Keyword Succeeds    10 min    0 sec
+    ...    Is Resource Present     ConfigMap    ${TRUSTED_CA_BUNDLE_CONFIGMAP}    ${TEST_NS}    ${IS_PRESENT}
 
     [Teardown]     Restore DSCI Trusted CA Bundle Settings    ${SAVED_CUSTOM_CA_BUNDLE}
 
@@ -141,3 +165,11 @@ Get Custom CA Bundle Value In DSCI
     Should Be Equal    "${rc}"    "0"   msg=${value}
 
     RETURN    ${value}
+
+Trusted CA Bundle Include Namespace
+    [Documentation]    Include/Exclude specific namespace from containing the Trusted CA Bundle ConfigMap
+    [Arguments]    ${namespace}    ${include}
+
+    ${rc}   ${value}=    Run And Return Rc And Output
+    ...    oc annotate ns ${namespace} security.opendatahub.io/inject-trusted-ca-bundle=${include} --overwrite
+    Should Be Equal    "${rc}"    "0"   msg=${value}


### PR DESCRIPTION
This test case validates that specific namespaces can be excluding from containing the Trusted CA Bundle ConfigMap