### PR TITLE
Fix user permission tests

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -103,7 +103,8 @@ Wait For RHODS Dashboard To Load
     IF    "${expected_page}" == "${NONE}"
         Wait Until Page Contains Element    //div[@data-testid="home-page"]    timeout=${timeout}
     ELSE
-        Wait For Dashboard Page Title    ${expected_page}    timeout=${timeout}
+        Wait Until Keyword Succeeds    3x    5s
+        ...    Wait For Dashboard Page Title    ${expected_page}    timeout=${timeout}
     END
     IF    ${wait_for_cards} == ${TRUE}
         Wait Until Keyword Succeeds    3 times   5 seconds    Wait Until Cards Are Loaded


### PR DESCRIPTION
1. [Fix] the Jupyter app user custom permission settings
   * fixes the failing test caued by recent changes in the ODHDashboard
  resource which we use for the dashboard page loading
   * minor refactoring of the code and some comments added for easier
  understandability of the test steps
2. [Fix] improve the way we wait for the particular Dashboard page to load
For some dashboard pages, it takes time to load properly and they can
change the content during that time. E.g. there is a "Loading" text with
an animated gif provided until the actual page is present.
In case of accessing the Applications -> Enabled -> Jupyter app tile,
there may be also present a page title with "Loading..." text for a
brief amount of time. Such thing breaks our detection technique as then
our expected page title text doesn't match with what was present on the
page and fails with:
   ```
   BuiltIn.Should Be Equal:
   Loading... != Start a notebook server
   ```
   Adding a couple of retries should help to avoid such situation.

---

CI:
![image](https://github.com/user-attachments/assets/29296ff0-46f0-4e73-afcd-5637e533252d)

