### PR TITLE
Fix Test `Check Application Switcher Links` for OCM

### DIFF
--- a/ods_ci/tests/Resources/Page/HybridCloudConsole/OCM.robot
+++ b/ods_ci/tests/Resources/Page/HybridCloudConsole/OCM.robot
@@ -7,10 +7,10 @@ Library         SeleniumLibrary
 
 *** Keywords ***
 Wait Until OCM Cluster Page Is Loaded
-    [Documentation]     wait until the OCM page loads for ${cluster_name}
-    [Arguments]    ${cluster_name}
+    [Documentation]     wait until the OCM page includes ClusterID ${cluster_id}
+    [Arguments]    ${cluster_id}
     Wait OCM Splash Page
-    Element Should Contain    //div[@class="pf-v5-l-split__item"]/h1    ${cluster_name}
+    Wait Until Page Contains Element    xpath=//*[@data-testid="clusterID" and text()="${cluster_id}"]    timeout=30s
 
 Login To OCM
     [Documentation]    Login to the OpenShift Cluster Manager


### PR DESCRIPTION
Fix the test in 0401__ods_dashboard.robot: `Check Application Switcher Links To Openshift Cluster Manager`
that stopped working on Managed Cluster (when verifying the cluster in OCM).

![image](https://github.com/user-attachments/assets/fa3c619d-acd4-438e-9776-968db93f4a04)
