### PR TITLE
[Fix] expected version in the 2024.2 images

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -487,6 +487,11 @@ Check Versions In JupyterLab
         # CUDA version is checked in GPU-specific test cases, we can skip it here.
         ELSE IF  "${libDetail}[0]" == "CUDA"
             CONTINUE
+        ELSE IF  "${libDetail}[0]" == "Nvidia-CUDA-CU12-Bundle"
+            ${status}  ${value} =  Verify Installed Library Version  nvidia-cuda-nvcc-cu12  ${libDetail}[1]
+            IF  '${status}' == 'FAIL'
+              ${return_status} =    Set Variable    FAIL
+            END
         ELSE IF  "${libDetail}[0]" == "Elyra"
             ${status}  ${value} =  Verify Installed Library Version  elyra-code-snippet-extension  ${libDetail}[1]
             IF  '${status}' == 'FAIL'

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
@@ -1,5 +1,6 @@
 *** Settings ***
-Documentation       Test Suite to verify installed library versions
+Documentation       Test Suite to verify installed library versions.
+...                 It tests only the latest versions of the images.
 
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Common.robot
@@ -17,9 +18,8 @@ Test Tags          JupyterHub
 *** Variables ***
 @{status_list}      # robocop: disable
 &{package_versions}      # robocop: disable
-${JupyterLab_Version}         v3.6
-${Notebook_Version}           v6.5
-${JupyterLab-git_Version}     v0.44
+${JupyterLab_Version}         v4.2
+${JupyterLab-git_Version}     v0.50
 
 
 *** Test Cases ***
@@ -42,20 +42,22 @@ Verify Libraries in Cuda Image
 Verify Libraries in SDS Image
     [Documentation]    Verifies libraries in Standard Data Science image
     [Tags]    Tier1
-    Verify List Of Libraries In Image    science-notebook    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}
+    Verify List Of Libraries In Image    science-notebook    JupyterLab ${JupyterLab_Version}
     ...    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in PyTorch Image
     [Documentation]    Verifies libraries in PyTorch image
     [Tags]    Tier1
     ...       ODS-215    ODS-216    ODS-217    ODS-218    ODS-466
-    Verify List Of Libraries In Image    pytorch    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}    JupyterLab-git ${JupyterLab-git_Version}
+    Verify List Of Libraries In Image
+    ...    pytorch    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Tensorflow Image
     [Documentation]    Verifies libraries in Tensorflow image
     [Tags]    Tier1
     ...       ODS-204    ODS-205    ODS-206    ODS-207  ODS-474
-    Verify List Of Libraries In Image    tensorflow    JupyterLab ${JupyterLab_Version}    Notebook ${Notebook_Version}    JupyterLab-git ${JupyterLab-git_Version}
+    Verify List Of Libraries In Image
+    ...    tensorflow    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify All Images And Spawner
     [Documentation]    Verifies that all images have the correct libraries with same versions
@@ -92,10 +94,6 @@ Verify Libraries In Base Image    # robocop: disable
 
 Load Spawner Page
     [Documentation]    Suite Setup, loads JH Spawner
-    ${version_check} =  Is RHODS Version Greater Or Equal Than  1.20.0
-    IF    ${version_check}==False
-       Wait Until All Builds Are Complete    namespace=${APPLICATIONS_NAMESPACE}    build_timeout=45m
-    END
     Begin Web Test
     Launch JupyterHub Spawner From Dashboard
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
@@ -59,13 +59,19 @@ Verify Libraries in Tensorflow Image
     Verify List Of Libraries In Image
     ...    tensorflow    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
+Verify Libraries in TrustyAI Image
+    [Documentation]    Verifies libraries in TrustyAI image
+    [Tags]    Tier1
+    Verify List Of Libraries In Image
+    ...    odh-trustyai-notebook    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
+
 Verify All Images And Spawner
     [Documentation]    Verifies that all images have the correct libraries with same versions
     [Tags]    Tier1
     ...       ODS-340    ODS-452    ODS-468
     List Should Not Contain Value    ${status_list}    FAIL
     ${length} =    Get Length    ${status_list}
-    Should Be Equal As Integers    ${length}    5
+    Should Be Equal As Integers    ${length}    6
     Log To Console    ${status_list}
 
 


### PR DESCRIPTION
Apart from the title, also extra exception for a newly introduced cuda bundle in tensorflow image and the test is extended also for the TrustyAI image.

Notebook python package is no longer dependency required by Jupyterlab package, so it is missing from the images now.

---

CI:
![image](https://github.com/user-attachments/assets/a1ed48c4-8456-4f2f-8b88-d90932e11ae0)

Note: the failures are expected due to the bug in the release, fix is on the way opendatahub-io/notebooks#742