### PR TITLE
Update Codeflare SDK release tag for 2.16 release

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -5,7 +5,8 @@ Library          Process
 
 
 *** Variables ***
-${CODEFLARE-SDK-RELEASE-TAG}             v0.22.0
+${CODEFLARE-SDK-RELEASE-TAG}             v0.23.1
+${CODEFLARE-SDK-RELEASE-TAG-3.9}         adjustments-release-0.21.1
 ${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/latest/download
@@ -25,6 +26,7 @@ ${AWS_STORAGE_BUCKET}                    ${S3.BUCKET_5.NAME}
 ${AWS_ACCESS_KEY_ID}                     ${S3.AWS_ACCESS_KEY_ID}
 ${AWS_SECRET_ACCESS_KEY}                 ${S3.AWS_SECRET_ACCESS_KEY}
 ${AWS_STORAGE_BUCKET_MNIST_DIR}          mnist-datasets
+${KUBECONFIGPATH}                        %{HOME}/.kube/config
 
 
 *** Keywords ***
@@ -43,11 +45,14 @@ Prepare Codeflare-SDK Test Setup
 
     Clone Git Repository    ${CODEFLARE-SDK_REPO_URL}    ${CODEFLARE-SDK-RELEASE-TAG}    ${CODEFLARE-SDK_DIR}
 
+    # Perform oc login with default kubeconfig
+    Login To OCP Using API And Kubeconfig    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${KUBECONFIGPATH}
+
 Run Codeflare-SDK Test
     [Documentation]   Run codeflare-sdk Test
-    [Arguments]    ${TEST_TYPE}    ${TEST_NAME}    ${PYTHON_VERSION}    ${RAY_IMAGE}
+    [Arguments]    ${TEST_TYPE}    ${TEST_NAME}    ${PYTHON_VERSION}    ${RAY_IMAGE}    ${RELEASE_BRANCH}
     Log To Console    "Running codeflare-sdk test: ${TEST_NAME}"
-    ${result} =    Run Process  cd ${CODEFLARE-SDK_DIR} && poetry env use ${PYTHON_VERSION} && poetry install --with test,docs && poetry run pytest -v -s ./tests/${TEST_TYPE}/${TEST_NAME} --timeout\=420
+    ${result} =    Run Process  cd ${CODEFLARE-SDK_DIR} && git fetch origin && git checkout ${RELEASE_BRANCH} && git branch && poetry env use ${PYTHON_VERSION} && poetry install --with test,docs && poetry run pytest -v -s ./tests/${TEST_TYPE}/${TEST_NAME} --timeout\=420
     ...    env:RAY_IMAGE=${RAY_IMAGE}
     ...    env:AWS_DEFAULT_ENDPOINT=${AWS_DEFAULT_ENDPOINT}
     ...    env:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
@@ -56,6 +61,9 @@ Run Codeflare-SDK Test
     ...    env:AWS_STORAGE_BUCKET_MNIST_DIR=${AWS_STORAGE_BUCKET_MNIST_DIR}
     ...    env:PIP_INDEX_URL=${PIP_INDEX_URL}
     ...    env:PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
+    ...    env:CONTROL_LABEL=node-role.kubernetes.io/control-plane=
+    ...    env:WORKER_LABEL=node-role.kubernetes.io/worker=
+    ...    env:TOLERATION_KEY=node-role.kubernetes.io/master
     ...    shell=true
     ...    stderr=STDOUT
     Log To Console    ${result.stdout}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -132,7 +132,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     [Setup]    Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}    Set Variable    test-ns-rayupgrade
     ${JOB_NAME}    Set Variable    mnist
-    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMNISTRayClusterUp    3.11    ${RAY_IMAGE_3.11}
+    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMNISTRayClusterUp    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup
     Launch Dashboard    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -162,7 +162,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     ${PRJ_UPGRADE}    Set Variable    test-ns-rayupgrade
     ${LOCAL_QUEUE}    Set Variable    local-queue-mnist
     ${JOB_NAME}    Set Variable    mnist
-    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMnistJobSubmit    3.11    ${RAY_IMAGE_3.11}
+    Run Codeflare-SDK Test    upgrade    raycluster_sdk_upgrade_test.py::TestMnistJobSubmit    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
     Set Global Variable    ${DW_PROJECT_CREATED}    True
     Set Library Search Order    SeleniumLibrary
     RHOSi Setup

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
@@ -8,10 +8,6 @@ Resource          ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 Resource          ../../../Resources/RHOSi.resource
 Resource          ../../../../tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 
-*** Variables ***
-${CODEFLARE-SDK_HTC_REPO_URL}                https://github.com/Ygnas/codeflare-sdk.git
-${CODEFLARE-SDK-HTC-RELEASE-TAG}             heterogeneous-clusters
-${CODEFLARE-SDK_HTC_DIR}                     codeflare-sdk-htc
 
 *** Test Cases ***
 Run TestRayClusterSDKOauth test with Python 3.9
@@ -21,7 +17,7 @@ Run TestRayClusterSDKOauth test with Python 3.9
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}
+    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
 
 Run TestRayClusterSDKOauth test with Python 3.11
     [Documentation]    Run Python E2E test: TestRayClusterSDKOauth
@@ -30,7 +26,7 @@ Run TestRayClusterSDKOauth test with Python 3.11
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}
+    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 Run TestRayLocalInteractiveOauth test with Python 3.9
     [Documentation]    Run Python E2E test: TestRayLocalInteractiveOauth
@@ -39,7 +35,7 @@ Run TestRayLocalInteractiveOauth test with Python 3.9
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}
+    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
 
 Run TestRayLocalInteractiveOauth test with Python 3.11
     [Documentation]    Run Python E2E test: TestRayLocalInteractiveOauth
@@ -48,7 +44,7 @@ Run TestRayLocalInteractiveOauth test with Python 3.11
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}
+    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 Run TestHeterogenousClustersOauth
     [Documentation]    Run Python E2E test: TestHeterogenousClustersOauth (workaround for 2.15)
@@ -58,26 +54,7 @@ Run TestHeterogenousClustersOauth
     ...     WorkloadsOrchestration
     ...     HeterogeneousCluster
     ...     Codeflare-sdk
-    DistributedWorkloads.Clone Git Repository    ${CODEFLARE-SDK_HTC_REPO_URL}    ${CODEFLARE-SDK-HTC-RELEASE-TAG}    ${CODEFLARE-SDK_HTC_DIR}
-    Log To Console    "Running codeflare-sdk test: ${TEST_NAME}"
-    ${result} =    Run Process  source ${VIRTUAL_ENV_NAME}/bin/activate && cd ${CODEFLARE-SDK_HTC_DIR} && poetry env use 3.11 && poetry install --with test,docs && poetry run pytest -v -s ./tests/e2e/heterogeneous_clusters_oauth_test.py --timeout\=600 && deactivate
-    ...    env:RAY_IMAGE=${RAY_IMAGE}
-    ...    env:AWS_DEFAULT_ENDPOINT=${AWS_DEFAULT_ENDPOINT}
-    ...    env:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
-    ...    env:AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
-    ...    env:AWS_STORAGE_BUCKET=${AWS_STORAGE_BUCKET}
-    ...    env:AWS_STORAGE_BUCKET_MNIST_DIR=${AWS_STORAGE_BUCKET_MNIST_DIR}
-    ...    env:PIP_INDEX_URL=${PIP_INDEX_URL}
-    ...    env:PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
-    ...    env:CONTROL_LABEL=node-role.kubernetes.io/control-plane=
-    ...    env:WORKER_LABEL=node-role.kubernetes.io/worker=
-    ...    env:TOLERATION_KEY=node-role.kubernetes.io/master
-    ...    shell=true
-    ...    stderr=STDOUT
-    Log To Console    ${result.stdout}
-    IF    ${result.rc} != 0
-        FAIL    Running test ${TEST_NAME} failed
-    END
+    Run Codeflare-SDK Test    e2e    heterogeneous_clusters_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite


### PR DESCRIPTION
closes [RHOAIENG-15764](https://issues.redhat.com/browse/RHOAIENG-15764)

- Updated Codeflare SDK release tag for 2.16 rhoai release for downstream testing 
- Fix Codeflare SDK 3.9 tests to run against release tag v0.21.1