### PR TITLE
Update odh-model-controller replicas to 1

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelServing/modelmesh.resource
+++ b/ods_ci/tests/Resources/CLI/ModelServing/modelmesh.resource
@@ -26,7 +26,7 @@ Verify odh-model-controller Deployment
     [Documentation]    Verifies the correct deployment of the model controller in the rhods namespace
     @{odh_model_controller} =  Oc Get    kind=Pod    namespace=${APPLICATIONS_NAMESPACE}    label_selector=control-plane=odh-model-controller    # robocop: disable
     ${containerNames} =  Create List  manager
-    Verify Deployment    ${odh_model_controller}  3  1  ${containerNames}
+    Verify Deployment    ${odh_model_controller}  1  1  ${containerNames}
 
 Verify Openvino Deployment
     [Documentation]    Verifies the correct deployment of the ovms server pod(s) in the rhods namespace


### PR DESCRIPTION
rh-pre-commit.version: 2.3.1
rh-pre-commit.check-secrets: ENABLED

---

Here is the tracking for the change of the number of replicas for the odh-model-controller:
* https://issues.redhat.com/browse/RHOAIENG-7034
* https://github.com/opendatahub-io/odh-model-controller/pull/268