### PR TITLE
RHAOIENG-15527: enhance ODS-1877 to use data-testid 

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
@@ -17,7 +17,7 @@ ${PROJECT_CREATE_BTN_XP}=     xpath=//button[text()="Create data science project
 ${ACTIONS_BTN_XP}=    xpath=//div/button[@aria-label="Actions"]
 ${DELETE_ACTION_BTN_XP}=  xpath=//div/ul/li/button[text()="Delete project"]
 ${EDIT_ACTION_BTN_XP}=    xpath=//div/ul/li/button[text()="Edit project"]
-${SPAWNER_LINK}=        xpath=//*[text()="Launch standalone notebook server"]
+${SPAWNER_LINK}=        //*[@data-testid="launch-standalone-notebook-server"]
 ${PROJECT_SEARCH_BAR}=    [data-testid="projects-table-toolbar"]
 ${PROJECT_FILTER_TYPE}=    ${PROJECT_SEARCH_BAR} [data-testid="filter-toolbar-dropdown"]
 ${PROJECT_SEARCH_INPUT}=    ${PROJECT_SEARCH_BAR} [data-testid="filter-toolbar-text-field"] input


### PR DESCRIPTION
This fixes an automation bug for ODS-1877 which is currently failing in RHOAI Smoke tests. Test is updated to use the data-testid
![image](https://github.com/user-attachments/assets/6e9985ee-06d7-40df-a1e5-75a2a3d98c8f)
