### PR TITLE
Updating MYSQL Database Image To Use Specific Digest

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/mysql-db.yaml
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/samples/mysql/mysql-db.yaml
@@ -89,7 +89,7 @@ items:
             - --datadir
             - /var/lib/mysql/datadir
             - --default-authentication-plugin=mysql_native_password
-          image: public.ecr.aws/docker/library/mysql:8.3.0
+          image: public.ecr.aws/docker/library/mysql@sha256:9de9d54fecee6253130e65154b930978b1fcc336bcc86dfd06e89b72a2588ebe
           imagePullPolicy: IfNotPresent
           livenessProbe:
             exec:


### PR DESCRIPTION
This is a requirement for pointing to custom images in a disconnected cluster

Tested on a disconnected cluster dis-shared-02

![Screenshot 2024-10-04 at 14 13 56](https://github.com/user-attachments/assets/2c5ef4aa-a374-4732-9e25-5c63a8d9ddd1)
![Screenshot 2024-10-04 at 14 19 11](https://github.com/user-attachments/assets/f1c7e8a7-0ee0-42ec-8fd8-2598f5dbf0cb)
