### PR TITLE
fix: minor fix in deployment command to find replicas

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -142,7 +142,7 @@ Wait For Deployment Replica To Be Ready
     Wait For Pods To Be Ready    ${label_selector}    ${namespace}    ${timeout}    ${exp_replicas}
     # Now the status should match the number of expected replicas with ready replicas
     Run And Verify Command
-    ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.items[].status | .replicas == .readyReplicas'  #robocop: disable:line-too-long
+    ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas == .readyReplicas'  #robocop: disable:line-too-long
     ...    print_to_log=${FALSE}
 
 Wait For Pods To Succeed


### PR DESCRIPTION
The previous command was causing an error when checking ODH nightlies deployment

Before:

12:23:42  Waiting for all RHODS resources to be up and running
12:23:42  Waiting for Deployment with label "name=opendatahub-operator" in Namespace "opendatahub-operators", to have desired Replica-Set ready
12:23:43  | FAIL |
12:23:43  '4 == 0' should be true.


After:

13:56:37  Waiting for all RHODS resources to be up and running
13:56:37  Waiting for Deployment with label "name=opendatahub-operator" in Namespace "opendatahub-operators", to have desired Replica-Set ready
13:56:37  Verified opendatahub-operators