### PR TITLE
Modify available OCP versions logic

### DIFF
--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -147,7 +147,7 @@ class OpenshiftClusterManager:
 
                 version_cmd = f'ocm list versions {chan_grp} | grep -w "{re.escape(version)}*"'
                 versions = execute_command(version_cmd)
-                if versions is not None:
+                if versions:
                     version = [ver for ver in versions.split("\n") if ver][-1]
                 self.openshift_version = version
             else:


### PR DESCRIPTION
Check if available OCP versions is neither None nor empty str.
The existing logic fails for old OCP versions (e.g. 4.12-latest), from a [failing job](https://opendatascience-jenkins-csb-rhods.apps.ocp-c1.prod.psi.redhat.com/job/devops/job/rhoai-test-flow/1118/console) with Versions status logging:
`Versions length before failure: 0 and its type is: <class 'str'>`