### PR TITLE
Update the Python version and other requirements for the 2024b OOTB images

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
@@ -62,12 +62,11 @@ Can Spawn Notebook
     Remove Spawner Environment Variable  env_four
     Remove Spawner Environment Variable  env_five
     Remove Spawner Environment Variable  env_six
-    ${version-check}=   Is RHODS Version Greater Or Equal Than  1.18.0
-    IF  ${version-check}==True
-        FOR    ${env_var}    IN    @{UNSUPPORTED_VAR_NAMES}
-            Verify Unsupported Environment Variable Is Not Allowed    ${env_var}
-        END
+
+    FOR    ${env_var}    IN    @{UNSUPPORTED_VAR_NAMES}
+        Verify Unsupported Environment Variable Is Not Allowed    ${env_var}
     END
+
     # TODO: Verify why error isn't appearing within 1 minute
     # Verify Notebook Spawner Modal Does Not Get Stuck When Requesting Too Many Resources To Spawn Server
     Spawn Notebook  same_tab=${False}
@@ -82,7 +81,7 @@ Can Spawn Notebook
     Maybe Close Popup
     ${is_launcher_selected} =  Run Keyword And Return Status  JupyterLab Launcher Tab Is Selected
     IF  not ${is_launcher_selected}  Open JupyterLab Launcher
-    Launch a new JupyterLab Document    kernel=Python 3.9
+    Launch a new JupyterLab Document    kernel=Python 3.11
     Close Other JupyterLab Tabs
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -58,7 +58,6 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Based I
     PyTorch       Datascience with Python 3.11 (UBI9)    pytorch pipeline
     TensorFlow    Datascience with Python 3.11 (UBI9)    tensorflow pipeline
     TrustyAI      Datascience with Python 3.11 (UBI9)    trustyai pipeline
-    HabanaAI      Datascience with Python 3.11 (UBI8)    habanaai pipeline
 
 
 *** Keywords ***

--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -44,7 +44,7 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Image
     [Timeout]    10m
     Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     ...    img=Standard Data Science
-    ...    runtime_image=Datascience with Python 3.9 (UBI9)
+    ...    runtime_image=Datascience with Python 3.11 (UBI9)
     ...    experiment_name=standard data science pipeline
 
 Verify Pipelines Integration With Elyra When Using Standard Data Science Based Images
@@ -55,10 +55,10 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Based I
     [Template]    Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     [Tags]        Tier1    ODS-2271
     [Timeout]     30m
-    PyTorch       Datascience with Python 3.9 (UBI9)    pytorch pipeline
-    TensorFlow    Datascience with Python 3.9 (UBI9)    tensorflow pipeline
-    TrustyAI      Datascience with Python 3.9 (UBI9)    trustyai pipeline
-    HabanaAI      Datascience with Python 3.8 (UBI8)    habanaai pipeline
+    PyTorch       Datascience with Python 3.11 (UBI9)    pytorch pipeline
+    TensorFlow    Datascience with Python 3.11 (UBI9)    tensorflow pipeline
+    TrustyAI      Datascience with Python 3.11 (UBI9)    trustyai pipeline
+    HabanaAI      Datascience with Python 3.11 (UBI8)    habanaai pipeline
 
 
 *** Keywords ***


### PR DESCRIPTION
These changes are required for the testing of the recently updated 2024b images added with the RHOAI 2.14 release.

These images also contains new Jupyter 4 and Elyra 4 version, see [1].

* [1] https://issues.redhat.com/browse/RHOAIENG-11697

Another change in this PR is a removal of the simple test for Habana image as that image is removed in 2.14. This change is to comply with this issue [2].

* [2] https://issues.redhat.com/browse/RHOAIENG-13415
---

CI:
![image](https://github.com/user-attachments/assets/456e9723-fa43-4bd0-95be-53e09e4077b9)
