### PR TITLE
[2.8.z][fix] Expected string of the final results

### DIFF
--- a/ods_ci/tests/Tests/500__jupyterhub/test-minimal-image.robot
+++ b/ods_ci/tests/Tests/500__jupyterhub/test-minimal-image.robot
@@ -78,7 +78,7 @@ Can Launch Python3 Smoke Test Notebook
     ${output} =   Get Text    (//div[contains(@class,"jp-OutputArea-output")])[last()]
     Should Not Match    ${output}    ERROR*
     Should Be Equal As Strings    ${output}
-    ...    [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, 0.9116818405511811]
+    ...    [0.40201256371442895, 0.8875, 0.846875, 0.875, 0.896875, np.float64(0.9116818405511811)]
 
 Verify Tensorflow Can Be Installed In The Minimal Python Image Via Pip
     [Documentation]    Verify Tensorflow Can Be Installed In The Minimal Python image via pip


### PR DESCRIPTION
After some of the package update, there is now preserved numpy float64 data format in the printed results which in earler version weren't.

(cherry picked from commit 31f5703a9ad22b22eee25a83a1a882a6eb1a6663)

This is a backport of the #1729.