### PR TITLE
Align common Distributed Workloads tests

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -182,8 +182,8 @@ Run Training Operator ODH Test
         FAIL    ${TEST_NAME} failed
     END
 
-Prepare Codeflare E2E Test Suite
-    [Documentation]    Prepare Codeflare E2E Core Test Suite
+Prepare DistributedWorkloads Integration Test Suite
+    [Documentation]    Prepare DistributedWorkloads Integration Test Suite
     Log To Console    "Restarting kueue"
     Restart Kueue
 
@@ -196,7 +196,7 @@ Prepare Codeflare E2E Test Suite
     IF    ${result.rc} != 0
         FAIL    Unable to retrieve odh compiled binary
     END
-    Create Directory    %{WORKSPACE}/codeflare-odh-logs
+    Create Directory    %{WORKSPACE}/distributed-workloads-odh-logs
     Log To Console    "Retrieving user tokens"
     ${common_user_token} =    Generate User Token    ${NOTEBOOK_USER_NAME}    ${NOTEBOOK_USER_PASSWORD}
     Set Suite Variable    ${NOTEBOOK_USER_TOKEN}   ${common_user_token}
@@ -204,8 +204,8 @@ Prepare Codeflare E2E Test Suite
     Login To OCP Using API    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     RHOSi Setup
 
-Teardown Codeflare E2E Test Suite
-    [Documentation]    Teardown Codeflare E2E Test Suite
+Teardown DistributedWorkloads Integration Test Suite
+    [Documentation]    Teardown DistributedWorkloads Integration Test Suite
     Log To Console    "Log back as cluster admin"
     Login To OCP Using API    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     Log To Console    "Removing test binaries"
@@ -220,8 +220,8 @@ Generate User Token
     Should Be Equal As Integers    ${rc}    ${0}
     RETURN    ${out}
 
-Run Codeflare ODH Test
-    [Documentation]    Run Codeflare ODH Test
+Run DistributedWorkloads ODH Test
+    [Documentation]    Run DistributedWorkloads ODH Test
     [Arguments]    ${TEST_NAME}    ${RAY_IMAGE}
     Log To Console    "Running test: ${TEST_NAME}"
     ${result} =    Run Process    ./${ODH_BINARY_NAME} -test.run ${TEST_NAME}
@@ -230,7 +230,7 @@ Run Codeflare ODH Test
     ...    env:CODEFLARE_TEST_TIMEOUT_SHORT=5m
     ...    env:CODEFLARE_TEST_TIMEOUT_MEDIUM=10m
     ...    env:CODEFLARE_TEST_TIMEOUT_LONG=20m
-    ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/codeflare-odh-logs
+    ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/distributed-workloads-odh-logs
     ...    env:CODEFLARE_TEST_RAY_IMAGE=${RAY_IMAGE}
     ...    env:ODH_NAMESPACE=${APPLICATIONS_NAMESPACE}
     ...    env:NOTEBOOK_USER_NAME=${NOTEBOOK_USER_NAME}

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
@@ -2,9 +2,9 @@
 Documentation       Suite to test Workload metrics feature
 Library             SeleniumLibrary
 Library             OpenShiftLibrary
-Resource            ../../../Resources/Page/DistributedWorkloads/WorkloadMetricsUI.resource
-Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
-Resource            ../../../../tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+Resource            ../../Resources/Page/DistributedWorkloads/WorkloadMetricsUI.resource
+Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+Resource            ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 Suite Setup         Project Suite Setup
 Suite Teardown      Project Suite Teardown
 Test Tags           DistributedWorkloadMetrics

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
@@ -1,11 +1,11 @@
 *** Settings ***
-Documentation     Codeflare operator E2E tests - https://github.com/opendatahub-io/distributed-workloads/tree/main/tests/odh
-Suite Setup       Prepare Codeflare E2E Test Suite
-Suite Teardown    Teardown Codeflare E2E Test Suite
+Documentation     Distributed Workloads Integration tests - https://github.com/opendatahub-io/distributed-workloads/tree/main/tests/odh
+Suite Setup       Prepare DistributedWorkloads Integration Test Suite
+Suite Teardown    Teardown DistributedWorkloads Integration Test Suite
 Library           OperatingSystem
 Library           Process
-Resource          ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
-Resource          ../../../../tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+Resource          ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 
 
 *** Variables ***
@@ -20,8 +20,8 @@ Run TestKueueRayCpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistRayCpu    ${RAY_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayCpu    ${RAY_CUDA_IMAGE}
 
 Run TestKueueRayGpu ODH test
     [Documentation]    Run Go ODH test: TestKueueRayGpu
@@ -29,8 +29,8 @@ Run TestKueueRayGpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistRayGpu    ${RAY_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayGpu    ${RAY_CUDA_IMAGE}
 
 Run TestRayTuneHPOCpu ODH test
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoCpu
@@ -38,8 +38,8 @@ Run TestRayTuneHPOCpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistRayTuneHpoCpu    ${RAY_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoCpu    ${RAY_CUDA_IMAGE}
 
 Run TestRayTuneHPOGpu ODH test
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoGpu
@@ -47,8 +47,8 @@ Run TestRayTuneHPOGpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE}
 
 Run TestKueueCustomRayCpu ODH test
     [Documentation]    Run Go ODH test: TestKueueCustomRayCpu
@@ -56,8 +56,8 @@ Run TestKueueCustomRayCpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistCustomRayImageCpu    ${RAY_TORCH_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageCpu    ${RAY_TORCH_CUDA_IMAGE}
 
 Run TestKueueCustomRayGpu ODH test
     [Documentation]    Run Go ODH test: TestKueueCustomRayGpu
@@ -66,5 +66,5 @@ Run TestKueueCustomRayGpu ODH test
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
-    ...     CodeflareOperator
-    Run Codeflare ODH Test    TestMnistCustomRayImageGpu    ${RAY_TORCH_CUDA_IMAGE}
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageGpu    ${RAY_TORCH_CUDA_IMAGE}


### PR DESCRIPTION
This PR aligns common Distributed Workloads tests for both components - Training & Workloads Orchestration

- Remove `distributed-workloads-ui tests` from `0602__training` folder and placed under `0600__distributed_workloads`
- Rename `test-run-codeflare-tests` to `test-run-distributed-workloads-tests` as these tests are not specific to `code-flare operator` only. These are the integration tests of distributed workloads.
- Remove `test-run-distributed-workloads-tests` from `0602__training` folder and placed under `0600__distributed_workloads`
