### PR TITLE
New KW `Wait For Deployment Replica To Be Ready` for oc_install.robot

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -103,7 +103,7 @@ Verify RHODS Installation
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true"
     # Needs to be removed ASAP
     IF  "${PRODUCT}" == "ODH"
-        Log To Console    "Waiting for 2 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-dashboard"
+        Log To Console    Waiting for 2 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-dashboard
         Wait For Pods Numbers  2
         ...                   namespace=${APPLICATIONS_NAMESPACE}
         ...                   label_selector=app=odh-dashboard
@@ -112,7 +112,7 @@ Verify RHODS Installation
         Add UI Admin Group To Dashboard Admin
 
     ELSE
-        Log To Console    "Waiting for 5 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=${DASHBOARD_APP_NAME}"
+        Log To Console    Waiting for 5 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=${DASHBOARD_APP_NAME}
         Wait For Pods Numbers  5
         ...                   namespace=${APPLICATIONS_NAMESPACE}
         ...                   label_selector=app=${DASHBOARD_APP_NAME}
@@ -121,12 +121,12 @@ Verify RHODS Installation
   END
   ${workbenches} =    Is Component Enabled    workbenches    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${workbenches}" == "true"
-    Log To Console    "Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=notebook-controller"
+    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=notebook-controller
     Wait For Pods Numbers  1
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app=notebook-controller
     ...                   timeout=400
-    Log To Console    "Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-notebook-controller"
+    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-notebook-controller
     Wait For Pods Numbers  1
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app=odh-notebook-controller
@@ -134,17 +134,17 @@ Verify RHODS Installation
   END
   ${modelmeshserving} =    Is Component Enabled    modelmeshserving    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${modelmeshserving}" == "true"
-    Log To Console    "Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller"
+    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller
     Wait For Pods Numbers   3
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app=odh-model-controller
     ...                   timeout=400
-    Log To Console    "Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=component=model-mesh-etcd"
+    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=component=model-mesh-etcd
     Wait For Pods Numbers   1
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=component=model-mesh-etcd
     ...                   timeout=400
-    Log To Console    "Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=modelmesh-controller"
+    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=modelmesh-controller
     Wait For Pods Numbers   3
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app.kubernetes.io/name=modelmesh-controller
@@ -152,7 +152,7 @@ Verify RHODS Installation
   END
   ${datasciencepipelines} =    Is Component Enabled    datasciencepipelines    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${datasciencepipelines}" == "true"
-    Log To Console    "Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=data-science-pipelines-operator"
+    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=data-science-pipelines-operator
     Wait For Pods Numbers   1
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app.kubernetes.io/name=data-science-pipelines-operator
@@ -160,7 +160,7 @@ Verify RHODS Installation
   END
   ${modelregistry} =    Is Component Enabled    modelregistry    ${DSC_NAME}
   IF    "${modelregistry}" == "true"
-    Log To Console    "Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/part-of=model-registry-operator"
+    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/part-of=model-registry-operator
     Wait For Pods Numbers   1
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app.kubernetes.io/part-of=model-registry-operator
@@ -168,12 +168,12 @@ Verify RHODS Installation
   END
   ${kserve} =    Is Component Enabled    kserve    ${DSC_NAME}
   IF    "${kserve}" == "true"
-    Log To Console    "Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller"
+    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller
     Wait For Pods Numbers   3
     ...                   namespace=${APPLICATIONS_NAMESPACE}
     ...                   label_selector=app=odh-model-controller
     ...                   timeout=400
-    Log To Console    "Waiting for 1 pods in ${APPLICATIONS_NAMESPACE}, label_selector=control-plane=kserve-controller-manager"
+    Log To Console    Waiting for 1 pods in ${APPLICATIONS_NAMESPACE}, label_selector=control-plane=kserve-controller-manager
     Wait For Pods Numbers   1
        ...                   namespace=${APPLICATIONS_NAMESPACE}
        ...                   label_selector=control-plane=kserve-controller-manager
@@ -181,14 +181,14 @@ Verify RHODS Installation
   END
 
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true" or "${workbenches}" == "true" or "${modelmeshserving}" == "true" or "${datasciencepipelines}" == "true"  # robocop: disable
-    Log To Console    "Waiting for pod status in ${APPLICATIONS_NAMESPACE}"
+    Log To Console    Waiting for pod status in ${APPLICATIONS_NAMESPACE}
     Wait For Pods Status  namespace=${APPLICATIONS_NAMESPACE}  timeout=200
     Log  Verified Applications NS: ${APPLICATIONS_NAMESPACE}  console=yes
   END
 
   # Monitoring stack only deployed for managed, as modelserving monitoring stack is no longer deployed
   IF  "${cluster_type}" == "managed"
-     Log To Console    "Waiting for pod status in ${MONITORING_NAMESPACE}"
+     Log To Console    Waiting for pod status in ${MONITORING_NAMESPACE}
      Wait For Pods Status  namespace=${MONITORING_NAMESPACE}  timeout=600
      Log  Verified Monitoring NS: ${MONITORING_NAMESPACE}  console=yes
   END
@@ -226,18 +226,15 @@ Install RHODS In Managed Cluster Using CLI
 Wait For Pods Numbers
   [Documentation]   Wait for number of pod during installtion
   [Arguments]     ${count}     ${namespace}     ${label_selector}    ${timeout}
-  ${status}   Set Variable   False
-  FOR    ${counter}    IN RANGE   ${timeout}
-         ${return_code}    ${output}    Run And Return Rc And Output   oc get pod -n ${namespace} -l ${label_selector} | tail -n +2 | wc -l
-         IF    ${output} == ${count}
-               ${status}  Set Variable  True
-               Log To Console  pods ${label_selector} created
-               BREAK
-         END
-         Sleep    1 sec
-  END
-  IF    '${status}' == 'False'
-        Run Keyword And Continue On Failure    FAIL    Timeout- ${output} pods found with the label selector ${label_selector} in ${namespace} namespace
+  ${output} =    Wait Until Keyword Succeeds    ${timeout}s   3s    Run And Verify Command
+  ...    oc wait -n ${namespace} --for condition\=ready pod -l "${label_selector}" --timeout\=${timeout}s    print_to_log=${FALSE}
+  Log To Console    ${output}
+  ${result} =    Run Process    oc get pod -n ${namespace} -l ${label_selector} | tail -n +2 | wc -l    shell=true
+  Log To Console  ${result.stdout}/${count} pods created with label ${label_selector} in ${namespace} namespace
+  IF    ${result.stdout} != ${count}
+    Log To Console    [WARN] Timeout exceeded for all ${count} pods to be ready. Verifying if desired ReplicaSet created    STDERR
+    Run Keyword And Continue On Failure    Run And Verify Command
+    ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas \=\= .readyReplicas'
   END
 
 Apply DSCInitialization CustomResource

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -80,10 +80,8 @@ Verify RHODS Installation
   Set Global Variable    ${DASHBOARD_APP_NAME}    ${PRODUCT.lower()}-dashboard
   Log  Verifying RHODS installation  console=yes
   Log To Console    Waiting for all RHODS resources to be up and running
-  Wait For Pods Numbers  1
-  ...                   namespace=${OPERATOR_NAMESPACE}
-  ...                   label_selector=name=${OPERATOR_NAME_LABEL}
-  ...                   timeout=2000
+  Wait For Deployment Replica To Be Ready    namespace=${OPERATOR_NAMESPACE}
+  ...    label_selector=name=${OPERATOR_NAME_LABEL}    timeout=2000s
   Wait For Pods Status  namespace=${OPERATOR_NAMESPACE}  timeout=1200
   Log  Verified ${OPERATOR_NAMESPACE}  console=yes
 
@@ -99,85 +97,57 @@ Verify RHODS Installation
     END
     Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}
   END
+
   ${dashboard} =    Is Component Enabled    dashboard    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true"
     # Needs to be removed ASAP
     IF  "${PRODUCT}" == "ODH"
-        Log To Console    Waiting for 2 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-dashboard
-        Wait For Pods Numbers  2
-        ...                   namespace=${APPLICATIONS_NAMESPACE}
-        ...                   label_selector=app=odh-dashboard
-        ...                   timeout=1200
+        Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+        ...    label_selector=app=odh-dashboard    timeout=1200s
         #This line of code is strictly used for the exploratory cluster to accommodate UI/UX team requests
         Add UI Admin Group To Dashboard Admin
-
     ELSE
-        Log To Console    Waiting for 5 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=${DASHBOARD_APP_NAME}
-        Wait For Pods Numbers  5
-        ...                   namespace=${APPLICATIONS_NAMESPACE}
-        ...                   label_selector=app=${DASHBOARD_APP_NAME}
-        ...                   timeout=1200
+        Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+        ...    label_selector=app=${DASHBOARD_APP_NAME}    timeout=1200s
     END
   END
+
   ${workbenches} =    Is Component Enabled    workbenches    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${workbenches}" == "true"
-    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=notebook-controller
-    Wait For Pods Numbers  1
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app=notebook-controller
-    ...                   timeout=400
-    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-notebook-controller
-    Wait For Pods Numbers  1
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app=odh-notebook-controller
-    ...                   timeout=400
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app=notebook-controller    timeout=400s
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app=odh-notebook-controller    timeout=400s
   END
+
   ${modelmeshserving} =    Is Component Enabled    modelmeshserving    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${modelmeshserving}" == "true"
-    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller
-    Wait For Pods Numbers   3
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app=odh-model-controller
-    ...                   timeout=400
-    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=component=model-mesh-etcd
-    Wait For Pods Numbers   1
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=component=model-mesh-etcd
-    ...                   timeout=400
-    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=modelmesh-controller
-    Wait For Pods Numbers   3
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app.kubernetes.io/name=modelmesh-controller
-    ...                   timeout=400
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app=odh-model-controller    timeout=400s
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=component=model-mesh-etcd    timeout=400s
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app.kubernetes.io/name=modelmesh-controller    timeout=400s
   END
+
   ${datasciencepipelines} =    Is Component Enabled    datasciencepipelines    ${DSC_NAME}
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${datasciencepipelines}" == "true"
-    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/name=data-science-pipelines-operator
-    Wait For Pods Numbers   1
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app.kubernetes.io/name=data-science-pipelines-operator
-    ...                   timeout=400
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app.kubernetes.io/name=data-science-pipelines-operator    timeout=400s
   END
+
   ${modelregistry} =    Is Component Enabled    modelregistry    ${DSC_NAME}
   IF    "${modelregistry}" == "true"
-    Log To Console    Waiting for 1 pod in ${APPLICATIONS_NAMESPACE}, label_selector=app.kubernetes.io/part-of=model-registry-operator
-    Wait For Pods Numbers   1
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app.kubernetes.io/part-of=model-registry-operator
-    ...                   timeout=400
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app.kubernetes.io/part-of=model-registry-operator    timeout=400s
   END
+
   ${kserve} =    Is Component Enabled    kserve    ${DSC_NAME}
   IF    "${kserve}" == "true"
-    Log To Console    Waiting for 3 pods in ${APPLICATIONS_NAMESPACE}, label_selector=app=odh-model-controller
-    Wait For Pods Numbers   3
-    ...                   namespace=${APPLICATIONS_NAMESPACE}
-    ...                   label_selector=app=odh-model-controller
-    ...                   timeout=400
-    Log To Console    Waiting for 1 pods in ${APPLICATIONS_NAMESPACE}, label_selector=control-plane=kserve-controller-manager
-    Wait For Pods Numbers   1
-       ...                   namespace=${APPLICATIONS_NAMESPACE}
-       ...                   label_selector=control-plane=kserve-controller-manager
-       ...                   timeout=400
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app=odh-model-controller    timeout=400s
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=control-plane=kserve-controller-manager    timeout=400s
   END
 
   IF    ("${UPDATE_CHANNEL}" == "stable" or "${UPDATE_CHANNEL}" == "beta") or "${dashboard}" == "true" or "${workbenches}" == "true" or "${modelmeshserving}" == "true" or "${datasciencepipelines}" == "true"  # robocop: disable
@@ -226,15 +196,18 @@ Install RHODS In Managed Cluster Using CLI
 Wait For Pods Numbers
   [Documentation]   Wait for number of pod during installtion
   [Arguments]     ${count}     ${namespace}     ${label_selector}    ${timeout}
-  ${output} =    Wait Until Keyword Succeeds    ${timeout}s   3s    Run And Verify Command
-  ...    oc wait -n ${namespace} --for condition\=ready pod -l "${label_selector}" --timeout\=${timeout}s    print_to_log=${FALSE}
-  Log To Console    ${output}
-  ${result} =    Run Process    oc get pod -n ${namespace} -l ${label_selector} | tail -n +2 | wc -l    shell=true
-  Log To Console  ${result.stdout}/${count} pods created with label ${label_selector} in ${namespace} namespace
-  IF    ${result.stdout} != ${count}
-    Log To Console    [WARN] Timeout exceeded for all ${count} pods to be ready. Verifying if desired ReplicaSet created    STDERR
-    Run Keyword And Continue On Failure    Run And Verify Command
-    ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas \=\= .readyReplicas'
+  ${status}   Set Variable   False
+  FOR    ${counter}    IN RANGE   ${timeout}
+         ${return_code}    ${output}    Run And Return Rc And Output   oc get pod -n ${namespace} -l ${label_selector} | tail -n +2 | wc -l
+         IF    ${output} == ${count}
+               ${status}  Set Variable  True
+               Log To Console  pods ${label_selector} created
+               BREAK
+         END
+         Sleep    1 sec
+  END
+  IF    '${status}' == 'False'
+        Run Keyword And Continue On Failure    FAIL    Timeout- ${output} pods found with the label selector ${label_selector} in ${namespace} namespace
   END
 
 Apply DSCInitialization CustomResource

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -437,11 +437,12 @@ Extract URLs From Text
     RETURN    ${urls}
 
 Run And Verify Command
-    [Documentation]    Run an oc delete command and log the output and errors
-    [Arguments]    ${command}
-    ${result}=    Run Process    ${command}    shell=yes
-    Log    ${result.stdout}\n${result.stderr}     console=True
+    [Documentation]    Run and verify shell command 
+    [Arguments]    ${command}    ${print_to_log}=${TRUE}
+    ${result}=    Run Process    ${command}    shell=yes    stderr=STDOUT
+    IF    ${print_to_log}    Log    ${result.stdout}     console=True
     Should Be True    ${result.rc} == 0
+    RETURN    ${result.stdout}
 
 Run And Watch Command
   [Documentation]    Run any shell command (including args) with optional:

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -124,6 +124,16 @@ Wait For Pods To Be Ready
         Length Should Be  ${replicas}  ${exp_replicas}
     END
 
+Wait For Deployment Replica To Be Ready
+  [Documentation]   Wait for Deployment of ${label_selector} in ${namespace} to have the Replica-Set Ready
+  [Arguments]     ${namespace}     ${label_selector}    ${timeout}=600s
+  Log To Console    Waiting for Deployment with label "${label_selector}" in Namespace "${namespace}", to have desired Replica-Set
+  ${output} =    Wait Until Keyword Succeeds    ${timeout}   3s    Run And Verify Command
+  ...    oc wait -n ${namespace} --for condition\=ready pod -l "${label_selector}" --timeout\=${timeout}
+  ...    print_to_log=${FALSE}
+  Run And Verify Command
+  ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas \=\= .readyReplicas'
+
 Wait For Pods To Succeed
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}
     Wait Until Keyword Succeeds    ${timeout}    3s


### PR DESCRIPTION
This is to verify if the number of running pods is as desired by replica-set, instead of directly failing if the pods number is not as defined in ODS-CI (hard-coded).

For example, 3 pods are currently expected for odh-model-controller in ODS-CI, but in the latest ODH build the replica-set desired number is 1, not 3. This should fix this false failure.
