### PR TITLE
[Fix] the modal window checks when stopping a workbench

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -348,7 +348,8 @@ Stop Workbench From Projects Home Page
         ${stop_button}=    Set Variable    xpath=//a[@data-testid="notebook-route-link" and text()="${workbench_title}"]/ancestor::tr[@data-testid="project-notebooks-table-row"]//button[@data-testid="notebook-stop-action"]
         Wait Until Element Is Visible    ${stop_button}    timeout=10s
         Click Element    ${stop_button}
-        Handle Stop Workbench Confirmation Modal    press_cancel=${press_cancel}
+        Handle Stop Workbench Confirmation Modal    workbench_title=${workbench_title}
+        ...    press_cancel=${press_cancel}
     ELSE
         Fail     msg=Cannot stop ${workbench_title} workbench because it is neither starting nor running.
     END

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -406,7 +406,8 @@ Stop Workbench
     IF    ${is_started} == ${TRUE} or ${is_starting} == ${TRUE}
         Click Button    xpath=//div[@data-testid="table-row-title"]//*[text()="${workbench_title}"]/ancestor::tr//button[@data-testid="notebook-stop-action"]
         Wait Until Generic Modal Appears
-        Handle Stop Workbench Confirmation Modal    press_cancel=${press_cancel}
+        Handle Stop Workbench Confirmation Modal    workbench_title=${workbench_title}
+        ...    press_cancel=${press_cancel}
         ...    from_running=${from_running}
     ELSE
         Fail   msg=Cannot stop workbench ${workbench_title} because it is not neither running or starting...
@@ -414,13 +415,15 @@ Stop Workbench
 
 Handle Stop Workbench Confirmation Modal
     [Documentation]    Handles modal to stop workbench
-    [Arguments]    ${press_cancel}=${FALSE}    ${from_running}=${TRUE}
+    [Arguments]    ${workbench_title}    ${press_cancel}=${FALSE}    ${from_running}=${TRUE}
     Run Keyword And Continue On Failure    Page Should Contain    Stop workbench?
     IF    ${from_running} == ${TRUE}
         Run Keyword And Continue On Failure
-        ...    Page Should Contain    Are you sure you want to stop the workbench? Any changes without saving will be erased.
-        Run Keyword And Continue On Failure    Page Should Contain    To save changes, access your
-        Run Keyword And Continue On Failure    Page Should Contain Element    xpath=//a[.="workbench"]
+        ...    Page Should Contain    Any unsaved changes to the ${workbench_title} workbench will be lost.
+        Run Keyword And Continue On Failure
+        ...    Page Should Contain    To save changes, open the workbench.
+        Run Keyword And Continue On Failure
+        ...    Page Should Contain Element    xpath=//a[.="open the workbench"]
     END
     Run Keyword And Continue On Failure    Page Should Contain Element    xpath=//input[@id="dont-show-again"]
     Run Keyword And Continue On Failure    Click Element    xpath=//input[@id="dont-show-again"]


### PR DESCRIPTION
The content of the modal window in DS project page changed when stopping a workbench. This change should align it with the actual content in RHOAI 2.16.

---

CI:
![image](https://github.com/user-attachments/assets/4ee68aee-0bf6-4693-bdac-d576195e629d)
