### PR TITLE
[Fix] this fixes the negative test for the Anaconda app integration

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/AiApps/Anaconda.resource
+++ b/ods_ci/tests/Resources/Page/ODH/AiApps/Anaconda.resource
@@ -12,7 +12,7 @@ ${ANACONDA_DISPLAYED_NAME}=     Anaconda Commercial Edition
 ${ANACONDA_DISPLAYED_NAME_LATEST}=    Anaconda Professional
 ${ANACONDA_KEY_IN}=             Anaconda CE Key
 ${INVALID_KEY}=                 abcdef-invalidkey
-${ERROR_MSG}=                   error\nValidation failed\nError attempting to validate. Please check your entries.
+${ANACONDA_LICENSE_ERROR_MSG}=    Error attempting to validate. Please check your entries.
 ${VAL_SUCCESS_MSG}=             Validation result: 200
 ${TOKEN_VAL_SUCCESS_MSG}=       Success! Your token was validated and Conda has been configured.
 ${PKG_INSTALL_ERROR_MSG}=   Collecting package metadata (current_repodata.json): failed
@@ -102,8 +102,7 @@ Remove Anaconda Components For Validation
 Anaconda Activation Should Have Failed
     [Documentation]    Checks if the anaconda activation has failed
     Capture Page Screenshot    anaconda_failed_activation.png
-    ${text}=    Get Text    xpath://*[@class="pf-c-form__alert"]
-    Should Be Equal    ${text}    ${ERROR_MSG}
+    Page Should Contain    ${ANACONDA_LICENSE_ERROR_MSG}
 
 Verify Anaconda Element Present Based On Version
   [Documentation]   Checks Anaconda input element present based on version.


### PR DESCRIPTION
There are other tests failing for the anaconda since it looks like we have a wrong key in our repo. Will look into these later.

---

CI:

![image](https://github.com/user-attachments/assets/8eb10011-4491-43f7-adb9-bbb0e3b7a384)
