### PR TITLE
RHOAIENG-14857 Update the test to implement data-testids

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettingsRuntimes.resource
@@ -46,13 +46,13 @@ Serving Runtime Template Should Be Listed
     [Arguments]    ${displayed_name}    ${serving_platform}
     Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
-    ...    //td[@data-label="Name"]//span[text()="${displayed_name}"]
+    ...    //*[@data-testid="serving-runtime ovms-ods-ci"]
     ...    timeout=10s
     Run Keyword And Continue On Failure
     ...    Wait Until Page Contains Element
-    ...    xpath=//td[@data-label="Name"]//span[text()="${displayed_name}"]/ancestor::td/following-sibling::td[@data-label="Serving platforms supported"]    # robocop: disable
+    ...    //*[@data-testid="serving-runtime ovms-ods-ci"]//ancestor::*[@data-testid="serving-runtime-platform-label"]    # robocop: disable
     ${actual_platform_labels_str}=    Get Text
-    ...    xpath=//td[@data-label="Name"]//span[text()="${displayed_name}"]/ancestor::td/following-sibling::td[@data-label="Serving platforms supported"]    # robocop: disable
+    ...    //*[@data-testid="serving-runtime ovms-ods-ci"]//ancestor::*[@data-testid="serving-runtime-platform-label"]    # robocop: disable
     ${actual_platform_labels}=    Split To Lines    ${actual_platform_labels_str}
     IF    "${serving_platform}" == "both"
         Run Keyword And Continue On Failure    Length Should Be    ${actual_platform_labels}    ${2}


### PR DESCRIPTION
This fixes UI failures for ODS-2276. The test is updated to use the data-testids

Tested on : devops/job/rhoai-test-flow/961/

![image](https://github.com/user-attachments/assets/58c17ec0-9e44-4fca-8532-2aab0c886ea8)
