### PR TITLE
add ProductBug tag

### DIFF
--- a/ods_ci/tests/Tests/100__deploy/120__upgrades/122__post_ugrade.robot
+++ b/ods_ci/tests/Tests/100__deploy/120__upgrades/122__post_ugrade.robot
@@ -102,7 +102,8 @@ Reset Culler Timeout
 
 Resetting Pod Toleration Via UI
     [Documentation]    Sets a Pod toleration via the admin UI
-    [Tags]  Upgrade
+    ...                Product Bug: RHOAIENG-12826
+    [Tags]  Upgrade ProductBug
     [Setup]    Begin Web Test
     Menu.Navigate To Page    Settings    Cluster settings
     Wait Until Page Contains    Notebook pod tolerations


### PR DESCRIPTION
this is a known bug for 2.8, adding a `ProductBug` tag and the Jira number