### PR TITLE
[Fix] partially reverts #1901 as we should keep using the library keyword

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -357,13 +357,15 @@ Add And Run JupyterLab Code Cell 5 In Active Notebook
     [Arguments]    @{code}    ${n}=1
     # This keyword was copied and amended from JupyterLibrary resources - Notebook.Add And Run JupyterLab Code Cell.
 
+    ${add icon} =    Get JupyterLab Icon XPath Custom    add
+
     ${nb} =    Get WebElement    xpath://div${JLAB XP NB FRAG}\[${n}]
     ${nbid} =    Get Element Attribute    ${nb}    id
 
     ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
     ${tab-id} =    Get Element Attribute    ${active-nb-tab}    id
 
-    Click Element    xpath://div[@aria-labelledby="${tab-id}"]//div[@data-jp-item-name="insert"]
+    Click Element    xpath://div[@aria-labelledby="${tab-id}"]/div[1]//${add icon}
     Sleep    0.1s
     Click Element    xpath://div[@aria-labelledby="${tab-id}"]//div[contains(concat(' ',normalize-space(@class),' '),' jp-mod-selected ')]
     Set CodeMirror Value    \#${nbid}${JLAB CSS ACTIVE INPUT}    @{code}


### PR DESCRIPTION
After the fix #1899 this change isn't necessary so let's use the standard way how JupyterLibrary does this so we are in sync there.

Partially reverts the #1901.

CI:

![image](https://github.com/user-attachments/assets/aa4b3cc5-c5bf-4565-8c57-5f751d2aa636)
