### PR TITLE
[Fix] the project selector on the pipelines page

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -134,7 +134,7 @@ Verify Hello World Pipeline Elements
 Select Pipeline Project By Name
     [Documentation]    Select the project by project name
     [Arguments]    ${project_name}
-    ${project_menu}=    Set Variable    xpath://*[@data-testid="project-selector-dropdown"]
+    ${project_menu}=    Set Variable    xpath://*[@data-testid="project-selector-toggle"]
     Wait until Element is Visible    ${project_menu}   timeout=20
     Click Element    ${project_menu}
     Click Element    xpath://*[@role="menuitem" and string()="${project_name}"]


### PR DESCRIPTION
The exact id is used also in ModelServer.resource, but this is being updated by #1927 [here](https://github.com/red-hat-data-services/ods-ci/pull/1927/files#diff-4502503de47a41c7671478405135f6f5acabde2cd5da8c47aa4bcf39037fe47cR28) already, so not touching it in this PR.

In the future we should consider to deduplicate these two sometimes, but now I don't have enough cycles to do so.

CI:

![image](https://github.com/user-attachments/assets/fd5724a8-9475-49c0-96c0-dbf132e5d221)
