### PR TITLE
Fix `pip install`s in GitHub Actions

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -25,11 +25,9 @@ jobs:
       -   name: Checkout repository
           uses: actions/checkout@v4
       -   name: Install dependencies
-          run: |
-                python -m pip install --upgrade pip
-                pip install robotframework-robocop
+          run: pipx install robotframework-robocop
       -   name: Run robocop
-          run: python -m robocop --verbose --reports sarif . || true
+          run: robocop --verbose --reports sarif . || true
       -   name: Upload SARIF file
           uses: github/codeql-action/upload-sarif@v2
           with:
@@ -39,28 +37,21 @@ jobs:
     name: python linters
     runs-on: ubuntu-latest
     env:
-      poetry_version: '1.7.1'
+      python_version: '3.11'
+      poetry_version: '1.8.3'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Cache poetry in ~/.local
-        uses: actions/cache@v4
-        id: cached-home-local
-        with:
-          path: ~/.local
-          key: "${{ runner.os }}-local-${{ env.poetry_version }}"
-
       - name: Install poetry
-        if: steps.cached-home-local.outputs.cache-hit != 'true'
-        run: pip install poetry==${{ env.poetry_version }}
+        run: pipx install poetry==${{ env.poetry_version }}
 
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '${{ env.python_version }}'
           cache: 'poetry'
 
       - name: Configure poetry
@@ -86,28 +77,19 @@ jobs:
     name: selftests
     runs-on: ubuntu-latest
     env:
-        poetry_version: '1.7.1'
+      python_version: '3.11'
+      poetry_version: '1.8.3'
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Cache poetry in ~/.local
-        uses: actions/cache@v4
-        id: cached-home-local
-        with:
-          path: ~/.local
-          key: "${{ runner.os }}-local-${{ env.poetry_version }}"
 
       - name: Install poetry
-        if: steps.cached-home-local.outputs.cache-hit != 'true'
-        run: pip install poetry==${{ env.poetry_version }}
+        run: pipx install poetry==${{ env.poetry_version }}
 
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
-          python-version: '3.11'
+          python-version: '${{ env.python_version }}'
           cache: 'poetry'
 
       - name: Configure poetry


### PR DESCRIPTION
The `pip install` command now requires passing `--break-system-packages`, otherwise it refuses the install.
To solve this, it's best to install with `pipx`.

In addition, this commit removes cache for `pip install poetry`, because the speedup is minimal and totally not worth the effort.

* https://github.com/actions/runner-images/issues/8615

```
Run python -m pip install --upgrade pip
error: externally-managed-environment

× This environment is externally managed
╰─> To install Python packages system-wide, try apt install
    python3-xyz, where xyz is the package you are trying to
    install.
    
    If you wish to install a non-Debian-packaged Python package,
    create a virtual environment using python3 -m venv path/to/venv.
    Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
    sure you have python3-full installed.
    
    If you wish to install a non-Debian packaged Python application,
    it may be easiest to use pipx install xyz, which will manage a
    virtual environment for you. Make sure you have pipx installed.
    
    See /usr/share/doc/python3.[1](https://github.com/red-hat-data-services/ods-ci/actions/runs/11324701737/job/31490057077#step:3:1)2/README.venv for more information.

note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
hint: See PEP [6](https://github.com/red-hat-data-services/ods-ci/actions/runs/11324701737/job/31490057077#step:3:7)68 for the detailed specification.
Error: Process completed with exit code 1.
```

from https://github.com/red-hat-data-services/ods-ci/actions/runs/11324701737/job/31490057077