### PR TITLE
[Fix] the tests for the minimal image

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -93,6 +93,11 @@ Wait Until JupyterLab Code Cell Is Not Active
   ...    //div[contains(@class,"jp-Cell-inputArea")]/div[contains(@class,"jp-InputArea-prompt") and (.="[*]:")][1]
   ...    ${timeout}
 
+Scroll At The End Of The Notebook
+  [Documentation]  Scrolls at the end of the opened Notebook so that
+  ...    the button for addition of a new cell is visible.
+  Scroll Element Into View    //button[string()="Click to add a cell."]
+
 Select Empty JupyterLab Code Cell
   Click Element  //div[contains(@class,"jp-mod-noOutputs jp-Notebook-cell")]
 


### PR DESCRIPTION
* fixes wait for the true finish - let's give it some time to render properly
* updates the expected tensorflow version to be installed due to the pre-installed packages that are no longer compatible with the 2.7 version anymore - in our TensorFlow image we use 2.17 version, so I added 2.16 version here, which is compatible with the rest of the packages on the minimal image and also can be upgraded to a higher version to pass the followup check

---

CI:

![image](https://github.com/user-attachments/assets/1a14026c-2f2f-48cc-93db-e0d070eae6ed)
