### PR TITLE
Update the way how to remove environment variables for Jupyter ntb

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -174,18 +174,18 @@ Add Spawner Environment Variable
 
 Remove All Spawner Environment Variables
    [Documentation]  Removes all existing environment variables in the Spawner
-   @{env_vars_list} =    Create List
-   @{env_elements} =    Get WebElements    xpath://*[.='Variable name']/../../div[2]/input
+   ${remove_env_btn_xpath} =    Set Variable    //*[@data-id="remove-env-var-button"]
+   ${first_remove_env_btn_xpath} =    Set Variable
+   ...    //*[@class="odh-notebook-controller__env-var-row"][1]${remove_env_btn_xpath}
 
-   # We need to fist get the env values and remove them later to avoid a
-   # selenium error due to modifiying the DOM while iterating its contents
-   FOR    ${element}    IN    @{env_elements}
-       ${txt} =   Get Value  ${element}
-       Append To List  ${env_vars_list}   ${txt}
-   END
-
-   FOR    ${env}    IN    @{env_vars_list}
-       Remove Spawner Environment Variable   ${env}
+   WHILE    ${TRUE}
+       ${remove_btn_number} =    Get Element Count    ${remove_env_btn_xpath}
+       IF    ${remove_btn_number} > 0
+           Click Button    ${first_remove_env_btn_xpath}
+           Sleep    0.5s    # Give browser time to react
+       ELSE
+           BREAK
+       END
    END
 
 Remove Spawner Environment Variable
@@ -359,8 +359,8 @@ Spawn Notebook With Arguments  # robocop: disable
                 Capture Page Screenshot    reload.png
                 Wait Until JupyterHub Spawner Is Ready
             END
+            Remove All Spawner Environment Variables
             IF  &{envs}
-                Remove All Spawner Environment Variables
                 FOR  ${key}  ${value}  IN  &{envs}[envs]
                     Sleep  1
                     Add Spawner Environment Variable  ${key}  ${value}


### PR DESCRIPTION
This change slightly simplifies the way how the variables are removed from the Jupyter spawner page for the notebook - now it doesn't depend on particular variable values, but simply clicks until the remove button is present on the page.

Another change here is that this variable removal is now run also in case that the given set of variables to the `Spawn Notebook With Arguments` keyword is empty. This will ensure that any eventual leftovers from previous test are cleaned up properly not affecting this current test.

CI: tested on my cluster with empty and non-empty variables pre-set to the jupyter spawner page