### PR TITLE
Add AutomationBug Tag to Verify RHODS User Groups

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -53,7 +53,7 @@ Verify Pod Toleration
 
 Verify RHODS User Groups
     [Documentation]    Verify User Configuration after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade     AutomationBug
     ${admin}        Set Variable        ${payload[0]['spec']['groupsConfig']['adminGroups']}
     ${user}     Set Variable        ${payload[0]['spec']['groupsConfig']['allowedGroups']}
     Should Be Equal As Strings      '${admin}'      'rhods-admins,rhods-users'


### PR DESCRIPTION
This is a temporary tag as it fails on cascade meanwhile Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates is being fixed