### PR TITLE
Update DW tests to run with both Python 3.11 and Python 3.9

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -13,7 +13,6 @@ ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distr
 ${RAY_IMAGE_3.11}                        quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
 ${RAY_IMAGE_3.9}                         quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
 ${FMS_HF_TUNING_IMAGE}                   quay.io/modh/fms-hf-tuning@sha256:73bcd66500b8637a9db1339f64c3217212ef74700a22a790f78e9a1f26b8b71a
-${NOTEBOOK_IMAGE}                        quay.io/modh/odh-generic-data-science-notebook@sha256:16fc91984a9baf7765a6362493906a2c726b9906031711e2e55d686d296e6b3a
 ${NOTEBOOK_USER_NAME}                    ${TEST_USER_3.USERNAME}
 ${NOTEBOOK_USER_PASSWORD}                ${TEST_USER_3.PASSWORD}
 ${KFTO_CORE_BINARY_NAME}                 kfto
@@ -189,7 +188,7 @@ Generate User Token
 
 Run DistributedWorkloads ODH Test
     [Documentation]    Run DistributedWorkloads ODH Test
-    [Arguments]    ${TEST_NAME}    ${DW_RAY_IMAGE}
+    [Arguments]    ${TEST_NAME}    ${DW_RAY_IMAGE}    ${NOTEBOOK_IMAGE}
     Log To Console    "Running test: ${TEST_NAME}"
     ${result} =    Run Process    ./${ODH_BINARY_NAME} -test.run ${TEST_NAME}
     ...    shell=true

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
@@ -6,70 +6,72 @@ Library           OperatingSystem
 Library           Process
 Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 Resource          ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+Test Tags         DistributedWorkloads3.11
 
 
 *** Variables ***
-${RAY_CUDA_IMAGE}                    quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
-${RAY_TORCH_CUDA_IMAGE}              quay.io/rhoai/ray@sha256:5077f9bb230dfa88f34089fecdfcdaa8abc6964716a8a8325c7f9dcdf11bbbb3
-${RAY_ROCM_IMAGE}                    quay.io/modh/ray@sha256:f8b4f2b1c954187753c1f5254f7bb6a4286cec5a4f1b43def7ef4e009f2d28cb
+${RAY_CUDA_IMAGE_3.11}               quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
+${RAY_TORCH_CUDA_IMAGE_3.11}         quay.io/rhoai/ray@sha256:5077f9bb230dfa88f34089fecdfcdaa8abc6964716a8a8325c7f9dcdf11bbbb3
+${RAY_ROCM_IMAGE_3.11}               quay.io/modh/ray@sha256:f8b4f2b1c954187753c1f5254f7bb6a4286cec5a4f1b43def7ef4e009f2d28cb
+${NOTEBOOK_IMAGE_3.11}               quay.io/modh/odh-generic-data-science-notebook@sha256:7c1a4ca213b71d342a2d1366171304e469da06d5f15710fab5dd3ce013aa1b73
 
 
 *** Test Cases ***
-Run TestKueueRayCpu ODH test
+Run TestKueueRayCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayCpu
     [Tags]  ODS-2514
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistRayCpu    ${RAY_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistRayCpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestKueueRayCudaGpu ODH test
+Run TestKueueRayCudaGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayCudaGpu
     [Tags]  Resources-GPU    NVIDIA-GPUs
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistRayCudaGpu    ${RAY_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistRayCudaGpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestKueueRayROCmGpu ODH test
+Run TestKueueRayROCmGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayROCmGpu
     [Tags]  Resources-GPU    AMD-GPUs    ROCm
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistRayROCmGpu    ${RAY_ROCM_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistRayROCmGpu    ${RAY_ROCM_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestRayTuneHPOCpu ODH test
+Run TestRayTuneHPOCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoCpu
     [Tags]  RHOAIENG-10004
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoCpu    ${RAY_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoCpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestRayTuneHPOGpu ODH test
+Run TestRayTuneHPOGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoGpu
     [Tags]  Resources-GPU    NVIDIA-GPUs
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestKueueCustomRayCpu ODH test
+Run TestKueueCustomRayCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayCpu
     [Tags]  RHOAIENG-10013
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageCpu    ${RAY_TORCH_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageCpu    ${RAY_TORCH_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
-Run TestKueueCustomRayGpu ODH test
+Run TestKueueCustomRayGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayGpu
     [Tags]  RHOAIENG-10013
     ...     Resources-GPU    NVIDIA-GPUs
@@ -77,4 +79,4 @@ Run TestKueueCustomRayGpu ODH test
     ...     DistributedWorkloads
     ...     Training
     ...     WorkloadsOrchestration
-    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageGpu    ${RAY_TORCH_CUDA_IMAGE}
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageGpu    ${RAY_TORCH_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
@@ -1,0 +1,98 @@
+*** Settings ***
+Documentation     Distributed Workloads Integration tests - https://github.com/opendatahub-io/distributed-workloads/tree/main/tests/odh
+Suite Setup       Prepare DistributedWorkloads Integration Test Suite for 3.9
+Suite Teardown    Teardown DistributedWorkloads Integration Test Suite
+Library           OperatingSystem
+Library           Process
+Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+Resource          ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+Test Tags         DistributedWorkloads3.9
+
+
+*** Variables ***
+# This is the last and latest distributed workloads release assest which contains test binaries compatible with python 3.9
+${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS_3.9}   https://github.com/opendatahub-io/distributed-workloads/releases/download/v2.14.0-09-24-2024_adjustments_1
+${RAY_CUDA_IMAGE_3.9}                         quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
+${RAY_TORCH_CUDA_IMAGE_3.9}                   quay.io/rhoai/ray@sha256:158b481b8e9110008d60ac9fb8d156eadd71cb057ac30382e62e3a231ceb39c0
+${NOTEBOOK_IMAGE_3.9}                         quay.io/modh/odh-generic-data-science-notebook@sha256:b1066204611b4bcfa6172c3115650a8e8393089d5606458fa0d8c53633d2ce17
+
+
+*** Test Cases ***
+Run TestKueueRayCpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestKueueRayCpu
+    [Tags]  ODS-2514
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayCpu    ${RAY_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+Run TestKueueRayGpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestKueueRayGpu
+    [Tags]  Resources-GPU    NVIDIA-GPUs
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayGpu    ${RAY_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+Run TestRayTuneHPOCpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestMnistRayTuneHpoCpu
+    [Tags]  RHOAIENG-10004
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoCpu    ${RAY_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+Run TestRayTuneHPOGpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestMnistRayTuneHpoGpu
+    [Tags]  Resources-GPU    NVIDIA-GPUs
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+Run TestKueueCustomRayCpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestKueueCustomRayCpu
+    [Tags]  RHOAIENG-10013
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageCpu    ${RAY_TORCH_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+Run TestKueueCustomRayGpu ODH test with Python 3.9
+    [Documentation]    Run Go ODH test: TestKueueCustomRayGpu
+    [Tags]  RHOAIENG-10013
+    ...     Resources-GPU    NVIDIA-GPUs
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     WorkloadsOrchestration
+    Run DistributedWorkloads ODH Test    TestMnistCustomRayImageGpu    ${RAY_TORCH_CUDA_IMAGE_3.9}    ${NOTEBOOK_IMAGE_3.9}
+
+
+*** Keywords ***
+Prepare DistributedWorkloads Integration Test Suite for 3.9
+    [Documentation]    Prepare DistributedWorkloads Integration Test Suite for 3.9
+    # The bug fix for self signed certificate error is not available in codeflare-sdk version "v0.21.1" which is the
+    # last supported release for python 3.9 and hence skipping tests for self managed installtion
+    Skip If RHODS Is Self-Managed
+    Log To Console    "Downloading compiled test binary ${ODH_BINARY_NAME}"
+
+    ${result} =    Run Process    curl --location --silent --output ${ODH_BINARY_NAME} ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS_3.9}/${ODH_BINARY_NAME} && chmod +x ${ODH_BINARY_NAME}
+    ...    shell=true
+    ...    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL    Unable to retrieve odh compiled binary
+    END
+    Create Directory    %{WORKSPACE}/distributed-workloads-odh-logs
+    Log To Console    "Retrieving user tokens"
+    ${common_user_token} =    Generate User Token    ${NOTEBOOK_USER_NAME}    ${NOTEBOOK_USER_PASSWORD}
+    Set Suite Variable    ${NOTEBOOK_USER_TOKEN}   ${common_user_token}
+    Log To Console    "Log back as cluster admin"
+    Login To OCP Using API    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
+    RHOSi Setup


### PR DESCRIPTION
Close [RHOAIENG-15416](https://issues.redhat.com/browse/RHOAIENG-15416)

- Added separate `test-run-distributed-workloads-tests_3.9.robot` test file to run tests with python 3.9

- Update existing test file `test-run-distributed-workloads-tests.robot` to run tests with python 3.11