### PR TITLE
[Fix] the test for the package versions on images

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -453,7 +453,6 @@ Verify Installed Labextension Version
 Check Versions In JupyterLab
     [Arguments]  ${libraries-to-check}
     ${return_status} =    Set Variable    PASS
-    @{packages} =    Create List    Python    Boto3    Kafka-Python    Matplotlib    Scikit-learn    Pandas    Scipy    Numpy
     FOR  ${libString}  IN  @{libraries-to-check}
         # libString = LibName vX.Y -> libDetail= [libName, X.Y]
         @{libDetail} =  Split String  ${libString}  ${SPACE}v
@@ -531,12 +530,18 @@ Check Versions In JupyterLab
               ${return_status} =    Set Variable    FAIL
             END
         END
+
+        # Now check that selected list of packages has same version among all the images.
+        @{packages} =    Create List    Python    Boto3    Kafka-Python    Scipy
+
         Continue For Loop If  "${libDetail}[0]" not in ${packages}
         IF    "${libDetail}[0]" not in ${package_versions}
         ...    Set To Dictionary    ${package_versions}    ${libDetail}[0]=${libDetail}[1]
         IF    "${package_versions["${libDetail}[0]"]}" != "${libDetail}[1]"
              ${return_status} =    Set Variable    FAIL
-             Run Keyword And Continue On Failure  FAIL  "${package_versions["${libDetail}[0]"]} != ${libDetail}[1]"
+             Run Keyword And Continue On Failure    Fail
+             ...    Version of this library in this image doesn't align with versions in other images
+             ...    "${package_versions["${libDetail}[0]"]} != ${libDetail}[1]"
         END
     END
     RETURN  ${return_status}


### PR DESCRIPTION
In the second part of this test, we have a selected list of packages so that we expect these packages to be same version amongst all the tested images. We have to reduce this list as now there are more packages that are expected not to be in the same version as was in past.

---

CI:

![image](https://github.com/user-attachments/assets/d14df1db-0898-401b-a1a0-228109108083)

The failed tests are expected and will be fixed once this fix opendatahub-io/notebooks#742 is propagated into the product.