### PR TITLE
Adds a new tests to check the notebook controllers deployments

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -107,16 +107,19 @@ Get Events And Pod Logs
     RETURN    ${events}    ${podlogs}
 
 Wait For Pods To Be Ready
+    [Documentation]    Waits until the pods with given label selector in the given namespace have `condition=ready`.
+    ...                This keyword can also check for the expected number of the pod replicas using `${exp_replicas}`
+    ...                argument.
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=600s    ${exp_replicas}=${NONE}
     Wait Until Keyword Succeeds    ${timeout}    3s
     ...    Check If Pod Exists    namespace=${namespace}    label_selector=${label_selector}
     ...    status_only=${FALSE}
     ${rc}    ${out}=    Run And Return Rc And Output
-    ...    oc wait --for=condition=ready pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
+    ...    oc wait --for=condition=ready=true pod -l ${label_selector} -n ${namespace} --timeout=${timeout}
     IF    ${rc} != ${0}
         ${events}    ${podlogs}=    Get Events And Pod Logs    ${namespace}    ${label_selector}
 
-        Fail    msg=Pod is not ready by timeout
+        Fail    msg=Pod defined by selector "${label_selector}" in "${namespace}" namespace is not ready by timeout.
     END
     IF    "${exp_replicas}" != "${NONE}"
         @{replicas}=    Oc Get    kind=Pod    namespace=${namespace}
@@ -125,14 +128,22 @@ Wait For Pods To Be Ready
     END
 
 Wait For Deployment Replica To Be Ready
-  [Documentation]   Wait for Deployment of ${label_selector} in ${namespace} to have the Replica-Set Ready
-  [Arguments]     ${namespace}     ${label_selector}    ${timeout}=600s
-  Log To Console    Waiting for Deployment with label "${label_selector}" in Namespace "${namespace}", to have desired Replica-Set
-  ${output} =    Wait Until Keyword Succeeds    ${timeout}   3s    Run And Verify Command
-  ...    oc wait -n ${namespace} --for condition\=ready pod -l "${label_selector}" --timeout\=${timeout}
-  ...    print_to_log=${FALSE}
-  Run And Verify Command
-  ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas \=\= .readyReplicas'
+    [Documentation]   Wait for Deployment of ${label_selector} in ${namespace} to have the Replica-Set Ready
+    [Arguments]     ${label_selector}    ${namespace}     ${timeout}=600s    ${exp_replicas}=${NONE}
+    Log To Console
+    ...    Waiting for Deployment with label "${label_selector}" in Namespace "${namespace}", to have desired Replica-Set ready  #robocop: disable:line-too-long
+    IF    "${exp_replicas}" != "${NONE}"
+        # Check the expected number of pods replica in Deployment if desired
+        Run And Verify Command
+        ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.items[].spec | .replicas == ${exp_replicas}'  #robocop: disable:line-too-long
+        ...    print_to_log=${FALSE}
+    END
+    # Wait until pods for the replica are ready
+    Wait For Pods To Be Ready    ${label_selector}    ${namespace}    ${timeout}    ${exp_replicas}
+    # Now the status should match the number of expected replicas with ready replicas
+    Run And Verify Command
+    ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.items[].status | .replicas == .readyReplicas'  #robocop: disable:line-too-long
+    ...    print_to_log=${FALSE}
 
 Wait For Pods To Succeed
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}

--- a/ods_ci/tests/Tests/0500__ide/0500__ide_deployment_cr_checks.robot
+++ b/ods_ci/tests/Tests/0500__ide/0500__ide_deployment_cr_checks.robot
@@ -1,0 +1,94 @@
+*** Settings ***
+Documentation    Test Suite that checks the deployment, pods and containers of the notebook controllers for workbench
+...              component.
+Resource         ../../Resources/OCP.resource
+Resource         ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+Test Tags        IDE    Smoke
+Suite Setup      Suite Setup
+Suite Teardown   Suite Teardown
+
+
+*** Variables ***
+${KF_NTB_CTRL_LABEL_SELECTOR} =    app=notebook-controller
+${KF_NTB_POD_REPLICAS} =    1
+${KF_NTB_CONTAINERS} =    1
+${KF_NTB_CONTAINER_LIMITS_CPU} =    500m
+${KF_NTB_CONTAINER_LIMITS_MEMORY} =    4Gi
+${KF_NTB_CONTAINER_REQUESTS_CPU} =    500m
+${KF_NTB_CONTAINER_REQUESTS_MEMORY} =    256Mi
+${ODH_NTB_CTRL_LABEL_SELECTOR} =    app=odh-notebook-controller
+${ODH_NTB_POD_REPLICAS} =    1
+${ODH_NTB_CONTAINERS} =    1
+${ODH_NTB_CONTAINER_LIMITS_CPU} =    500m
+${ODH_NTB_CONTAINER_LIMITS_MEMORY} =    4Gi
+${ODH_NTB_CONTAINER_REQUESTS_CPU} =    500m
+${ODH_NTB_CONTAINER_REQUESTS_MEMORY} =    256Mi
+
+
+*** Test Cases ***
+Verify Odh Notebook Controller Deployment Pods Replicas
+    [Documentation]    Check the Deployment pods replicas for ODH ntb controller and compares it with the expected
+    ...                number.
+    # The timeout is low as all resources should be up and running by this time already.
+    Wait For Deployment Replica To Be Ready
+    ...    label_selector=${ODH_NTB_CTRL_LABEL_SELECTOR}
+    ...    namespace=${APPLICATIONS_NAMESPACE}
+    ...    timeout=10s
+    ...    exp_replicas=${ODH_NTB_POD_REPLICAS}
+
+Verify Odh Notebook Controller Containers
+    [Documentation]    Check the containers of the ODH ntb controller and their resources and compares it with the
+    ...                expected number.
+    Run And Verify Command
+    ...    oc get pods -n ${APPLICATIONS_NAMESPACE} -l ${ODH_NTB_CTRL_LABEL_SELECTOR} -ojson | jq -e '.items[].spec.containers | length == ${ODH_NTB_CONTAINERS}'  #robocop: disable:line-too-long
+
+    ${limits} =    Create Dictionary
+    ...    cpu=${ODH_NTB_CONTAINER_LIMITS_CPU}    memory=${ODH_NTB_CONTAINER_LIMITS_MEMORY}
+    ${requests} =    Create Dictionary
+    ...    cpu=${ODH_NTB_CONTAINER_REQUESTS_CPU}    memory=${ODH_NTB_CONTAINER_REQUESTS_MEMORY}
+    Container Hardware Resources Should Match Expected
+    ...    container_name=manager
+    ...    pod_label_selector=${ODH_NTB_CTRL_LABEL_SELECTOR}
+    ...    namespace=${APPLICATIONS_NAMESPACE}
+    ...    exp_limits=${limits}
+    ...    exp_requests=${requests}
+
+Verify Kf Notebook Controller Deployment Pods Replicas
+    [Documentation]    Check the Deployment pods replicas for Kf ntb controller and compares it with expected number
+    # The timeout is low as all resources should be up and running by this time already.
+    Wait For Deployment Replica To Be Ready
+    ...    label_selector=${KF_NTB_CTRL_LABEL_SELECTOR}
+    ...    namespace=${APPLICATIONS_NAMESPACE}
+    ...    timeout=10s
+    ...    exp_replicas=${KF_NTB_POD_REPLICAS}
+
+Verify Kf Notebook Controller Containers
+    [Documentation]    Check the containers of the Kf ntb controller and their resources and compares it with the
+    ...                expected number.
+    Run And Verify Command
+    ...    oc get pods -n ${APPLICATIONS_NAMESPACE} -l ${KF_NTB_CTRL_LABEL_SELECTOR} -ojson | jq -e '.items[].spec.containers | length == ${KF_NTB_CONTAINERS}'  #robocop: disable:line-too-long
+
+    ${limits} =    Create Dictionary
+    ...    cpu=${KF_NTB_CONTAINER_LIMITS_CPU}    memory=${KF_NTB_CONTAINER_LIMITS_MEMORY}
+    ${requests} =    Create Dictionary
+    ...    cpu=${KF_NTB_CONTAINER_REQUESTS_CPU}    memory=${KF_NTB_CONTAINER_REQUESTS_MEMORY}
+    Container Hardware Resources Should Match Expected
+    ...    container_name=manager
+    ...    pod_label_selector=${KF_NTB_CTRL_LABEL_SELECTOR}
+    ...    namespace=${APPLICATIONS_NAMESPACE}
+    ...    exp_limits=${limits}
+    ...    exp_requests=${requests}
+
+
+*** Keywords ***
+Suite Setup
+    [Documentation]    Suite setup
+    RHOSi Setup
+    ${workbenches} =    Is Component Enabled    workbenches    ${DSC_NAME}
+    IF    "${workbenches}" != "true"
+        Fail    The workbench component isn't enabled!
+    END
+
+Suite Teardown
+    [Documentation]    Suite teardown
+    RHOSi Teardown


### PR DESCRIPTION
This creates a dedicated test for the notebook controller deployments, their replica sets and containers. Just a basic metadata are checked.

Should resolve the:
* https://issues.redhat.com/browse/RHOAIENG-13756
* https://issues.redhat.com/browse/RHOAIENG-13757

---

CI: job/devops/job/rhoai-test-flow/985/

![image](https://github.com/user-attachments/assets/05aea728-1401-48b5-a2ea-5f2de106c26b)

Since I touched also the code that is used during the product installation on the cluster, I ran the job linked above together with the RHOAI 2.15 installation and it passed just fine.

Also, the execution above was run without the [latest change](https://github.com/red-hat-data-services/ods-ci/compare/0fcc02897ea78829399de19c0752f4b661b80a7a..f0b9279aa5eae0f7192b14c3f8192342c4050a62) - I checked locally that no `true` is printed in the log anymore.