### PR TITLE
Increase timeout when running iris-pipeline in releases/2.13.0

### DIFF
--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-kfp.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-kfp.robot
@@ -56,7 +56,7 @@ Verify Users Can Create And Run A Pipeline That Uses Custom Python Packages To I
     ...    project=${PROJECT_NAME}
     ...    python_file=iris_pipeline.py
     ...    method_name=my_pipeline
-    ...    status_check_timeout=180
+    ...    status_check_timeout=300
     ...    pipeline_params=${emtpy_dict}
     [Teardown]    Projects.Delete Project Via CLI By Display Name    ${PROJECT_NAME}
 


### PR DESCRIPTION
Backports existing timeout increase in master

Signed-off-by: Jorge Garcia Oncins <jgarciao@redhat.com>