### PR TITLE
Backport fix in pipeline path in create_run_from_pipeline_func (releases/2.10.0)

### DIFF
--- a/ods_ci/libs/DataSciencePipelinesKfp.py
+++ b/ods_ci/libs/DataSciencePipelinesKfp.py
@@ -101,7 +101,7 @@ class DataSciencePipelinesKfp:
         if current_path is None:
             current_path = os.getcwd()
         my_source = self.import_souce_code(
-            f"{current_path}/ods_ci/tests/Resources/Files/pipeline-samples/v2/{source_code}"
+            f"{current_path}/tests/Resources/Files/pipeline-samples/v2/{source_code}"
         )
         pipeline = getattr(my_source, fn)
 

--- a/ods_ci/libs/DataSciencePipelinesKfp.py
+++ b/ods_ci/libs/DataSciencePipelinesKfp.py
@@ -100,9 +100,7 @@ class DataSciencePipelinesKfp:
         # the current_path will be ods-ci
         if current_path is None:
             current_path = os.getcwd()
-        my_source = self.import_souce_code(
-            f"{current_path}/tests/Resources/Files/pipeline-samples/v2/{source_code}"
-        )
+        my_source = self.import_souce_code(f"{current_path}/tests/Resources/Files/pipeline-samples/v2/{source_code}")
         pipeline = getattr(my_source, fn)
 
         # pipeline_params


### PR DESCRIPTION
In /job/devops/job/rhoai-test-flow/1488 (uses releases/2.10.0 branch)  we see test `Verify Ods Users Can Create And Run A Data Science Pipeline Using The kfp Python Package` failing because of this

`FileNotFoundError: [Errno 2] No such file or directory: '/home/jenkins/workspace/devops/rhoai-test-flow/ods-ci/ods_ci/ods_ci/tests/Resources/Files/pipeline-samples/v2/flip_coin.py'`