### PR TITLE
Fix:  xpath=//input[@data-testid="resource-manage-project-modal-name"] failure

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -8,7 +8,7 @@ Resource       ./Workbenches.resource
 ${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
-${RESOURCE_INPUT_XP}=    css:[data-testid="resource-manage-project-modal-name"]
+${RESOURCE_INPUT_XP}=    css:[data-testid="manage-project-modal-name"]
 ${GENERIC_CREATE_BTN_XP}=     xpath=//button[text()="Create"]
 ${GENERIC_CANCEL_BTN_XP}=     xpath=//button[text()="Cancel"]
 # TODO: Update to latter option once the change is pulled from ODH into downstream!

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -8,7 +8,7 @@ Resource       ./Workbenches.resource
 ${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
-${RESOURCE_INPUT_XP}=    xpath=//input[@data-testid="resource-manage-project-modal-name"]
+${RESOURCE_INPUT_XP}=    css:data-testid="resource-manage-project-modal-name"
 ${GENERIC_CREATE_BTN_XP}=     xpath=//button[text()="Create"]
 ${GENERIC_CANCEL_BTN_XP}=     xpath=//button[text()="Cancel"]
 # TODO: Update to latter option once the change is pulled from ODH into downstream!

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -8,7 +8,7 @@ Resource       ./Workbenches.resource
 ${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
-${RESOURCE_INPUT_XP}=    css:data-testid="resource-manage-project-modal-name"
+${RESOURCE_INPUT_XP}=    css:[data-testid="resource-manage-project-modal-name"]
 ${GENERIC_CREATE_BTN_XP}=     xpath=//button[text()="Create"]
 ${GENERIC_CANCEL_BTN_XP}=     xpath=//button[text()="Cancel"]
 # TODO: Update to latter option once the change is pulled from ODH into downstream!

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -8,7 +8,7 @@ Resource       ./Workbenches.resource
 ${DS_PROJECT_TITLE}=    Data Science Projects
 ${TITLE_INPUT_XP}=    xpath=//input[@id="manage-project-modal-name"]
 ${DESCR_INPUT_XP}=    xpath=//textarea[@id="manage-project-modal-description"]
-${RESOURCE_INPUT_XP}=    css:[data-testid="manage-project-modal-name"]
+${RESOURCE_INPUT_XP}=    css:[data-testid="resource-manage-project-modal-name"]
 ${GENERIC_CREATE_BTN_XP}=     xpath=//button[text()="Create"]
 ${GENERIC_CANCEL_BTN_XP}=     xpath=//button[text()="Cancel"]
 # TODO: Update to latter option once the change is pulled from ODH into downstream!

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -17,7 +17,7 @@ Test Tags          Dashboard
 *** Variables ***
 ${PRJ_TITLE}=   ODS-CI Common Prj
 ${PRJ_TITLE1}=    ODS-CI DS Project1
-${PRJ_RESOURCE_NAME}=   ods-ci-common-project
+${PRJ_RESOURCE_NAME}=   ods-ci-common-ds-project
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Projects feature and shared by multiple tests
 ${NB_IMAGE}=        Minimal Python
 ${WORKBENCH_TITLE}=   ODS-CI Workbench 1

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -15,9 +15,9 @@ Test Tags          Dashboard
 
 
 *** Variables ***
-${PRJ_TITLE}=   ODS-CI Common Prj
+${PRJ_TITLE}=   ods-ci-common-project
 ${PRJ_TITLE1}=    ODS-CI DS Project1
-${PRJ_RESOURCE_NAME}=   ods-ci-common-ds-project
+${PRJ_RESOURCE_NAME}=   ods-ci-common-project
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Projects feature and shared by multiple tests
 ${NB_IMAGE}=        Minimal Python
 ${WORKBENCH_TITLE}=   ODS-CI Workbench 1

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -15,7 +15,7 @@ Test Tags          Dashboard
 
 
 *** Variables ***
-${PRJ_TITLE}=   ods-ci-common-project
+${PRJ_TITLE}=   ODS-CI Common Prj
 ${PRJ_TITLE1}=    ODS-CI DS Project1
 ${PRJ_RESOURCE_NAME}=   ods-ci-common-project
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Projects feature and shared by multiple tests


### PR DESCRIPTION
Failures discovered in ODH Smoke & Sanity

Refactored to identify the element by data-testid only.

Tests fixed:
ODS-1784
ODS-1786
ODS-1775