### PR TITLE
Use correct MNIST dataset location for DW tests

### DIFF
--- a/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
+++ b/ods_ci/tests/Tests/650__distributed_workloads/test-run-codeflare-tests.robot
@@ -91,6 +91,7 @@ Run Codeflare E2E Test
     ...    env:CODEFLARE_TEST_TIMEOUT_MEDIUM=10m
     ...    env:CODEFLARE_TEST_TIMEOUT_LONG=20m
     ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/codeflare-e2e-logs
+    ...    env:MNIST_DATASET_URL=https://ossci-datasets.s3.amazonaws.com/mnist/
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
         FAIL    ${TEST_NAME} failed


### PR DESCRIPTION
Use correct MNIST dataset URL for Distributed Workoad operator tests.
Existing dataset URL has invalid certificate. Since then we moved in latest `codeflare-common` to this new URL, however 2.8 is using old `codeflare-common`. By setting the dataset URL we can override value from `codeflare-common`.