### PR TITLE
[model server] Update post upgrade expected inference response

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -151,7 +151,7 @@ Test Inference Post RHODS Upgrade
     ${INFERENCE_INPUT_OPENVINO}    Set Variable
     ...    @tests/Resources/Files/openvino-example-input.json
     ${EXPECTED_INFERENCE_OUTPUT_OPENVINO}    Set Variable
-    ...    {"model_name":"test-model__isvc-8655dc7979","model_version":"1","outputs":[{"name":"Func/StatefulPartitionedCall/output/_13:0","datatype":"FP32","shape":[1,1],"data":[0.99999994]}]}º       # robocop: disable:line-too-long
+    ...    {"model_name":"test-model__isvc-8655dc7979","model_version":"1","outputs":[{"name":"Func/StatefulPartitionedCall/output/_13:0","datatype":"FP32","shape":[1,1],"data":[0.99999994]}]}   # robocop: disable:line-too-long
     Fetch CA Certificate If RHODS Is Self-Managed
     Open Model Serving Home Page
     Verify Model Status     ${MODEL_NAME}           success


### PR DESCRIPTION
rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED


verified
```
==============================================================================
Post Upgrade :: Test Suite for Upgrade testing,to be run after the upgrade    
==============================================================================
[ WARN ] No Prometheus namespace found
DataScienceCluster default-dsc in the namespace redhat-ods-operator attribute .status.release.name value is OpenShift AI Self-Managed
DSCInitialization default-dsci in the namespace redhat-ods-operator attribute .status.release.name value is OpenShift AI Self-Managed
DataScienceCluster default-dsc in the namespace redhat-ods-operator attribute .status.release.version value is 2.16.0
DSCInitialization default-dsci in the namespace redhat-ods-operator attribute .status.release.version value is 2.16.0
[ WARN ] No Prometheus namespace found                                        
Test Inference Post RHODS Upgrade :: Test the inference result aft... | PASS |
------------------------------------------------------------------------------
Post Upgrade :: Test Suite for Upgrade testing,to be run after the... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
```