### PR TITLE
[fix] This bumps the expected CUDA version for the workbench images

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
@@ -13,8 +13,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         minimal-gpu
-${EXPECTED_CUDA_VERSION} =  12.1
-${EXPECTED_CUDA_VERSION_N_1} =  11.8
+${EXPECTED_CUDA_VERSION} =  12.4
+${EXPECTED_CUDA_VERSION_N_1} =  12.1
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
@@ -15,8 +15,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         pytorch
-${EXPECTED_CUDA_VERSION} =  12.1
-${EXPECTED_CUDA_VERSION_N_1} =  11.8
+${EXPECTED_CUDA_VERSION} =  12.4
+${EXPECTED_CUDA_VERSION_N_1} =  12.1
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
@@ -16,8 +16,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         tensorflow
-${EXPECTED_CUDA_VERSION} =  12.1
-${EXPECTED_CUDA_VERSION_N_1} =  11.8
+${EXPECTED_CUDA_VERSION} =  12.4
+${EXPECTED_CUDA_VERSION_N_1} =  12.1
 
 
 *** Test Cases ***


### PR DESCRIPTION
With the introduction of the 2024b images, there is also a new CUDA version available. As such, we now have 12.4 in the 2024b and 12.1 in the 2024a images versions.