### PR TITLE
fix: use cleanup.sh script to uninstall in sm clusters

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -21,20 +21,17 @@ Uninstalling RHODS Operator
   ...  Uninstall RHODS
 
 Uninstall RHODS
-  ${new_operator} =    Is RHODS Version Greater Or Equal Than    2.0.0
-  IF  "${cluster_type}" == "managed" and ${new_operator} == $False
+  IF  "${cluster_type}" == "managed"
     Uninstall RHODS In OSD
-  ELSE IF  "${cluster_type}" == "selfmanaged" and ${new_operator} == $False
+  ELSE IF  "${cluster_type}" == "selfmanaged"
     Uninstall RHODS In Self Managed Cluster
-  ELSE IF  ${new_operator}
-    Uninstall RHODS V2
   ELSE
     Fail  Kindly provide supported cluster type
   END
 
 Uninstall RHODS In OSD
   Clone OLM Install Repo
-  ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t addon   #robocop:disable
+  ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t addon -k   #robocop:disable
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing RHODS
   Log To Console   ${output}
 
@@ -45,7 +42,7 @@ Uninstall RHODS In Self Managed Cluster
   ELSE IF  "${INSTALL_TYPE}" == "OperatorHub"
       Uninstall RHODS In Self Managed Cluster For Operatorhub
   ELSE
-        FAIL    Provided install type is not supported
+      FAIL    Provided install type is not supported
   END
 
 RHODS Operator Should Be Uninstalled
@@ -55,7 +52,7 @@ RHODS Operator Should Be Uninstalled
 Uninstall RHODS In Self Managed Cluster Using CLI
   [Documentation]   UnInstall rhods on self-managedcluster using cli
   Clone OLM Install Repo
-  ${return_code}    Run and Watch Command    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator    timeout=10 min
+  ${return_code}    Run and Watch Command    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator -k    timeout=10 min
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing RHODS
 
 Uninstall RHODS In Self Managed Cluster For Operatorhub
@@ -68,57 +65,6 @@ Uninstall RHODS In Self Managed Cluster For Operatorhub
   Verify Project Does Not Exists  ${MONITORING_NAMESPACE}
   Verify Project Does Not Exists  ${NOTEBOOKS_NAMESPACE}
   ${return_code}    ${output}    Run And Return Rc And Output   oc delete namespace ${OPERATOR_NAMESPACE}
-
-Uninstall RHODS V2
-    [Documentation]    Keyword to uninstall the version 2 of the RHODS operator in Self-Managed
-    Log To Console    message=Deleting DSC CR From Cluster
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc get DataScienceCluster --all-namespaces -o custom-columns=:metadata.name --ignore-not-found | xargs -I {} oc patch DataScienceCluster {} --type=merge -p '{"metadata": {"finalizers":null}}' || true  #robocop:disable
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete datasciencecluster --all --ignore-not-found
-    Should Be Equal As Integers  ${return_code}   0   msg=Error deleting DataScienceCluster CR
-    Log To Console    message=Deleting DSCi CR From Cluster
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...   oc get DSCInitialization --all-namespaces -o custom-columns=:metadata.name --ignore-not-found | xargs -I {} oc patch DSCInitialization {} --type=merge -p '{"metadata": {"finalizers":null}}' || true  #robocop:disable
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete dscinitialization --all --ignore-not-found
-    Should Be Equal As Integers  ${return_code}   0   msg=Error deleting DSCInitialization CR
-    Log To Console    message=Deleting Operator Subscription From Cluster
-    ${return_code}    ${subscription_name}    Run And Return Rc And Output
-    ...    oc get subscription -n ${OPERATOR_NAMESPACE} --no-headers | awk '{print $1}'
-    IF  "${return_code}" == "0" and "${subscription_name}" != "${EMPTY}"
-        ${return_code}    ${csv_name}    Run And Return Rc And Output
-        ...    oc get subscription ${subscription_name} -n ${OPERATOR_NAMESPACE} -ojson | jq '.status.currentCSV' | tr -d '"'
-        IF  "${return_code}" == "0" and "${csv_name}" != "${EMPTY}"
-          ${return_code}    ${output}    Run And Return Rc And Output
-          ...    oc delete clusterserviceversion ${csv_name} -n ${OPERATOR_NAMESPACE} --ignore-not-found
-          Should Be Equal As Integers  ${return_code}   0   msg=Error deleting RHODS CSV ${csv_name}
-        END
-        ${return_code}    ${output}    Run And Return Rc And Output
-        ...    oc delete subscription ${subscription_name} -n ${OPERATOR_NAMESPACE} --ignore-not-found
-        Should Be Equal As Integers  ${return_code}   0   msg=Error deleting RHODS subscription
-    END
-    Log To Console    message=Deleting Operator CSV From Cluster
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete clusterserviceversion opendatahub-operator.1.18.0 -n openshift-operators --ignore-not-found
-    Log To Console    message=Deleting Operator Catalog From Cluster
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete CatalogSource rhoai-catalog-dev -n openshift-marketplace --ignore-not-found  # robocop: disable
-    ${return_code}    ${output}    Run And Return Rc And Output
-        ...    oc delete CatalogSource addon-managed-odh-catalog -n openshift-marketplace --ignore-not-found  # robocop: disable
-    Log To Console    message=Deleting Operator Group From Cluster
-    ${return_code}    ${output}    Run And Return Rc And Output
-    ...    oc delete operatorgroup --all -n ${OPERATOR_NAMESPACE} --ignore-not-found
-    Should Be Equal As Integers  ${return_code}   0   msg=Error deleting operatorgroup
-    Log To Console    message=Deleting Operator and it's associate namepsace
-    ${return_code}    ${output}    Run And Return Rc And Output    oc delete ns -l opendatahub.io/generated-namespace --ignore-not-found
-    Verify Project Does Not Exists  ${APPLICATIONS_NAMESPACE}
-    Verify Project Does Not Exists  ${MONITORING_NAMESPACE}
-    Verify Project Does Not Exists  ${NOTEBOOKS_NAMESPACE}
-    IF  "${OPERATOR_NAMESPACE}" != "openshift-marketplace"
-        ${return_code}    ${output}    Run And Return Rc And Output   oc delete namespace ${OPERATOR_NAMESPACE} --ignore-not-found
-        Verify Project Does Not Exists  ${OPERATOR_NAMESPACE}
-    END
 
 Uninstall Service Mesh Operator CLI
     [Documentation]    Keyword to uninstall the Service Mesh Operator


### PR DESCRIPTION
As discussed with @bdattoma and @aloganat, we were not using olminstall scripts to uninstall ODH/RHOAI. This PR replaces the "Uninstall RHODS V2" Kw by the one for selfmanaged clusters, using cleanup script