### PR TITLE
fix: add statement to approve the installplan when a new operator is being installed

### DIFF
--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation       Collcetion of keywords to manage ISV operators via CLI
 Resource            ../../RHOSi.resource
+Resource            ../../OCP.resource
 Library             OperatingSystem
 
 
@@ -8,6 +9,7 @@ Library             OperatingSystem
 ${FILES_RESOURCES_DIRPATH}=    tests/Resources/Files
 ${SUBSCRIPTION_YAML_TEMPLATE_FILEPATH}=    ${FILES_RESOURCES_DIRPATH}/isv-operator-subscription.yaml
 ${OPERATORGROUP_YAML_TEMPLATE_FILEPATH}=   ${FILES_RESOURCES_DIRPATH}/isv-operator-group.yaml
+${IS_PRESENT}=                           0
 
 
 *** Keywords ***
@@ -32,7 +34,17 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<CATALOG_SOURCE>/${catalog_source_name}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<CS_NAMESPACE>/${cs_namespace}/g" ${operator_sub_filepath}    # robocop: disable
     Oc Apply    kind=Subscription    src=${operator_sub_filepath}
-
+    Wait Until Keyword Succeeds    1 min    0 sec
+    ...    Is Resource Present    Subscription    ${subscription_name}     ${namespace}    ${IS_PRESENT}
+    Sleep    30s
+    ${installplan_name}=     Get Resource Attribute      ${namespace}
+    ...      Subscription       ${subscription_name}        .status.installPlanRef.name
+    ${installplan_approval}=     Get Resource Attribute      ${namespace}
+    ...      InstallPlan       ${installplan_name}        .spec.approval
+    IF    "${installplan_approval}" == "Manual"
+          ${return_code}    ${out}=     Run And Return Rc And Output   oc patch installplan ${installplan_name} -n ${namespace} --type='json' -p '[{"op": "replace", "path": "/spec/approved", "value": true}]'  #robocop:disable
+          Should Be Equal As Integers    ${return_code}     0   msg=Error while approving installplan
+    END
 
 Create Operator Group
     [Documentation]    Creates the Operator Group object which might be needed by an operator.

--- a/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
@@ -28,7 +28,7 @@ ${IS_NOT_PRESENT}                           1
 Validate DSC and DSCI Created With Errors When Service Mesh Operator Is Not Installed    #robocop:disable
     [Documentation]    The purpose of this Test Case is to validate that DSC and DSCI are created
     ...                without Service Mesh Operator installed, but with errors
-    [Tags]    Operator    Tier3    ODS-2584    RHOAIENG-2514    ExcludeOnDisconnected
+    [Tags]    Operator    Tier3    ODS-2584    RHOAIENG-2514
 
     Remove DSC And DSCI Resources
     Uninstall Service Mesh Operator CLI
@@ -50,7 +50,7 @@ Validate DSC and DSCI Created With Errors When Service Mesh Operator Is Not Inst
 Validate DSC and DSCI Created With Errors When Serverless Operator Is Not Installed    #robocop:disable
     [Documentation]    The purpose of this Test Case is to validate that DSC and DSCI are created
     ...                without Serverless Operator installed, but with errors
-    [Tags]    Operator    Tier3    ODS-2586    RHOAIENG-2512    ExcludeOnDisconnected
+    [Tags]    Operator    Tier3    ODS-2586    RHOAIENG-2512
 
     Remove DSC And DSCI Resources
     Uninstall Serverless Operator CLI
@@ -70,7 +70,7 @@ Validate DSC and DSCI Created With Errors When Serverless Operator Is Not Instal
 Validate DSC and DSCI Created With Errors When Service Mesh And Serverless Operators Are Not Installed   #robocop:disable
     [Documentation]    The purpose of this Test Case is to validate that DSC and DSCI are created
     ...                without dependant operators ((servicemesh, serverless) installed, but with errors
-    [Tags]    Operator    Tier3    ODS-2527     RHOAIENG-2518     ExcludeOnDisconnected
+    [Tags]    Operator    Tier3    ODS-2527     RHOAIENG-2518
 
     Remove DSC And DSCI Resources
     Uninstall Service Mesh Operator CLI
@@ -96,7 +96,7 @@ Validate DSC and DSCI Created With No Errors When Kserve Serving Is Unmanaged An
     [Documentation]    The purpose of this Test Case is to validate that DSC and DSCI are created
     ...                without dependant operators ((servicemesh, serverless) installed and with no errors
     ...                because the Kserve component serving is unmanaged
-    [Tags]    Operator    Tier3     RHOAIENG-3472      ExcludeOnDisconnected
+    [Tags]    Operator    Tier3     RHOAIENG-3472
 
     Remove DSC And DSCI Resources
     Uninstall Service Mesh Operator CLI

--- a/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
@@ -29,7 +29,7 @@ ${MSSG_REGEX}                               denied the request: only one service
 *** Test Cases ***
 Validate Service Mesh Control Plane Already Created
     [Documentation]    This Test Case validates that only one ServiceMeshControlPlane is allowed to be installed per project/namespace
-    [Tags]      RHOAIENG-2517      ExcludeOnDisconnected
+    [Tags]      RHOAIENG-2517
     Fetch Image Url And Update Channel
     Check Whether DSC Exists And Save Component Statuses
     Fetch Cluster Type By Domain


### PR DESCRIPTION
Related ticket: https://issues.redhat.com/browse/RHOAIENG-14362

Also enabling again the disruptive tests that were disabled in disconnected environments. This PR fixes that


Checks:

- Selfmanaged cluster OK
- Managed cluster OK
- Disconnected cluster OK