### PR TITLE
Updating Python Client to 0.2.8a1

### DIFF
--- a/ods_ci/tests/Resources/CLI/ModelRegistry/MRMS_TEST_RUNNER.ipynb
+++ b/ods_ci/tests/Resources/CLI/ModelRegistry/MRMS_TEST_RUNNER.ipynb
@@ -9,7 +9,7 @@
    },
    "outputs": [],
    "source": [
-    "!pip install --no-index --find-links . model_registry-0.2.6a1-py3-none-any.whl"
+    "!pip install --no-index --find-links . model_registry-0.2.8a1-py3-none-any.whl"
    ]
   },
   {

--- a/ods_ci/tests/Tests/1300__model_registry/1301_model_registry_model_serving.robot
+++ b/ods_ci/tests/Tests/1300__model_registry/1301_model_registry_model_serving.robot
@@ -24,7 +24,7 @@ ${EXAMPLE_ISTIO_ENV}=                ${MODELREGISTRY_BASE_FOLDER}/samples/istio/
 ${ISTIO_ENV}=                        ${MODELREGISTRY_BASE_FOLDER}/samples/istio/components/istio.env
 ${SAMPLE_ONNX_MODEL}=                ${MODELREGISTRY_BASE_FOLDER}/mnist.onnx
 ${MR_PYTHON_CLIENT_FILES}=           ${MODELREGISTRY_BASE_FOLDER}/Python_Dependencies
-${MR_PYTHON_CLIENT_WHL_VERSION}=     model_registry==0.2.6a1
+${MR_PYTHON_CLIENT_WHL_VERSION}=     model_registry==0.2.8a1
 ${SERVICE_MESH_MEMBER}=              ${MODELREGISTRY_BASE_FOLDER}/serviceMeshMember_template.yaml
 ${ENABLE_REST_API}=                  ${MODELREGISTRY_BASE_FOLDER}/enable_rest_api_route.yaml
 ${IPYNB_UPDATE_SCRIPT}=              ${MODELREGISTRY_BASE_FOLDER}/updateIPYNB.py


### PR DESCRIPTION
This PR upgrades the e2e test to use the latest python client version 0.2.8a1