### PR TITLE
Add AutomationBug tag to drift tests

### DIFF
--- a/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
+++ b/ods_ci/tests/Tests/1200__ai_explainability/1203__trustyai_drift_metrics.robot
@@ -20,7 +20,7 @@ ${LOG_OUTPUT_FILE}                    drift_test.txt
 *** Test Cases ***
 Run Drift Metrics Tests
     [Documentation]    Verifies that the Drift metrics are available for a deployed model
-    [Tags]    RHOAIENG-8163     Smoke
+    [Tags]    RHOAIENG-8163     Smoke     AutomationBug
     Run Drift Pytest Framework
 
 


### PR DESCRIPTION
This test is not stable in ods-ci, so we need to add the AutomationBug tag until we stabilize it.