### PR TITLE
Shorten the name of a project resource name to pass the check

### DIFF
--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects_additional.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects_additional.robot
@@ -14,7 +14,7 @@ Test Tags          Dashboard
 *** Variables ***
 ${PRJ_TITLE}=   ODS-CI DS Project 2
 ${PRJ_TITLE_GPU}=   ODS-CI DS Project GPU
-${PRJ_RESOURCE_NAME}=   ods-ci-ds-project-test-additional
+${PRJ_RESOURCE_NAME}=   ods-ci-ds-pr-test-0410
 ${PRJ_DESCRIPTION}=   ${PRJ_TITLE} is a test project for validating DS Project feature
 ${TOLERATIONS}=    workbench-tolerations
 ${TOLERATIONS_2}=    workbench-tolerations-two


### PR DESCRIPTION
The resource name may be max 30 characters in length.

![selenium-screenshot-6](https://github.com/user-attachments/assets/cfbc74ed-9719-4d65-98e9-bd6cdbc30fda)

----

Tested this with CI - `/job/devops/job/rhoai-test-flow/648` the suite setup finishes just fine now. There are some other xpath changes required further down for the workbench status management, but I think this was discussed elsewhere already so I'm not touching that part.