### PR TITLE
Add keywords to skip tests on Self managed cluster

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -587,3 +587,13 @@ Skip If Operator Starting Version Is Not Supported
     [Arguments]    ${minimum_version}
     ${supported}=    Is Starting Version Supported    minimum_version=${minimum_version}
     Skip If    condition="${supported}"=="${FALSE}"    msg=This test is skipped because starting operator version < ${minimum_version}
+
+Skip If Cluster Type Is Self-Managed
+    [Documentation]    Skips test if cluster type  is Self-managed
+    ${cluster_type}=    Is Cluster Type Self-Managed
+    Skip If    condition=${cluster_type}==True    msg=This test is skipped for Self-managed cluster
+
+Skip If Cluster Type Is Managed
+    [Documentation]    Skips test if cluster type  is Managed
+    ${cluster_type}=    Is Cluster Type Self-Managed
+    Skip If    condition=${cluster_type}==False    msg=This test is skipped for Managed cluster

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -332,3 +332,18 @@ Wait For Namespace To Be Active
     Log    ${rc}
     Log    ${value}
     Should Be Equal As Integers    ${rc}    0
+
+Is Cluster Type Self-Managed
+    [Documentation]    Get the value of cluster type depending on the console URL domain
+    ...    Returns ${TRUE} if cluster type is Self-Managed
+    ...    Returns ${FALSE} if cluster type is Managed
+    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods
+    ${size}=    Get Length    ${matches}
+    IF    ${size}>0
+        ${domain}=    Get From List    ${matches}    0
+        IF    "${domain}" == "rh-ods"
+            RETURN    ${TRUE}
+        END
+    ELSE
+        RETURN    ${FALSE}
+    END

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
@@ -79,7 +79,7 @@ Prepare DistributedWorkloads Integration Test Suite for 3.9
     [Documentation]    Prepare DistributedWorkloads Integration Test Suite for 3.9
     # The bug fix for self signed certificate error is not available in codeflare-sdk version "v0.21.1" which is the
     # last supported release for python 3.9 and hence skipping tests for self managed installtion
-    Skip If RHODS Is Self-Managed
+    Skip If Cluster Type Is Self-Managed
     Log To Console    "Downloading compiled test binary ${ODH_BINARY_NAME}"
 
     ${result} =    Run Process    curl --location --silent --output ${ODH_BINARY_NAME} ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS_3.9}/${ODH_BINARY_NAME} && chmod +x ${ODH_BINARY_NAME}


### PR DESCRIPTION
Closes [RHOAIENG-16219](https://issues.redhat.com/browse/RHOAIENG-16219)

This PR 

- adds a keyword `Is Cluster Type Self-Managed` to get cluster type 
- adds a keyword `Skip If Cluster Type Is Self-Managed` and `Skip If Cluster Type Is Managed` to skip tests on self managed/managed cluster
