### PR TITLE
[fix] of the GPU tests for the IDE module

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
@@ -20,7 +20,7 @@ Verify Pytorch Can See GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
         # TODO: use Install And Import Package In JupyterLab after #202 is merged
-        Run Cell And Check For Errors    !pip install torch==1.8 numpy==1.24.4    timeout=300s
+        Run Cell And Check For Errors    !pip install torch==2.4.1 numpy==2.1.3    timeout=300s
     END
     Run Cell And Check Output
     ...    import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")
@@ -52,7 +52,8 @@ Find Max Number Of GPUs In One Node
 
 Get GPU nodes
     [Documentation]    Returns a list containing all nodes with GPUs
-    ${nodes_from_oc} =    Run    oc get nodes -l nvidia.com/gpu.present=true | grep ip | awk '{split($0,a); print a[1]}'
+    # TODO: we will need to adjust e.g. for AMD in the future...
+    ${nodes_from_oc} =    Run    oc get nodes -l nvidia.com/gpu.present=true --no-headers=true | awk '{split($0,a); print a[1]}'
     @{node_names} =    Split To Lines    ${nodes_from_oc}
     RETURN    @{node_names}
 

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -23,7 +23,7 @@ ${KFNBC_ACCELERATOR_DROPDOWN_XPATH} =    //label[@for='modal-notebook-accelerato
 ${KFNBC_ACCELERATOR_INPUT_XPATH} =    //input[@aria-label='Number of accelerators']
 ${KFNBC_ACCELERATOR_LESS_BUTTON_XPATH} =    ${KFNBC_ACCELERATOR_INPUT_XPATH}/parent::*/parent::*/preceding-sibling::*//button
 ${KFNBC_ACCELERATOR_PLUS_BUTTON_XPATH} =    ${KFNBC_ACCELERATOR_INPUT_XPATH}/parent::*/parent::*/following-sibling::*//button
-${KFNBC_MAX_ACCELERATOR_WARNING_XPATH} =    //div[contains(@class, 'pf-m-warning')]//h4[contains(text(), 'accelerator detected')]
+${KFNBC_MAX_ACCELERATOR_WARNING_XPATH} =    //div[contains(@class, 'pf-m-warning')]//h4[contains(text(), 'accelerator detected') or contains(text(),'accelerators detected')]
 ${KFNBC_MODAL_HEADER_XPATH} =    //div[@aria-label="Starting server modal"]
 ${KFNBC_MODAL_CANCEL_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[.="Cancel"]
 ${KFNBC_MODAL_CLOSE_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[.="Close"]


### PR DESCRIPTION
1. [fix] the detection of max available GPUs in case there is more than 1
2. [fix] bumped the installed version of torch and numpy This is to support the new version of images. I chose versions that are referenced for the 2.16 release currently [1].

    * [1] https://github.com/red-hat-data-services/notebooks/blob/f1e70f63764503a6989c57a949fe36cb842b30e8/jupyter/pytorch/ubi9-python-3.11/Pipfile.lock

3. [fix] the way we gather nodes with GPUs

    Note that this will need another change for AMD in the future.

---

Backport to 2.16 is #2105.