### PR TITLE
Backport to Release_2.16.0: Moved fetch cluster type to RHOSi.resources and assign correct subscr…

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -406,7 +406,7 @@ Wait For DSCI Ready State
 
 Wait For DSC Conditions Reconciled
     [Documentation]    Checks all DSC conditions to be successfully reconciled
-    [Arguments]    ${namespace}    ${dsc_name}    ${wait_time}=6m
+    [Arguments]    ${namespace}    ${dsc_name}    ${wait_time}=20m
     ${rc}    ${out}=    Run And Return Rc And Output
     ...    oc wait --timeout=${wait_time} --for jsonpath='{.status.conditions[].reason}'=ReconcileCompleted -n ${namespace} dsc ${dsc_name}    # robocop: disable
     Should Be Equal As Integers    ${rc}     ${0}

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -78,6 +78,7 @@ Protect Sensitive Variables In Keywords
 Initialize Global Variables
     [Documentation]   Sets global variables
     [Arguments]    ${force_fetch}=False
+    Fetch Cluster Type By Domain
     Assign Vars According To Product
     ${RHODS_VERSION}=    Get RHODS Version    ${force_fetch}
     Set Global Variable   ${RHODS_VERSION}
@@ -92,6 +93,16 @@ Required Global Variables Should Exist
     Variable Should Exist    ${OPERATOR_NAMESPACE}
     Variable Should Exist    ${NOTEBOOKS_NAMESPACE}
 
+Fetch Cluster Type By Domain
+    [Documentation]    This Keyword outputs the kind of cluster depending on the console URL domain
+    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods
+    ${matches_len}=     Get Length      ${matches}
+    IF  '${matches_len}' == '0'
+        Set Global Variable    ${CLUSTER_TYPE}    managed
+    ELSE
+        Set Global Variable    ${CLUSTER_TYPE}    selfmanaged
+    END
+
 Assign Vars According To Product
     [Documentation]    Assign vars related to product
     IF    "${PRODUCT}" == "RHODS"
@@ -104,7 +115,11 @@ Assign Vars According To Product
         Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=rhods-dashboard
         Set Suite Variable    ${APPLICATIONS_NAMESPACE}    redhat-ods-applications
-        Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
+        IF  "${CLUSTER_TYPE}" == "managed"
+            Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     addon-managed-odh
+        ELSE
+            Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
+        END
         Set Suite Variable  ${MODEL_REGISTRY_NAMESPACE}    rhoai-model-registries
     ELSE IF    "${PRODUCT}" == "ODH"
         Set Suite Variable    ${OPERATOR_APPNAME}  "Open Data Hub Operator"

--- a/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
@@ -32,7 +32,6 @@ Validate Service Mesh Control Plane Already Created
     [Tags]      RHOAIENG-2517       Operator
     Fetch Image Url And Update Channel
     Check Whether DSC Exists And Save Component Statuses
-    Fetch Cluster Type By Domain
     IF    "${CLUSTER_TYPE}" == "selfmanaged"
         Uninstall RHODS In Self Managed Cluster
         Create Smcp From Template
@@ -105,16 +104,6 @@ Fetch Image Url And Update Channel
     Should Be Equal As Integers    ${rc}    0
     Set Global Variable    ${UPDATE_CHANNEL}    ${out}
 
-Fetch Cluster Type By Domain
-    [Documentation]    This Keyword outputs the kind of cluster depending on the console URL domain
-    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods
-    ${domain}=    Get From List    ${matches}    0
-    IF    "${domain}" == "rh-ods"
-        Set Global Variable    ${CLUSTER_TYPE}    selfmanaged
-    ELSE
-        Set Global Variable    ${CLUSTER_TYPE}    managed
-    END
-
 Create Smcp From Template
     [Documentation]    Create a default ServiceMeshControlPlane from a template
     ${file_path}=    Set Variable    ./tasks/Resources/Files/
@@ -131,7 +120,7 @@ Operator Deployment Should Be Ready
     ${rc}=    Set Variable    1
     TRY
         WHILE    ${rc} != 0    limit=10m
-            Sleep    5s
+            Sleep    15s
             ${rc}    ${output}=    Run And Return Rc And Output
             ...    oc wait --for condition=available -n ${OPERATOR_NAMESPACE} deploy/${OPERATOR_DEPLOYMENT_NAME}
         END


### PR DESCRIPTION
…… (#2066)

* Moved fetch cluster type to RHOSi.resources and assign correct subscription name for managed cluster

* refactored Fetch Cluster Type By Domain kw

* fix list invokation

* fixed IF condition for matches_length

* string value for 0 comparison

* raised timeout for DSC Conditions reconciled

* raised timeout for DSC Conditions reconciled to 15 min

* raised timeout for DSC Conditions reconciled to 20 min

* raised sleep loop for Operator Deployment Should Be Ready