### PR TITLE
Remove generation validation from Pipelines Test

### DIFF
--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
@@ -63,10 +63,6 @@ Create PipelineServer Using Custom DSPA
     ...    ${assert_install}=${TRUE}    ${configure_pip_index}=${TRUE}
 
     Run And Verify Command     oc apply -f "${DSPA_PATH}/${dspa_file}" -n ${namespace}
-    IF    ${assert_install}==True
-        ${generation_value}=    Run And Verify Command    oc get datasciencepipelinesapplications -n ${namespace} -o json | jq '.items[0].metadata.generation'    # robocop: off=line-too-long
-        Should Be True    ${generation_value} == 2    DataSciencePipelinesApplication created
-    END
 
     IF  ${configure_pip_index}   Create Pipelines ConfigMap With Custom Pip Index Url And Trusted Host  ${namespace}
 


### PR DESCRIPTION
Remove generation validation from Pipelines Test

That step is not needed

Tested with: rhoai-test-flow/967