### PR TITLE
Fix Pipelines upgrade test (backport to 2.14.0)

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesKfp.py
+++ b/ods_ci/libs/DataSciencePipelinesKfp.py
@@ -305,6 +305,22 @@ class DataSciencePipelinesKfp:
         return run_status  # pyright: ignore [reportPossiblyUnboundVariable]
 
     @keyword
+    def get_last_run_by_pipeline_name(self, pipeline_name: str | None = None, namespace: str | None = None):
+        """
+        Gets run_id of the last run created for pipeline_name
+        :param pipeline_name:
+        :param namespace:
+        :return:
+            run_id
+        """
+        pipeline_id = self.client.get_pipeline_id(pipeline_name)
+        pipeline_version_id = self.get_last_pipeline_version(pipeline_id)
+        all_runs = self.get_all_runs(namespace=namespace, pipeline_version_id=pipeline_version_id)
+        if len(all_runs) > 0:
+            return all_runs[-1].run_id
+        return None
+
+    @keyword
     def delete_pipeline(self, pipeline_id):
         """Deletes a pipeline"""
         print(f"Deleting pipeline {pipeline_id}")

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
@@ -163,7 +163,6 @@ Wait Until Pipeline Server Is Deployed
             ...    Verify DSPv1 Pipeline Server Deployments    namespace=${namespace}
     END
 
-
 Wait Until Pipeline Server Is Deleted
     [Documentation]    Waits until all pipeline server pods are deleted
     [Arguments]    ${namespace}
@@ -186,7 +185,6 @@ Create Secret With Pipelines Object Storage Information
     [Arguments]    ${namespace}    ${object_storage_access_key}    ${object_storage_secret_key}
     Run And Verify Command    oc create secret generic dashboard-dspa-secret -n ${namespace} --from-literal=AWS_ACCESS_KEY_ID=${object_storage_access_key} --from-literal=AWS_SECRET_ACCESS_KEY=${object_storage_secret_key}    # robocop: off=line-too-long
     Run And Verify Command    oc label secret dashboard-dspa-secret -n ${namespace} opendatahub.io/dashboard=true
-
 
 Import Pipeline And Create Run
     [Documentation]
@@ -214,6 +212,15 @@ Import Pipeline And Create Run
     ...   params=${pipeline_run_params}
 
     RETURN    ${pipeline_id}    ${pipeline_version_id}    ${pipeline_run_id}    ${experiment_id}
+
+Get Last Run By Pipeline Name
+    [Documentation]  Returns ${pipeline_run_id} of the last run for the last version of ${pipeline_name}
+    [Arguments]    ${namespace}    ${username}    ${password}    ${pipeline_name}
+
+    DataSciencePipelinesKfp.Setup Client    user=${username}    pwd=${password}    project=${namespace}
+    ${pipeline_run_id}=    DataSciencePipelinesKfp.Get Last Run By Pipeline Name    pipeline_name=${pipeline_name}
+
+    RETURN    ${pipeline_run_id}
 
 Verify Run Status
     [Documentation]  Verifies pipeline run status matches ${pipeline_run_expected_status}

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -5,7 +5,7 @@ Resource         ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/
 
 
 *** Variables ***
-${PROJECT}=    dsp-upgrade-testing
+${PROJECT}=    upg-dsp
 ${PIPELINE_LONGRUNNING_FILEPATH}=    tests/Resources/Files/pipeline-samples/v2/cache-disabled/pip_index_url/take_nap_compiled.yaml  # robocop: disable:line-too-long
 
 
@@ -24,9 +24,13 @@ Verify Resources After Upgrade
 
     DataSciencePipelinesBackend.Wait Until Pipeline Server Is Deployed    namespace=${PROJECT}
 
+    ${take_nap_run_id}=    DataSciencePipelinesBackend.Get Last Run By Pipeline Name
+    ...    namespace=${PROJECT}    username=${TEST_USER.USERNAME}    password=${TEST_USER.PASSWORD}
+    ...    pipeline_name=take-nap
+
     Verify Run Status
     ...    namespace=${PROJECT}    username=${TEST_USER.USERNAME}    password=${TEST_USER.PASSWORD}
-    ...    pipeline_run_id=${DSP_LONGRUNNING_PIPELINE_RUN_ID}    pipeline_run_expected_status=RUNNING
+    ...    pipeline_run_id=${take_nap_run_id}    pipeline_run_expected_status=RUNNING
 
     Projects.Delete Project Via CLI By Display Name    ${PROJECT}
 
@@ -60,5 +64,3 @@ Start Long Running Pipeline
     ...    pipeline_package_path=${PIPELINE_LONGRUNNING_FILEPATH}
     ...    pipeline_run_name=take-nap-run
     ...    pipeline_run_params=${pipeline_run_params}
-
-    Set Global Variable  ${DSP_LONGRUNNING_PIPELINE_RUN_ID}    ${pipeline_run_id}


### PR DESCRIPTION
Fixes [RHOAIENG-14204](https://issues.redhat.com/browse/RHOAIENG-14204): Instead of storing pipeline_run_id in a global variable, obtain it using kfp-client

Tested in https://github.com/red-hat-data-services/ods-ci/pull/1971