### PR TITLE
Fix dsp post upgrade. Add keyword "Skip If Operator Starting Version Is Not Supported"

### DIFF
--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
@@ -218,14 +218,22 @@ Get Last Run By Pipeline Name
 
     RETURN    ${pipeline_run_id}
 
+Get Run Status
+    [Documentation]  Returns run status for ${pipeline_run_id}
+    [Arguments]    ${namespace}    ${username}    ${password}    ${pipeline_run_id}
+
+    DataSciencePipelinesKfp.Setup Client    user=${username}    pwd=${password}    project=${namespace}
+    ${pipeline_run_status}=    DataSciencePipelinesKfp.Get Run Status    run_id=${pipeline_run_id}
+    RETURN    ${pipeline_run_status}
+
 Verify Run Status
     [Documentation]  Verifies pipeline run status matches ${pipeline_run_expected_status}
     [Arguments]    ${namespace}           ${username}                  ${password}
     ...    ${pipeline_run_id}    ${pipeline_run_expected_status}="SUCCEEDED"
 
-    DataSciencePipelinesKfp.Setup Client    user=${username}    pwd=${password}    project=${namespace}
+    ${pipeline_run_status}=    DataSciencePipelinesBackend.Get Run Status
+    ...        ${namespace}    ${username}    ${password}    ${pipeline_run_id}
 
-    ${pipeline_run_status}=    DataSciencePipelinesKfp.Get Run Status    run_id=${pipeline_run_id}
     IF   "${pipeline_run_status}" != "${pipeline_run_expected_status}"
         ${error_msg}=    Catenate    Expected pipeline status was ${pipeline_run_expected_status} but pipeline run
         ...    has status=${pipeline_run_status}

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -23,8 +23,8 @@ Verify Resources After Upgrade
     [Documentation]    Verifies the status of the resources created in ${PROJECT} after the upgrade
     ...    Deletes ${PROJECT} if all verifications are correct (leaving for debugging purposes if not)
 
+    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
     Skip If Namespace Does Not Exist    ${PROJECT}
-
     DataSciencePipelinesBackend.Wait Until Pipeline Server Is Deployed    namespace=${PROJECT}
 
     ${take_nap_run_id}=    DataSciencePipelinesBackend.Get Last Run By Pipeline Name

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -23,7 +23,6 @@ Verify Resources After Upgrade
     [Documentation]    Verifies the status of the resources created in ${PROJECT} after the upgrade
     ...    Deletes ${PROJECT} if all verifications are correct (leaving for debugging purposes if not)
 
-    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
     Skip If Namespace Does Not Exist    ${PROJECT}
     DataSciencePipelinesBackend.Wait Until Pipeline Server Is Deployed    namespace=${PROJECT}
 

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation    Upgrade Testing Keywords
 Resource         DataSciencePipelinesBackend.resource
+Resource         ../../../Resources/Common.robot
 Resource         ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 
 
@@ -22,15 +23,21 @@ Verify Resources After Upgrade
     [Documentation]    Verifies the status of the resources created in ${PROJECT} after the upgrade
     ...    Deletes ${PROJECT} if all verifications are correct (leaving for debugging purposes if not)
 
+    Skip If Namespace Does Not Exist    ${PROJECT}
+
     DataSciencePipelinesBackend.Wait Until Pipeline Server Is Deployed    namespace=${PROJECT}
 
     ${take_nap_run_id}=    DataSciencePipelinesBackend.Get Last Run By Pipeline Name
     ...    namespace=${PROJECT}    username=${TEST_USER.USERNAME}    password=${TEST_USER.PASSWORD}
     ...    pipeline_name=take-nap
 
-    Verify Run Status
+    ${pipeline_run_status}=    DataSciencePipelinesBackend.Get Run Status
     ...    namespace=${PROJECT}    username=${TEST_USER.USERNAME}    password=${TEST_USER.PASSWORD}
-    ...    pipeline_run_id=${take_nap_run_id}    pipeline_run_expected_status=RUNNING
+    ...    pipeline_run_id=${take_nap_run_id}
+
+    IF   "${pipeline_run_status}" != "RUNNING" and "${pipeline_run_status}" != "SUCCEEDED"
+        Fail    take-nap has status ${pipeline_run_status} after upgrade
+    END
 
     Projects.Delete Project Via CLI By Display Name    ${PROJECT}
 

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -316,6 +316,16 @@ Skip If RHODS Is Managed
        Skip If    condition=${is_self_managed}==False    msg=This test is skipped for Managed RHODS
     END
 
+Skip If Namespace Does Not Exist
+    [Documentation]    Skips test if ${namespace} does not exist in the cluster
+    [Arguments]    ${namespace}    ${msg}=${EMPTY}
+    ${rc}=    Run And Return Rc    oc get project ${namespace}
+    IF    "${msg}" != "${EMPTY}"
+       Skip If    condition="${rc}"!="${0}"    msg=${msg}
+    ELSE
+       Skip If    condition="${rc}"!="${0}"    msg=This test is skipped because namespace ${namespace} does not exist
+    END
+
 Run Keyword If RHODS Is Managed
     [Documentation]    Runs keyword ${name} using  @{arguments} if RHODS is Managed (Cloud Version)
     [Arguments]    ${name}    @{arguments}
@@ -451,7 +461,7 @@ Run And Verify Command
     IF    ${print_to_log}    Log    ${result.stdout}     console=True
     Should Be True    ${result.rc} == ${expected_rc}
     RETURN    ${result.stdout}
-  
+
 Run And Watch Command
   [Documentation]    Run any shell command (including args) with optional:
   ...    Timeout: 10 minutes by default.

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -567,7 +567,7 @@ Clone Git Repository
 Get Operator Starting Version
     [Documentation]    Returns the starting version of the operator in the upgrade chain
     ${rc}    ${out}=    Run And Return RC And Output
-    ...    oc get subscription rhods-operator -n redhat-ods-operator -o yaml | yq '.spec.startingCSV' | awk -F. '{print $2"."$3"."$4}'    # robocop: disable
+    ...    oc get subscription rhods-operator -n ${OPERATOR_NAMESPACE} -o yaml | yq '.spec.startingCSV' | awk -F. '{print $2"."$3"."$4}'    # robocop: disable
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${out}
 
@@ -578,3 +578,12 @@ Is Starting Version Supported
     ${starting_ver}=    Get Operator Starting Version
     ${out}=     Gte    ${starting_ver}    ${minimum_version}
     RETURN    ${out}
+
+Skip If Operator Starting Version Is Not Supported
+    [Documentation]    Skips test if ODH/RHOAI operator starting version is < ${minimum_version}
+    ...    Usage example: add    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
+    ...    in your post-upgrade tests if the resources needed by them were added in the pre-upgrade suite
+    ...    in ods-ci releases/2.14.0
+    [Arguments]    ${minimum_version}
+    ${supported}=    Is Starting Version Supported    minimum_version=${minimum_version}
+    Skip If    condition="${supported}"=="${FALSE}"    msg=This test is skipped because starting operator version < ${minimum_version}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -242,14 +242,14 @@ Verify That DSC And DSCI Release.Version Attribute matches the value in the subs
 Data Science Pipelines Post Upgrade Verifications
     [Documentation]    Verifies the status of the resources created in project dsp-test-upgrade after the upgradea
     [Tags]             Upgrade    DataSciencePipelines-Backend
+    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
     DataSciencePipelinesUpgradeTesting.Verify Resources After Upgrade
 
 Model Registry Post Upgrade Verification
     [Documentation]    Verifies that registered model/version in pre-upgrade is present after the upgrade
     [Tags]             Upgrade    ModelRegistryUpgrade
     ...                ProductBug    RHOAIENG-15033
-    ${check}=    Is Starting Version Supported    minimum_version=2.14.0
-    Skip If    ${check}==${FALSE}
+    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
     Model Registry Post Upgrade Scenario
     [Teardown]    Post Upgrade Scenario Teardown
 


### PR DESCRIPTION
- Adds keyword `Skip If Operator Starting Version Is Not Supported` based on previous work by @lugi0 
- Sets minimum starting version for pipelines post-upgrade verification
- In pipeline post-upgrade verification, accept RUNNING and SUCCEEDED state when checking the status of the test pipeline