### PR TITLE
[fix] the vscode minimal check

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -313,8 +313,7 @@ Wait Notebook To Be Loaded
 
     IF  "${ide}"=="VSCode"
         Wait Until Page Contains Element  xpath://div[@class="menubar-menu-button"]  timeout=60s
-        Wait Until Page Contains Element  xpath://div[@class="monaco-dialog-box"]  timeout=60s
-        Wait Until Page Contains  Do you trust the authors of the files in this folder?
+        Wait Until Page Contains  Get Started with VS Code for the Web
     ELSE IF  "${ide}"=="JupyterLab"
         Wait Until Page Contains Element  xpath://div[@id="jp-top-panel"]  timeout=60s
         Sleep    2s    reason=Wait for a possible popup


### PR DESCRIPTION
The modal box with the confirmation of the trust to the authors isn't being shown in the latest version of image we provide, so this test is now updated accordingly.

---

CI:
![image](https://github.com/user-attachments/assets/fb53bf62-41ab-4641-b76f-f4504cca2763)
