### PR TITLE
fix: ODS-2206, wrong pipelines xpath

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -16,7 +16,7 @@ ${PIPELINE_NAME_INPUT_XP}=                       xpath://*[@data-testid="pipelin
 ${PIPELINE_DESC_INPUT_XP}=                       xpath://*[@data-testid="pipeline-description"]
 ${PIPELINE_RUN_NAME_INPUT_XP}=                   id:run-name
 ${PIPELINE_RUN_DESC_INPUT_XP}=                   id:run-description
-${PIPELINE_RUN_EXPERIMENT_BUTTON_XP}=            xpath://*[@data-testid="experiment-toggle-button"]
+${PIPELINE_RUN_EXPERIMENT_BUTTON_XP}=            xpath://*[@data-testid="experiment-selector-toggle"]
 ${PIPELINE_RUN_EXPERIMENT_SELECTOR_TABLE_XP}=    xpath://*[@data-testid="experiment-selector-table-list"]
 ${PIPELINE_RUN_CREATE_BTN_XP}=                   xpath://*[@data-testid="run-page-submit-button"]
 ${PIPELINE_EXPERIMENT_TABLE_XP}=                 xpath://*[@data-testid="experiment-table"]

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -195,13 +195,13 @@ Pipeline Should Be Listed
     [Arguments]     ${pipeline_name}    ${pipeline_description}=${EMPTY}
 
     Projects.Move To Tab    Pipelines
-    ${pipeline_title_xp}=    Set Variable      //*[@data-testid="table-row-title"]/a/span[text()="${pipeline_name}"]
+    ${pipeline_title_xp}=    Set Variable      //*[@data-testid="table-row-title"]//span[text()="${pipeline_name}"]
     Run Keyword And Continue On Failure    Wait Until Page Contains Element    ${pipeline_title_xp}
 
     IF    "${pipeline_description}" != "${EMPTY}"
         Run Keyword And Continue On Failure
         ...    Wait Until Page Contains Element
-        ...        ${pipeline_title_xp}/ancestor::b/following-sibling::*[p[text()="${pipeline_description}"]]
+        ...        ${pipeline_title_xp}/ancestor::td//div[@class="odh-markdown-view"]/p[text()="${pipeline_description}"]
     END
 
 Pipeline Should Not Be Listed


### PR DESCRIPTION
Fix test: "Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Page Using Custom Pip Mirror"
Tags:  ODS-2206    ODS-2226    ODS-2633

Error:  
Element '//[@data-testid="table-row-title"]/a/span[text()="iris-ldap-user2"]/ancestor::b/following-sibling::[p[text()="test pipeline definition"]]' did not appear in 5 seconds. 

This error has happened in different nightlies:
rhoai/job/autotrigger-smoke/319/
odh/job/autotrigger-smoke/269/

Also, after fixing the first error, some new has shown in different view. Due to an xpath change.

It has been tested against the nightly cluster:
![image](https://github.com/user-attachments/assets/02245c68-810e-498e-9a15-9b88e0689107)

