### PR TITLE
fix: increase timeout for the dsci to 180 seconds

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -91,7 +91,7 @@ Verify RHODS Installation
         IF    "${TEST_ENV.lower()}" == "crc"
             ${timeout_in_seconds} =   Set Variable   180
         ELSE
-            ${timeout_in_seconds} =   Set Variable   30
+            ${timeout_in_seconds} =   Set Variable   60
         END
         Wait For DSCInitialization CustomResource To Be Ready    timeout=${timeout_in_seconds}
     END


### PR DESCRIPTION
I observed some situation where 30 seconds is not enough for the DSCI to be created, so increasing this timeout to 60 seconds.

Note: only happenning in ODH-nightlies, so no need to backport to other ods-ci branches.