### PR TITLE
fix: ODS-1813 wrong span

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -333,9 +333,9 @@ Start Workbench
     ${is_stopped}=      Run Keyword And Return Status   Workbench Status Should Be
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_STOPPED}
     IF    ${is_stopped} == ${TRUE}
-        Click Button    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]
-        Wait Until Element Is Visible    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Start"]    timeout=10
-        Click Element    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Start"]
+        Click Button    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]
+        Wait Until Element Is Visible    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Start"]    timeout=10
+        Click Element    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Start"]
     ELSE
         Log     msg=Cannot start ${workbench_title} workbench because it is not stopped.
     END
@@ -407,9 +407,9 @@ Stop Workbench
     ${is_starting}=      Run Keyword And Return Status   Workbench Status Should Be
     ...    workbench_title=${workbench_title}   status=${WORKBENCH_STATUS_STARTING}
     IF    ${is_started} == ${TRUE} or ${is_starting} == ${TRUE}
-        Click Button    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]
-        Wait Until Element Is Visible    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Stop"]    timeout=10
-        Click Element    xpath=//div[@data-testid="table-row-title"]//span[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Stop"]
+        Click Button    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]
+        Wait Until Element Is Visible    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Stop"]    timeout=10
+        Click Element    xpath=//div[@data-testid="table-row-title"]//div[text()="${workbench_title}"]/ancestor::tr//button[@aria-label="Kebab toggle"]/following::div//span[text()="Stop"]
         Wait Until Generic Modal Appears
         Handle Stop Workbench Confirmation Modal    press_cancel=${press_cancel}
         ...    from_running=${from_running}


### PR DESCRIPTION
https://issues.redhat.com/browse/RHOAIENG-14144
During 2.14 nightly execution this test was failing due to a modification of an xpath.
Test results (using nightly cluster):
![image](https://github.com/user-attachments/assets/caebc9fd-4ede-4f4a-9e80-8284d8c63518)
