### PR TITLE
Removing hard coded auth_provider

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/istio.env
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/istio/components/istio.env
@@ -1,4 +1,4 @@
-AUTH_PROVIDER=opendatahub-auth-provider
+AUTH_PROVIDER=
 DOMAIN=
 ISTIO_INGRESS=ingressgateway
 REST_CREDENTIAL_NAME=modelregistry-sample-rest-credential


### PR DESCRIPTION
Removes the hardcoded auth_provider value as it is no longer needed.