### PR TITLE
Add workbench runtimes for RHOAI 2.15 & script to download them from running workbench

### DIFF
--- a/ods_ci/tests/Resources/Files/workbench-runtimes/datascience-ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/datascience-ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "Datascience with Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "datascience"
+    ],
+    "display_name": "Datascience with Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:d894c46832742b3d5772ccd478d2293644e344b1be41e0a967cc6cf58212182d",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/pytorch-ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/pytorch-ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "pytorch"
+    ],
+    "display_name": "Pytorch with CUDA and Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:7d1b065f100666fe46f64a2e8aae888cb41a38b5482bb9b9343b14db05c2a14a",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/rocm-pytorch-ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/rocm-pytorch-ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "rocm-pytorch"
+    ],
+    "display_name": "Pytorch with ROCm and Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:a1cfb7bfcff3b2aae2b20b17da83b6683d632403f674a51af6efdfe809a6fc10",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/rocm-tensorflow-ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/rocm-tensorflow-ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "rocm-tensorflow"
+    ],
+    "display_name": "TensorFlow with ROCm and Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:ccc9b6c9d3f107988dc26deae607b792f3edbad03da53ee3a4698198f3aaab96",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/tensorflow-ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/tensorflow-ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "tensorflow"
+    ],
+    "display_name": "TensorFlow with CUDA and Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:94f39c7e2ab06a104b63d5d0759afa24123a2d173dce3b77a85bbcb1c3c76c58",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/ubi9-py311.json
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/ubi9-py311.json
@@ -1,0 +1,12 @@
+{
+  "display_name": "Python 3.11 (UBI9)",
+  "metadata": {
+    "tags": [
+      "minimal"
+    ],
+    "display_name": "Python 3.11 (UBI9)",
+    "image_name": "quay.io/modh/runtime-images@sha256:34a0aee985ff776d2004db9ef9d3e237366c1e6f1dc317901cac99bc81964809",
+    "pull_policy": "IfNotPresent"
+  },
+  "schema_name": "runtime-image"
+}

--- a/ods_ci/tests/Resources/Files/workbench-runtimes/update-runtimes.sh
+++ b/ods_ci/tests/Resources/Files/workbench-runtimes/update-runtimes.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#######################################################################################
+# Follow these steps to update the workbench runtimes in this folder                  #
+#  - Open a browser and connect to RHOAI Dashboard                                    #
+#  - Create a data science project my-project                                         #
+#  - Start a Workbench using the Standard Data Science Image. Name should be wb-sds   #
+#  - Open a terminal:                                                                 #
+#    - oc login ...                                                                   #
+#    - ./update-runtimes.sh my-project                                                #
+#  - The workbench runtimes will be downloaded, overwritting existing ones            #
+#######################################################################################
+
+RUNTIME_IMAGES_PATH=/opt/app-root/share/jupyter/metadata/runtime-images/
+
+if [ $# -ne 1 ]; then
+    echo "Wrong number of parameters: missing project name" >&2
+    script_name=$(basename "$0")
+    echo "Usage: $script_name my-project" >&2
+    exit 2
+fi
+export MY_PROJECT=${1}
+
+if ! oc get project "$MY_PROJECT" > /dev/null 2>&1
+then
+    echo "Project $MY_PROJECT not found or not connected to cluster"
+    exit 2
+fi
+oc project $MY_PROJECT
+
+pod_name=$(oc get pods --selector notebook-name=wb-sds -n "$MY_PROJECT"  --no-headers=true | awk '{print $1}')
+
+if [ -z "$pod_name" ]; then
+  echo "Could not find a running pod with --selector notebook-name=wb-sds in namespace $MY_PROJECT"
+  exit 2
+fi
+
+echo "Updating runtimes (getting info from pod $pod_name) ..."
+oc rsync "$pod_name":$RUNTIME_IMAGES_PATH  .    -c wb-sds


### PR DESCRIPTION
We have some pipeline tests that use the workbench runtimes (e.g. the pytorch-romc runtime). 

In order to help finding the latest workbench images shipped for each version of RHOAI, we would like to add them here in ods-ci, with a script to obtain them semi-automatically.

In a follow-up PR we'll update the images used in our pipeline samples.