### PR TITLE
Only upload the openshift CA cert if the cluster is self-managed in MR test

### DIFF
--- a/ods_ci/tests/Tests/1300__model_registry/1301_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1301_model_registry_model_serving.robot
@@ -74,7 +74,8 @@ Verify Model Registry Integration With Secured-DB
     Download Python Client Dependencies    ${MR_PYTHON_CLIENT_FILES}    ${MR_PYTHON_CLIENT_WHL_VERSION}
     Upload Python Client Files In The Workbench    ${MR_PYTHON_CLIENT_FILES}
     Upload Certificate To Jupyter Notebook    ${CERTS_DIRECTORY}/domain.crt
-    Upload Certificate To Jupyter Notebook    openshift_ca.crt
+    ${self_managed} =    Is RHODS Self-Managed
+    IF  ${self_managed}    Upload Certificate To Jupyter Notebook    openshift_ca.crt
     Jupyter Notebook Can Query Model Registry     ${JUPYTER_NOTEBOOK}
     SeleniumLibrary.Switch Window    ${handle}
     Open Model Registry Dashboard Page


### PR DESCRIPTION
We fetch the openshift CA cert only if the cluster is self managed, but then try to upload it regardless of cluster type (L#113).
Use the same check on the upload step to avoid trying to upload a non existing file.