### PR TITLE
Fix check for nvidia-device-plugin-daemonset when deploying NVIDIA operator stack

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -30,7 +30,6 @@ oc wait --timeout=3m --for jsonpath='{.status.components.labelSelector.matchExpr
 oc wait --timeout=3m --for jsonpath='{.status.components.labelSelector.matchExpressions[].operator}'=Exists operator gpu-operator-certified.nvidia-gpu-operator
 
 function wait_until_pod_ready_status() {
-  local timeout_seconds=1200
   local pod_label=$1
   local namespace=nvidia-gpu-operator
   local timeout=360

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -33,7 +33,7 @@ function wait_until_pod_ready_status() {
   local timeout_seconds=1200
   local pod_label=$1
   local namespace=nvidia-gpu-operator
-  local timeout=240
+  local timeout=360
   start_time=$(date +%s)
   while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
      pod_status="$(oc get pod -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
@@ -42,7 +42,10 @@ function wait_until_pod_ready_status() {
         echo "Waiting until GPU Pods or Daemonset of '$pod_label' in namespace '$namespace' are in running state..."
         echo "Pods status: '$pod_status'"
         echo "Daemonset status: '$daemon_status'"
-        oc wait --timeout="${timeout_seconds}s" --for=condition=ready pod -n "$namespace" -l app="$pod_label" || \
+        oc wait --timeout=10s --for=condition=ready pod -n "$namespace" -l app="$pod_label" || \
+        if [ $? -ne 0 ]; then
+          continue
+        fi
         oc rollout status --watch --timeout=3m daemonset -n "$namespace" -l app="$pod_label" || continue
         break
      fi

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -32,7 +32,7 @@ oc wait --timeout=3m --for jsonpath='{.status.components.labelSelector.matchExpr
 function wait_until_pod_ready_status() {
   local pod_label=$1
   local namespace=nvidia-gpu-operator
-  local timeout=360
+  local timeout=${2:-360}
   start_time=$(date +%s)
   while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
      pod_status="$(oc get pod -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
@@ -85,7 +85,7 @@ wait_until_pod_ready_status  "gpu-operator"
 oc apply -f "$GPU_INSTALL_DIR/../nfd_deploy.yaml"
 oc get csv -n nvidia-gpu-operator "$CSVNAME" -o jsonpath='{.metadata.annotations.alm-examples}' | jq .[0] > clusterpolicy.json
 oc apply -f clusterpolicy.json
-wait_until_pod_ready_status "nvidia-device-plugin-daemonset"
+wait_until_pod_ready_status "nvidia-device-plugin-daemonset" 600
 wait_until_pod_ready_status "nvidia-container-toolkit-daemonset"
 wait_until_pod_ready_status "nvidia-dcgm-exporter"
 wait_until_pod_ready_status "gpu-feature-discovery"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
@@ -46,4 +46,5 @@ oc wait --timeout=$MACHINE_WAIT_TIMEOUT --for jsonpath='{.status.readyReplicas}'
  if [ $? -ne 0 ]; then
   echo "Machine Set $NEW_MACHINESET_NAME does not have its Machines in Running status after $MACHINE_WAIT_TIMEOUT timeout"
   echo "Please check the cluster"
+  exit 1
 fi

--- a/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
@@ -41,6 +41,7 @@ oc apply --kustomize $PROVIDER_OVERLAY_DIR
 # Add GPU label to the new machine-set
 oc patch machinesets -n openshift-machine-api "$NEW_MACHINESET_NAME" -p '{"metadata":{"labels":{"gpu-machineset":"true"}}}' --type=merge
 # wait for the machine to be Ready
+echo "Waiting for GPU Node to be Ready"
 oc wait --timeout=$MACHINE_WAIT_TIMEOUT --for jsonpath='{.status.readyReplicas}'=1 machineset $NEW_MACHINESET_NAME -n openshift-machine-api
  if [ $? -ne 0 ]; then
   echo "Machine Set $NEW_MACHINESET_NAME does not have its Machines in Running status after $MACHINE_WAIT_TIMEOUT timeout"


### PR DESCRIPTION
As of now, when deploying the NVIDIA GPU operator stack, the nvidia-device-plugin-daemonset gets restarted after being in "init" status. Our script has already started waiting for the pod to be in Ready status but it waits for a pod which won't never be up and running. In addition, it has a 20 minutes timeout which makes CI spending more time than needed

Solution:
- instead of waiting 20 minutes after fetching the pod name, it waits only 10seconds and if the pod is not ready, it continues the loop (i.e., fetching the pod name again, wait 10 s, etc)
- wait for the GPU node to be ready before deploying the NVIDIA Stack, it reduces the risk of hitting the timeouts

PR validation:
1. provision smaller GPU on IBM cloud: `rhods-ci-pr-test/3368` PASS - the job failure at the end is not related to this PR. It took 15 minutes from provisioning to stack deployment
2. provision bigger GPU on GCP: `rhods-ci-pr-test/3371` - approx 15 min for e2e flow (provisioning + operator installtion)
4. test provisioning without this PR and compare timing: `rhods-ci-pr-test/3372` PASS - it took 28 minutes for e2e flow (provisioning + operator installtion) - the job failure at the end is not related to this PR