### PR TITLE
Fix `0410__ods_dashboard_projects` Suite Setup and Tags

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -363,18 +363,15 @@ Add And Run JupyterLab Code Cell 5 In Active Notebook
     # This keyword was copied and amended from JupyterLibrary resources - Notebook.Add And Run JupyterLab Code Cell.
 
     ${add icon} =    Get JupyterLab Icon XPath Custom    add
-
     ${nb} =    Get WebElement    xpath://div${JLAB XP NB FRAG}\[${n}]
     ${nbid} =    Get Element Attribute    ${nb}    id
-
     ${active-nb-tab} =    Get WebElement    xpath:${JL_TABBAR_SELECTED_XPATH}
     ${tab-id} =    Get Element Attribute    ${active-nb-tab}    id
-
-    Click Element    xpath://div[@aria-labelledby="${tab-id}"]/div[1]//${add icon}
+    Click Element    xpath://div[@aria-labelledby="${tab-id}"]//*[@data-jp-item-name="insert"]
     Sleep    0.1s
     Click Element    xpath://div[@aria-labelledby="${tab-id}"]//div[contains(concat(' ',normalize-space(@class),' '),' jp-mod-selected ')]
-    Set CodeMirror Value    \#${nbid}${JLAB CSS ACTIVE INPUT}    @{code}
-    Run Current JupyterLab Code Cell 5  ${tab-id}
+    Press Keys    None   @{code}
+    Click Element    xpath://div[@aria-labelledby="${tab-id}"]//*[@data-jp-item-name="run"]
     Click Element    xpath://div[@aria-labelledby="${tab-id}"]//div[contains(concat(' ',normalize-space(@class),' '),' jp-mod-selected ')]
 
 Add And Run JupyterLab Code Cell 6 In Active Notebook

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -103,6 +103,7 @@ Wait For RHODS Dashboard To Load
     IF    "${expected_page}" == "${NONE}"
         Wait Until Page Contains Element    //div[@data-testid="home-page"]    timeout=${timeout}
     ELSE
+        Menu.Navigate To Page   ${expected_page}
         Wait Until Keyword Succeeds    3x    5s
         ...    Wait For Dashboard Page Title    ${expected_page}    timeout=${timeout}
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -18,17 +18,14 @@ ${ACTIONS_BTN_XP}=    xpath=//div/button[@aria-label="Actions"]
 ${DELETE_ACTION_BTN_XP}=  xpath=//div/ul/li/button[text()="Delete project"]
 ${EDIT_ACTION_BTN_XP}=    xpath=//div/ul/li/button[text()="Edit project"]
 ${SPAWNER_LINK}=        xpath=//*[text()="Launch standalone notebook server"]
-${PROJECT_SEARCH_BAR}=    //div[@data-testid="dashboard-table-toolbar"]
-${PROJECT_FILTER_TYPE}=    ${PROJECT_SEARCH_BAR}//button[@data-testid="filter-dropdown-select"]
-${PROJECT_SEARCH_INPUT}=    ${PROJECT_SEARCH_BAR}//input[@aria-label="Search input"]
+${PROJECT_SEARCH_BAR}=    [data-testid="projects-table-toolbar"]
+${PROJECT_FILTER_TYPE}=    ${PROJECT_SEARCH_BAR} [data-testid="filter-toolbar-dropdown"]
+${PROJECT_SEARCH_INPUT}=    ${PROJECT_SEARCH_BAR} [data-testid="filter-toolbar-text-field"] input
 
 *** Keywords ***
 Open Data Science Projects Home Page
     [Documentation]    Open "Data Science Projects" page from the sidebar
-    Wait Until Page Contains    Data Science Projects
-    Click Link      Data Science Projects
     Wait For RHODS Dashboard To Load    wait_for_cards=${FALSE}    expected_page=Data Science Projects
-    Wait Until Page Contains    View your existing projects or create new projects.    timeout=30
     Maybe Wait For Dashboard Loading Spinner Page
 
 Is Data Science Projects Page Open
@@ -430,13 +427,12 @@ Remove Current Page Projects From All Projects
 Filter Projects By ${Type}
     [Documentation]    Search for projects where ${Type} includes "${text}"
     [Arguments]     ${text}
-    Open Data Science Projects Home Page
     ${searchbar_exists}=    Run Keyword And Return Status
-    ...    Page Should Contain Element    xpath:${PROJECT_SEARCH_BAR}
+    ...    Page Should Contain Element    css:${PROJECT_SEARCH_BAR}
     IF    ${searchbar_exists}
-        Click Element    xpath:${PROJECT_FILTER_TYPE}
-        Click Element    xpath:${PROJECT_SEARCH_BAR}//li[@data-testid="${Type}"]
-        Input Text    ${PROJECT_SEARCH_INPUT}    ${text}
+        Click Element    css:${PROJECT_FILTER_TYPE}
+        Click Element    css:${PROJECT_SEARCH_BAR} [id="${Type}"]
+        Input Text    css:${PROJECT_SEARCH_INPUT}    ${text}
     ELSE
         Log    No projects are listed
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -311,7 +311,7 @@ Start Workbench From Projects Home Page
         ${kebab_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@aria-label="Kebab toggle"]
         Wait Until Element Is Visible    ${kebab_button}    timeout=10s
         Click Element    ${kebab_button}
-        ${start_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@aria-label="Kebab toggle"]/following::div//span[text()="Start"]
+        ${start_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@data-testid="notebook-start-action"]
         Wait Until Element Is Visible    ${start_button}    timeout=10s
         Click Element    ${start_button}
     ELSE
@@ -345,7 +345,7 @@ Stop Workbench From Projects Home Page
         ${kebab_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@aria-label="Kebab toggle"]
         Wait Until Element Is Visible    ${kebab_button}    timeout=10s
         Click Element    ${kebab_button}
-        ${stop_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@aria-label="Kebab toggle"]/following::div//span[text()="Stop"]
+        ${stop_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@data-testid="notebook-stop-action"]
         Wait Until Element Is Visible    ${stop_button}    timeout=10s
         Click Element    ${stop_button}
         Handle Stop Workbench Confirmation Modal    press_cancel=${press_cancel}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -63,7 +63,7 @@ Create Workbench
     Input Text    ${WORKBENCH_NAME_INPUT_XP}    ${workbench_title}
     Input Text    ${WORKBENCH_DESCR_TXT_XP}    ${workbench_description}
     Run Keyword And Continue On Failure     Element Should Be Disabled    ${WORKBENCH_CREATE_BTN_2_XP}
-    Select Workbench Jupyter Image    image_name=${image_name}    version=${version}
+    Select Workbench Image    image_name=${image_name}    version=${version}
     IF    "${deployment_size}" != "${NONE}"    Select Workbench Container Size    size_name=${deployment_size}
     IF    "${gpus}" != "${NONE}"    Select Workbench Number Of GPUs    gpus=${gpus}
     IF    "${envs}" != "${NONE}"
@@ -197,7 +197,7 @@ Select An Existent PV
     Wait Until Page Contains Element    ${existing_pv_xpath}
     Click Element   ${existing_pv_xpath}
 
-Select Workbench Jupyter Image
+Select Workbench Image
     [Documentation]    Selects a Jupyter image in the workbench creation page
     [Arguments]     ${image_name}    ${version}=default
     IF  "${PRODUCT}" == "ODH"
@@ -206,7 +206,6 @@ Select Workbench Jupyter Image
             ${image_name}=    Set Variable    Jupyter Data Science
         END
     END
-
     Click Element    //a[@href="#notebook-image"]
     Wait Until Page Contains Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}
     Click Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}
@@ -221,15 +220,15 @@ Select Workbench Jupyter Image
             Fail    ${version} does not exist, use default/previous
         END
     END
-
     IF  "${version}"=="previous"
         # Let's reset the JupyterLibrary settings so that global variables for Jupyter 3 (default) are in place.
         Update Globals For JupyterLab 3 Custom
-    ELSE
+    # TODO: Create the missing Keyword "Update Globals For JupyterLab 4"
+    # ELSE
         # For Jupyter 4, we need to update global default variable values (images 2024b and newer)
         # This calls method from JupyterLibrary Version.resource module
         # https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/9e25fcb89a5f1a723c59e9b96706e4c638e0d9be/src/JupyterLibrary/clients/jupyterlab/Version.resource
-        Update Globals For JupyterLab 4
+        # Update Globals For JupyterLab 4
     END
 
 Verify Version Selection Dropdown

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -445,7 +445,7 @@ Edit Workbench
     # Also wait until the workbench name is populated in the text field - let's wait for DOM to finish
     Wait For Condition    return document.readyState == "complete"    timeout=5s
 
-Check Launched Workbench Is The Correct One
+Verify Workbench Image In Jupyter Lab
     [Documentation]    Checks if the launched workbench is the expected one
     [Arguments]     ${workbench_title}    ${image}    ${project_title}
     ${namespace}=    Get Openshift Namespace From Data Science Project   project_title=${project_title}

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -58,7 +58,6 @@ Verify Data Science Projects Page Is Accessible
     [Documentation]    Verifies "Data Science Projects" page is accessible from
     ...                the navigation menu on the left
     [Tags]    Smoke
-    ...       Tier1
     ...       ODS-1876
     Open Data Science Projects Home Page
     Page Should Contain Element     ${PROJECT_CREATE_BTN_XP}
@@ -67,7 +66,6 @@ Verify User Can Access Jupyter Launcher From DS Project Page
     [Documentation]    Verifies Data Science Projects home page contains
     ...                a link to Jupyter Spawner and it is working
     [Tags]    Smoke
-    ...       Tier1
     ...       ODS-1877
     Open Data Science Projects Home Page
     Page Should Contain Element     ${SPAWNER_LINK}
@@ -78,7 +76,6 @@ Verify Workbench Images Have Multiple Versions
     [Documentation]    Verifies that workbench images have an additional
     ...                dropdown which supports N/N-1 image versions.
     [Tags]    Sanity
-    ...       Tier1
     ...       ODS-2131
     Open Data Science Project Details Page    project_title=${PRJ_TITLE}    tab_id=workbenches
     Click Element    ${WORKBENCH_CREATE_BTN_XP}
@@ -90,14 +87,16 @@ Verify Workbench Images Have Multiple Versions
     END
 
 Verify User Cannot Create Project With Empty Fields
-    [Tags]    Sanity   ODS-1783    Tier1
+    [Tags]    Sanity
+    ...       ODS-1783
     [Documentation]    Verifies users is not allowed to create a project with Empty title
     Open Data Science Projects Home Page
     Create Project With Empty Title And Expect Error
     Close Generic Modal If Present
 
 Verify User Cannot Create Project Using Special Chars In Resource Name
-    [Tags]    Sanity    Tier1    ODS-1875
+    [Tags]    Sanity
+    ...       ODS-1875
     [Documentation]    Verifies users is not allowed to create a project with a custom resource name
     ...                containing special characters like "@" or "!"
     Open Data Science Projects Home Page
@@ -105,7 +104,8 @@ Verify User Cannot Create Project Using Special Chars In Resource Name
     Close Generic Modal If Present
 
 Verify User Can Create A Data Science Project
-    [Tags]    Smoke    ODS-1775    Tier1
+    [Tags]    Smoke
+    ...       ODS-1775
     [Documentation]    Verifies users can create a DS project
     Open Data Science Projects Home Page
     Log    message=DS Project creation covered by the Suite Setup
@@ -114,7 +114,8 @@ Verify User Can Create A Data Science Project
     ${ns_name}=    Check Corresponding Namespace Exists    project_title=${PRJ_TITLE}
 
 Verify User Can Create And Start A Workbench With Existent PV Storage
-    [Tags]    Smoke    ODS-1814    Tier1
+    [Tags]    Smoke
+    ...       ODS-1814
     [Documentation]    Verifies users can create a workbench and connect an existent PersistenVolume
     ${pv_name}=    Set Variable    ${PV_BASENAME}-existent
     Create PersistentVolume Storage    name=${pv_name}    description=${PV_DESCRIPTION}    project_title=${PRJ_TITLE}
@@ -131,7 +132,8 @@ Verify User Can Create And Start A Workbench With Existent PV Storage
     ...    project_title=${PRJ_TITLE}    pvc_title=${pv_name}
 
 Verify User Can Create A PV Storage
-    [Tags]    Sanity    Tier1    ODS-1819
+    [Tags]    Sanity
+    ...       ODS-1819
     [Documentation]    Verifies users can Create PersistentVolume Storage
     ...                THIS MUST BE UPDATED TO CHECK WORKBENCH GETS RESTARTED LIKE FOR ODS-1825.
     ...                MAIN GOAL OF THE TEST CASE IS COVERED BY ODS-1814
@@ -161,7 +163,9 @@ Verify User Can Create A PV Storage
     ...    Delete PVC In Project From CLI    pvc_title=${pv_name}    project_title=${PRJ_TITLE}
 
 Verify User Can Create And Start A Workbench Adding A New PV Storage
-    [Tags]    Sanity    ODS-1816    Tier1    ExcludeOnDisconnected
+    [Tags]    Sanity
+    ...       ODS-1816
+    ...       ExcludeOnDisconnected
     [Documentation]    Verifies users can create a workbench and connect a new PersistenVolume
     ...    We skip this test on Disconnected environment because we have a PVs predefined there hardcoded to 100Gi.
     ...    Since there is a size check in this test, it would fail unless some extra condition to be brought in here.
@@ -184,7 +188,7 @@ Verify User Can Create And Start A Workbench Adding A New PV Storage
     ...    project_title=${PRJ_TITLE}    pvc_title=${pv_name}
 
 Verify User Can Create A S3 Data Connection And Connect It To Workbenches
-    [Tags]    Sanity    Tier1
+    [Tags]    Sanity
     ...       ODS-1825    ODS-1972
     [Documentation]    Verifies users can add a Data connection to AWS S3
     Create Workbench    workbench_title=${WORKBENCH_TITLE}  workbench_description=${WORKBENCH_DESCRIPTION}
@@ -223,7 +227,8 @@ Verify User Can Create A S3 Data Connection And Connect It To Workbenches
     ...    Clean Project From Workbench Resources    workbench_title=${WORKBENCH_TITLE}    project_title=${PRJ_TITLE}
 
 Verify User Can Delete A Persistent Storage
-    [Tags]    Sanity    Tier1    ODS-1824
+    [Tags]    Sanity
+    ...       ODS-1824
     [Documentation]    Verifies users can delete a PersistenVolume
     ${pv_name}=    Set Variable    ${PV_BASENAME}-TO-DELETE
     ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
@@ -235,7 +240,8 @@ Verify User Can Delete A Persistent Storage
     Check Storage PersistentVolumeClaim Is Deleted    storage_name=${pv_name}    namespace=${ns_name}
 
 Verify User Can Delete A Data Connection
-    [Tags]    Sanity    Tier1    ODS-1826
+    [Tags]    Sanity
+    ...       ODS-1826
     [Documentation]    Verifies users can delete a Data connection
     ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
     Create S3 Data Connection    project_title=${PRJ_TITLE}    dc_name=${DC_3_S3_NAME}
@@ -248,7 +254,8 @@ Verify User Can Delete A Data Connection
     Check Data Connection Secret Is Deleted    dc_name=${DC_3_S3_NAME}    namespace=${ns_name}
 
 Verify user can create a workbench with an existing data connection
-    [Tags]  Sanity    Tier1  ODS-2176
+    [Tags]  Sanity
+    ...     ODS-2176
     [Documentation]  Verifies users can create a workbench with an existing data connection
     ${data_connection_name}=    Set Variable    aDataConnection
     Create S3 Data Connection  project_title=${PRJ_TITLE}
@@ -274,7 +281,8 @@ Verify user can create a workbench with an existing data connection
     ...                project_title=${PRJ_TITLE}
 
 Verify User Can Create A Workbench With Environment Variables
-    [Tags]    Sanity    Tier1    ODS-1864
+    [Tags]    Sanity
+    ...       ODS-1864
     [Documentation]    Verifies users can create a workbench and inject environment variables during creation
     ${pv_name}=    Set Variable    ${PV_BASENAME}-existent
     ${envs_var_secrets}=    Create Dictionary    secretA=TestVarA   secretB=TestVarB
@@ -295,7 +303,7 @@ Verify User Can Create A Workbench With Environment Variables
     [Teardown]    Clean Project From Workbench Resources    workbench_title=${WORKBENCH_4_TITLE}    project_title=${PRJ_TITLE}
 
 Verify User Can Create Environment Variables By Uploading YAML Secret/ConfigMap
-    [Tags]    Tier1    Sanity
+    [Tags]    Sanity
     ...       ODS-1883
     [Documentation]    Verify user can set environment varibles in their workbenches by
     ...                uploading a yaml Secret or Config Map file.
@@ -327,7 +335,8 @@ Verify User Can Create Environment Variables By Uploading YAML Secret/ConfigMap
     ...    project_title=${PRJ_TITLE}    pvc_title=${WORKBENCH_4_TITLE}-PV
 
 Verify User Can Log Out And Return To Project From Jupyter Notebook    # robocop: disable
-    [Tags]    Sanity    Tier1    ODS-1971
+    [Tags]    Sanity
+    ...       ODS-1971
     [Documentation]    Verifies user can log out and return to the project from Jupyter notebook.
     ...                Users have 2 options:
     ...                1. click "File" > "Log Out" to actually close the login session
@@ -362,7 +371,7 @@ Verify User Can Log Out And Return To Project From Jupyter Notebook    # robocop
     ...    project_title=${PRJ_TITLE}
 
 Verify Event Log Is Accessible While Starting A Workbench
-    [Tags]    Tier1    Sanity
+    [Tags]    Sanity
     ...       ODS-1970
     [Documentation]    Verify user can access event log while starting a workbench
     Create Workbench    workbench_title=${WORKBENCH_6_TITLE}  workbench_description=${WORKBENCH_6_DESCRIPTION}
@@ -385,7 +394,8 @@ Verify Event Log Is Accessible While Starting A Workbench
     ...    project_title=${PRJ_TITLE}
 
 Verify User Can Cancel Workbench Start From Event Log
-    [Tags]    Sanity    Tier1    ODS-1975
+    [Tags]    Sanity
+    ...       ODS-1975
     [Documentation]    Verify user can cancel workbench start from event log
 
     Create Workbench    workbench_title=${WORKBENCH_TITLE}  workbench_description=${WORKBENCH_DESCRIPTION}
@@ -410,7 +420,7 @@ Verify User Can Cancel Workbench Start From Event Log
     [Teardown]  Clean Project From Workbench Resources  workbench_title=${WORKBENCH_TITLE}  project_title=${PRJ_TITLE}
 
 Verify Error Is Reported When Workbench Fails To Start    # robocop: disable
-    [Tags]    Tier1    Sanity
+    [Tags]    Sanity
     ...       ODS-1973
     [Documentation]    Verify UI informs users about workbenches failed to start.
     ...                At the moment the test is considering only the scenario where
@@ -502,7 +512,7 @@ Verify Users Can Start, Stop And Launch A Workbench From DS Projects Home Page
     ...    SeleniumLibrary.Close Browser
 
 Verify User Can Delete A Data Science Project
-    [Tags]    Smoke    Tier1
+    [Tags]    Smoke
     ...       ODS-1784
     [Documentation]    Verifies users can delete a Data Science project
     Open Data Science Projects Home Page
@@ -511,7 +521,8 @@ Verify User Can Delete A Data Science Project
     # check workbenches and resources get deleted too
 
 Verify User Can Access Only Its Owned Projects
-    [Tags]    Sanity    Tier1    ODS-1868
+    [Tags]    Sanity
+    ...       ODS-1868
     [Documentation]    Verifies each user can access only they owned projects. Except for
     ...                cluster and dedicated admins which should be able to fetch all the DS Projects
     [Setup]    Run Keywords

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -576,7 +576,7 @@ Project Suite Setup
     Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     Launch Data Science Project Main Page
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
-    ...    resource_name=${PRJ_RESOURCE_NAME}    existing_project=${TRUE}
+    ...    existing_project=${TRUE}
 
 Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DS Projects. It Deletes

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -442,7 +442,7 @@ Verify Error Is Reported When Workbench Fails To Start    # robocop: disable
     Wait Until Project Is Open    project_title=${PRJ_TITLE}
 
 Verify Users Can Start, Stop, Launch And Delete A Workbench
-    [Tags]    Smoke    Tier1
+    [Tags]    Smoke
     ...       ODS-1813    ODS-1815   ODS-1817
     [Documentation]    Verifies users can start, stop, launch and delete a running workbench from project details page
     [Setup]        Run Keywords
@@ -463,7 +463,8 @@ Verify Users Can Start, Stop, Launch And Delete A Workbench
     Launch And Access Workbench    workbench_title=${WORKBENCH_TITLE}
     ...    username=${TEST_USER_3.USERNAME}     password=${TEST_USER_3.PASSWORD}
     ...    auth_type=${TEST_USER_3.AUTH_TYPE}
-    Check Launched Workbench Is The Correct One     workbench_title=${WORKBENCH_TITLE}
+    # TODO: Following Keyword should rather be called within "JupyterHub" Suite
+    Verify Workbench Image In Jupyter Lab     workbench_title=${WORKBENCH_TITLE}
     ...    image=${NB_IMAGE}    project_title=${PRJ_TITLE}
     SeleniumLibrary.Switch Window    title=${ODH_DASHBOARD_PROJECT_NAME}
     Wait Until Project Is Open    project_title=${PRJ_TITLE}
@@ -477,9 +478,8 @@ Verify Users Can Start, Stop, Launch And Delete A Workbench
     ...    SeleniumLibrary.Close Browser
 
 Verify Users Can Start, Stop And Launch A Workbench From DS Projects Home Page
-    [Tags]     Smoke    Sanity    Tier1
+    [Tags]     Sanity
     ...        ODS-1818    ODS-1823
-    ...        ProductBug    RHOAIENG-5084
     [Documentation]    Verifies users can start, stop, launch and delete a running workbench from project details page
     [Setup]        Run Keywords
     ...    Launch Data Science Project Main Page
@@ -491,20 +491,16 @@ Verify Users Can Start, Stop And Launch A Workbench From DS Projects Home Page
     ...        press_cancel=${FALSE}    envs=${NONE}
     ...    AND
     ...    Wait Until Workbench Is Started     workbench_title=${WORKBENCH_TITLE}
-    # ${ns_name}=    Get Openshift Namespace From Data Science Project   project_title=${PRJ_TITLE}
-    # ${_}    ${workbench_cr_name}=    Get Openshift Notebook CR From Workbench    workbench_title=${WORKBENCH_TITLE}
-    # ...    namespace=${ns_name}
     Open Data Science Projects Home Page
     Wait Until Project Is Listed    project_title=${PRJ_TITLE}
     Stop Workbench From Projects Home Page     workbench_title=${WORKBENCH_TITLE}   project_title=${PRJ_TITLE}
-    # ...    workbench_cr_name=${workbench_cr_name}    namespace=${ns_name}
     Workbench Launch Link Should Be Disabled    workbench_title=${WORKBENCH_TITLE}  project_title=${PRJ_TITLE}
     Start Workbench From Projects Home Page     workbench_title=${WORKBENCH_TITLE}   project_title=${PRJ_TITLE}
-    # ...    workbench_cr_name=${workbench_cr_name}    namespace=${ns_name}
     Launch And Access Workbench From Projects Home Page    workbench_title=${WORKBENCH_TITLE}
     ...    project_title=${PRJ_TITLE}    username=${TEST_USER_3.USERNAME}
     ...    password=${TEST_USER_3.PASSWORD}    auth_type=${TEST_USER_3.AUTH_TYPE}
-    Check Launched Workbench Is The Correct One     workbench_title=${WORKBENCH_TITLE}
+    # TODO: Following Keyword should rather be called within "JupyterHub" Suite
+    Verify Workbench Image In Jupyter Lab     workbench_title=${WORKBENCH_TITLE}
     ...    image=${NB_IMAGE}    project_title=${PRJ_TITLE}
     [Teardown]    Run Keywords
     ...    Clean Project From Workbench Resources    workbench_title=${WORKBENCH_TITLE}    project_title=${PRJ_TITLE}

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -576,7 +576,7 @@ Project Suite Setup
     Delete List Of Projects Via CLI   ocp_projects=${PROJECTS_TO_DELETE}
     Launch Data Science Project Main Page
     Create Data Science Project    title=${PRJ_TITLE}    description=${PRJ_DESCRIPTION}
-    ...    resource_name=${PRJ_RESOURCE_NAME}
+    ...    resource_name=${PRJ_RESOURCE_NAME}    existing_project=${TRUE}
 
 Project Suite Teardown
     [Documentation]    Suite teardown steps after testing DS Projects. It Deletes

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -85,8 +85,8 @@ Verify Workbench Images Have Multiple Versions
     Wait Until Page Contains Element    ${WORKBENCH_NAME_INPUT_XP}
     Run Keyword And Continue On Failure     Element Should Be Disabled    ${WORKBENCH_CREATE_BTN_2_XP}
     FOR    ${img}    IN    @{IMAGE_LIST}
-        Select Workbench Jupyter Image    image_name=${img}    version=previous
-        Select Workbench Jupyter Image    image_name=${img}    version=default
+        Select Workbench Image    image_name=${img}    version=previous
+        Select Workbench Image    image_name=${img}    version=default
     END
 
 Verify User Cannot Create Project With Empty Fields


### PR DESCRIPTION
Fix Tests, Keywords and Tags for Suite `0410__ods_dashboard_projects`, including:

- Update Tags in `0410__ods_dashboard_projects.robot`
- Fix Dashboard suite 410 setup to reuse existing DS project
- Fix `Projects.resource` elements locators
- Fix KW `Filter Projects By ${Type}`
- Update `Wait For RHODS Dashboard To Load` KW to navigate to Menu page
- Fix KW `Select Workbench Jupyter Image`
- Rename KW to `Verify Workbench Image In Jupyter Lab`
- Fix KW `Add And Run JupyterLab Code Cell 5 In Active Notebook`
- Fix KW `Start Workbench From Projects Home Page`
- Fx KW `Stop Workbench From Projects Home Page`

![image](https://github.com/user-attachments/assets/90a3a39b-cc03-4a97-81bb-6a0db1700af9)


