### PR TITLE
RHOAIENG-15629 - DSC And DSCI Release.Version Attribute ODS-CI test c…

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0108__operator.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0108__operator.robot
@@ -29,7 +29,7 @@ Verify That DSC And DSCI Release.Version Attribute matches the value in the subs
     ...       Operator
     ...       RHOAIENG-8082
     ${rc}    ${csv_name}=    Run And Return Rc And Output
-    ...    oc get subscription -n ${OPERATOR_NAMESPACE} -l ${OPERATOR_SUBSCRIPTION_LABEL} -ojson | jq '.items[0].status.currentCSV' | tr -d '"'
+    ...    oc get subscription -n ${OPERATOR_NAMESPACE} -l ${OPERATOR_SUBSCRIPTION_LABEL} -ojson | jq '.items[0].status.installedCSV' | tr -d '"'
 
     Should Be Equal As Integers    ${rc}    ${0}    ${rc}
 


### PR DESCRIPTION
…hecks version based on currentCSV instead of installedCSV

**JIRA:** [RHOAIENG-15629](https://issues.redhat.com/browse/RHOAIENG-15629)

Test run: <JENKINS>/job/rhoai/job/2.15/job/selfmanaged/job/cli/job/aws/job/rhoai-tier3/5/