### PR TITLE
Replace all Xpaths with `pf-v5` to `pf-v6`

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/WorkloadMetricsUI.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/WorkloadMetricsUI.resource
@@ -163,8 +163,8 @@ Get Memory Requested
 
 Get Requested Resources Tooltip Text
     [Documentation]    retuns tooltip text of requested resources chart
-    Wait Until Element Is Visible    xpath://*[contains(@style, 'fill: var(--pf-v5-chart-tooltip--Fill')]
-    ${tooltip_text} =  Get Text    xpath://*[contains(@style, 'fill: var(--pf-v5-chart-tooltip--Fill')]
+    Wait Until Element Is Visible    xpath://*[contains(@style, 'fill: var(--pf-v6-chart-tooltip--Fill')]
+    ${tooltip_text} =  Get Text    xpath://*[contains(@style, 'fill: var(--pf-v6-chart-tooltip--Fill')]
     RETURN    ${tooltip_text}
 
 Get Memory Requested Tooltip Text
@@ -266,7 +266,7 @@ Check Distributed Workload Resource Metrics Status
     [Documentation]    checks Distributed Workload Resource Metrics Status contents
     [Arguments]    ${job_name}    ${job_status}
     Check Expected String Contains    //td[@data-label="Name"]    ${job_name}
-    Check Expected String Equals    //td[@data-label="Status"]//span[@class="pf-v5-c-label__text"]    ${job_status}
+    Check Expected String Equals    //td[@data-label="Status"]//span[@class="pf-v6-c-label__text"]    ${job_status}
 
 Compare Workload Created Date With Current Date
     [Documentation]    Check Workload Created Date To Be Less Than Equal To Current Date
@@ -310,10 +310,10 @@ Check Distributed Workload Resource Metrics Chart
     ${cpu_usage_hover_value}     ${cpu_requested_hover_value} =  Get CPU Requested Tooltip Text
     Check Resource Consuming Usage    ${cpu_usage}    ${cpu_usage_hover_value}    CPU
     Should Be True     ${cpu_requested_hover_value} == ${cpu_requested}
-    ${cpu_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v5-chart-donut--label--title--Fill')]])[1]
+    ${cpu_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v6-chart-donut--label--title--Fill')]])[1]
     Check Resource Consuming Usage    ${cpu_usage}    ${cpu_consuming}    CPU
 
-    Mouse Over    (//button[@class="pf-v5-c-table__button"])[1]
+    Mouse Over    (//button[@class="pf-v6-c-table__button"])[1]
 
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingMemory-ChartLabel-title"]    timeout=120
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingMemory-ChartLegend-ChartLabel-0"]    timeout=120
@@ -323,7 +323,7 @@ Check Distributed Workload Resource Metrics Chart
     ${memory_usage_hover_value}     ${memory_requested_hover_value} =  Get Memory Requested Tooltip Text
     Check Resource Consuming Usage    ${memory_usage}    ${memory_usage_hover_value}    Memory
     Should Be True     ${memory_requested_hover_value} == ${memory_requested}
-    ${memory_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v5-chart-donut--label--title--Fill')]])[2]
+    ${memory_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v6-chart-donut--label--title--Fill')]])[2]
     Check Resource Consuming Usage    ${memory_usage}    ${memory_consuming}    Memory
 
 Check Distributed Worklaod Status Overview
@@ -339,7 +339,7 @@ Check Distributed Worklaod Status Overview
     ${get_created_datetime} =    Get Text    xpath=//td[@data-label="Created"]
     ${get_created_date} =    Evaluate    re.search(r'[^,]+','''${get_created_datetime}''').group(0)
     Compare Workload Created Date With Current Date    ${get_created_date}    ${get_current_date}
-    Check Expected String Equals    //td[@data-label="Status"]//span[@class="pf-v5-c-label__text"]    ${job_status}
+    Check Expected String Equals    //td[@data-label="Status"]//span[@class="pf-v6-c-label__text"]    ${job_status}
     Check Expected String Equals    //td[@data-label="Latest Message"]    ${job_status_message}
 
 Check Resource Consuming Usage
@@ -367,7 +367,7 @@ Submit Kueue Workload
 Wait For Job With Status
     [Documentation]    Wait for job status with job name
     [Arguments]    ${job_name}    ${job_status}    ${timeout}
-    Wait Until Element Is Visible    //td[@class='pf-v5-c-table__td' and contains(text(), '${job_name}')]/following-sibling::td[@data-label='Status']/span/span/span[@class='pf-v5-c-label__text'and text()='${job_status}']    timeout=${timeout}
+    Wait Until Element Is Visible    //td[@class='pf-v6-c-table__td' and contains(text(), '${job_name}')]/following-sibling::td[@data-label='Status']/span/span/span[@class='pf-v6-c-label__text'and text()='${job_status}']    timeout=${timeout}
 
 Check Warning Threshold Chart
     [Documentation]    verifies warning threshold of cpu and memory resources

--- a/ods_ci/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
+++ b/ods_ci/tests/Resources/Page/HybridCloudConsole/HCCLogin.robot
@@ -9,8 +9,8 @@ Is SSO Login Page Visible
   RETURN  ${login_prompt_visible}
 
 Wait For HCC Splash Page
-   Wait Until Page Contains Element    xpath://span[contains(@class, 'pf-v5-c-spinner')]   timeout=15
-   Wait Until Page Does Not Contain Element    xpath://span[contains(@class, 'pf-v5-c-spinner')]   timeout=20
+   Wait Until Page Contains Element    xpath://span[contains(@class, 'pf-v6-c-spinner')]   timeout=15
+   Wait Until Page Does Not Contain Element    xpath://span[contains(@class, 'pf-v6-c-spinner')]   timeout=20
    Sleep    3
 
 Login To HCC
@@ -69,11 +69,11 @@ Open Cluster By Name
   [Documentation]     Opens the cluster by name from the list of clusters.
   ${cluster_id} =     Get Cluster ID
   ${cluster_name}=    Get Cluster Name By Cluster ID    ${cluster_id}
-  Wait Until Page Contains Element  //input[@class="pf-v5-c-form-control cluster-list-filter"]
-  Input Text    //input[@class="pf-v5-c-form-control cluster-list-filter"]     ${cluster_name}
+  Wait Until Page Contains Element  //input[@class="pf-v6-c-form-control cluster-list-filter"]
+  Input Text    //input[@class="pf-v6-c-form-control cluster-list-filter"]     ${cluster_name}
   Sleep    1s
-  Wait Until Page Contains Element  //table[@class="pf-v5-c-table pf-m-grid-md"]//a    10
-  Click Link    //table[@class="pf-v5-c-table pf-m-grid-md"]//a
+  Wait Until Page Contains Element  //table[@class="pf-v6-c-table pf-m-grid-md"]//a    10
+  Click Link    //table[@class="pf-v6-c-table pf-m-grid-md"]//a
 
 Maybe Skip OCM Tour
   ${tour_modal} =  Run Keyword And Return Status  Page Should Contain Element  xpath=//div[@id="pendo-guide-container"]

--- a/ods_ci/tests/Resources/Page/OCPDashboard/Page.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/Page.robot
@@ -62,7 +62,7 @@ Delete Project By Name
   Wait Until Page Contains Element      //input[@data-test-id="item-filter"]
   Input Text    //input[@data-test-id="item-filter"]    ${project_name}
   Sleep     5
-  Click Button      //button[@class="pf-v5-c-dropdown__toggle pf-m-plain"]
+  Click Button      //button[@class="pf-v6-c-dropdown__toggle pf-m-plain"]
   Sleep     5
   Click Button      //button[@data-test-action="Delete Project"]
   Wait Until Page Contains Element      //div[@class="modal-header"]    10

--- a/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/Pods/Pods.robot
@@ -24,7 +24,7 @@ Get Pod Logs From UI
     ${log_lines_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
     ...    xpath://div[@class='log-window__lines']
     ${log_list_flag}=    Run Keyword And Return Status    Wait Until Page Contains Element
-    ...    xpath://div[@class='pf-v5-c-log-viewer__list']
+    ...    xpath://div[@class='pf-v6-c-log-viewer__list']
     IF    ${log_lines_flag} == ${TRUE}
         ${logs_text}=    Get Text    xpath://div[@class='log-window__lines']
     ELSE IF    ${log_list_flag} == ${TRUE}

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -19,7 +19,7 @@ ${JUPYTERHUB_DROPDOWN_XPATH} =    //button[@aria-label="Options menu"]
 ${KFNBC_CONTAINER_SIZE_TITLE} =    //div[.="Deployment size"]/..//span[.="Container Size"]
 ${KFNBC_CONTAINER_SIZE_DROPDOWN_XPATH} =  //label[@for="modal-notebook-container-size"]/../..//button[@aria-label="Options menu"]
 ${KFNBC_ACCELERATOR_HEADER_XPATH} =    //span[text()='Accelerator']
-${KFNBC_ACCELERATOR_DROPDOWN_XPATH} =    //label[@for='modal-notebook-accelerator']/ancestor::div[@class='pf-v5-c-form__group']/descendant::button
+${KFNBC_ACCELERATOR_DROPDOWN_XPATH} =    //label[@for='modal-notebook-accelerator']/ancestor::div[@class='pf-v6-c-form__group']/descendant::button
 ${KFNBC_ACCELERATOR_INPUT_XPATH} =    //input[@aria-label='Number of accelerators']
 ${KFNBC_ACCELERATOR_LESS_BUTTON_XPATH} =    ${KFNBC_ACCELERATOR_INPUT_XPATH}/parent::*/parent::*/preceding-sibling::*//button
 ${KFNBC_ACCELERATOR_PLUS_BUTTON_XPATH} =    ${KFNBC_ACCELERATOR_INPUT_XPATH}/parent::*/parent::*/following-sibling::*//button
@@ -29,7 +29,7 @@ ${KFNBC_MODAL_CANCEL_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[.="Cancel"]
 ${KFNBC_MODAL_CLOSE_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[.="Close"]
 ${KFNBC_MODAL_X_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[@aria-label="Close"]
 ${KFNBC_CONTROL_PANEL_HEADER_XPATH} =    //h1[.="Notebook server control panel"]
-${KFNBC_ENV_VAR_NAME_PRE} =    //span[.="Variable name"]/../../../div[@class="pf-v5-c-form__group-control"]
+${KFNBC_ENV_VAR_NAME_PRE} =    //span[.="Variable name"]/../../../div[@class="pf-v6-c-form__group-control"]
 ${DEFAULT_PYTHON_VER} =    3.11
 ${PREVIOUS_PYTHON_VER} =    3.9
 ${DEFAULT_NOTEBOOK_VER} =    2024.2
@@ -601,7 +601,7 @@ Fetch Image Tooltip Info
     [Documentation]    Fetches libraries in image tooltip text
     [Arguments]    ${img}
     ${xpath_img_tooltip} =    Set Variable    //input[contains(@id, "${img}")]/../label//div[@class=""][.=""]
-    ${xpath_tooltip_items} =    Set Variable    //div[@class='pf-v5-c-popover__body']/p
+    ${xpath_tooltip_items} =    Set Variable    //div[@class='pf-v6-c-popover__body']/p
     @{tmp_list} =    Create List
     Click Element    ${xpath_img_tooltip}
     ${libs} =    Get Element Count    ${xpath_tooltip_items}
@@ -670,7 +670,7 @@ Get List Of All Available Container Size
     ${size}    Create List
     #Click Element  xpath://div[contains(concat(' ',normalize-space(@class),' '),' jsp-spawner__size_options__select ')]\[1]
     Click Element  xpath://button[@aria-label="Options menu"][1]
-    ${link_elements}   Get WebElements  xpath://*[@class="pf-v5-c-select__menu-item-main"]
+    ${link_elements}   Get WebElements  xpath://*[@class="pf-v6-c-select__menu-item-main"]
     FOR  ${idx}  ${ext_link}  IN ENUMERATE  @{link_elements}  start=1
           ${text}      Get Text    ${ext_link}
           Append To List    ${size}     ${text}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -13,28 +13,28 @@ Library       JupyterLibrary
 # This variable is overriden for ODH runs via 'test-variables-odh-overwrite.yml'
 ${ODH_DASHBOARD_PROJECT_NAME}=   Red Hat OpenShift AI
 ${ODH_DASHBOARD_SPINNER_XP}=     xpath://*[@data-id="loading-empty-state" or @aria-valuetext="Loading..."]
-${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-v5-c-drawer__panel-main"]//button[.='Enable']
-${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-v5-c-drawer__panel-main"]//*[.='Get started']
-${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-v5-c-card'))]
+${ODH_DASHBOARD_SIDEBAR_HEADER_ENABLE_BUTTON}=         //*[@class="pf-v6-c-drawer__panel-main"]//button[.='Enable']
+${ODH_DASHBOARD_SIDEBAR_HEADER_GET_STARTED_ELEMENT}=   //*[@class="pf-v6-c-drawer__panel-main"]//*[.='Get started']
+${CARDS_XP}=  //*[(contains(@class, 'odh-card')) and (contains(@class, 'pf-v6-c-card'))]
 ${CARD_BUTTON_XP}=  //input[@name="odh-explore-selectable-card"]
 ${RES_CARDS_XP}=  //div[contains(@data-ouia-component-type, "Card")]
 ${JUPYTER_CARD_XP}=    //div[@data-testid="card jupyter"]
 ${EXPLORE_PANEL_XP}=    //div[@data-testid="explore-drawer-panel"]
-${HEADER_XP}=  div[@class='pf-v5-c-card__header']
-${TITLE_XP}=   div[@class='pf-v5-c-card__title']//span
-${TITLE_XP_OLD}=  div[@class='pf-v5-c-card__title']//div/div[1]
-${PROVIDER_XP}=  div[@class='pf-v5-c-card__title']//span[contains(@class, "provider")]
-${DESCR_XP}=  div[@class='pf-v5-c-card__body']
+${HEADER_XP}=  div[@class='pf-v6-c-card__header']
+${TITLE_XP}=   div[@class='pf-v6-c-card__title']//span
+${TITLE_XP_OLD}=  div[@class='pf-v6-c-card__title']//div/div[1]
+${PROVIDER_XP}=  div[@class='pf-v6-c-card__title']//span[contains(@class, "provider")]
+${DESCR_XP}=  div[@class='pf-v6-c-card__body']
 ${BADGES_XP}=  ${HEADER_XP}//div[contains(@class, 'badge') or contains(@class, 'coming-soon')]
 ${BADGES_XP_OLD}=  ${HEADER_XP}/div[contains(@class, 'badges')]/span[contains(@class, 'badge') or contains(@class, 'coming-soon')]
-${OFFICIAL_BADGE_XP}=  div[@class='pf-v5-c-card__title']//img
-${OFFICIAL_BADGE_XP_OLD}=  div[@class='pf-v5-c-card__title']//img[contains(@class, 'supported-image')]    # robocop: disable
+${OFFICIAL_BADGE_XP}=  div[@class='pf-v6-c-card__title']//img
+${OFFICIAL_BADGE_XP_OLD}=  div[@class='pf-v6-c-card__title']//img[contains(@class, 'supported-image')]    # robocop: disable
 ${FALLBK_IMAGE_XP}=  ${HEADER_XP}/svg[contains(@class, 'odh-card__header-fallback-img')]
 ${IMAGE_XP}=  ${HEADER_XP}//picture[contains(@class,'pf-m-picture')]/source
 ${IMAGE_XP_OLD}=  ${HEADER_XP}/img[contains(@class, 'odh-card__header-brand')]
 ${APPS_DICT_PATH_LATEST}=   tests/Resources/Files/AppsInfoDictionary_latest.json
 ${SIDEBAR_TEXT_CONTAINER_XP}=  //div[contains(@class,'odh-markdown-view')]
-${SUCCESS_MSG_XP}=  //div[@class='pf-v5-c-alert pf-m-success']
+${SUCCESS_MSG_XP}=  //div[@class='pf-v6-c-alert pf-m-success']
 ${PAGE_TITLE_XP}=  //*[@data-testid="app-page-title"]
 ${CLUSTER_SETTINGS_XP}=  //*[@data-testid="app-page-title" and text()="Cluster settings"]
 ${PVC_SIZE_INPUT_XP}=           xpath=//*[@data-testid="pvc-size-input"]
@@ -48,11 +48,11 @@ ${CUSTOM_IMAGE_LAST_ROW_NAME}=  tr[last()]/td[1]
 ${CUSTOM_IMAGE_LAST_ROW_VERSION}=  tr[last()]/td[2]
 ${CUSTOM_IMAGE_EDIT_BTN}=  button[@id="edit-package-software-button"]
 ${CUSTOM_IMAGE_REMOVE_BTN}=  button[@id="delete-package-software-button"]
-${NOTIFICATION_DRAWER_CLOSE_BTN}=  //div[@class="pf-v5-c-drawer__panel"]/div/div//button
-${NOTIFICATION_DRAWER_CLOSED}=  //div[@class="pf-v5-c-drawer__panel" and @hidden=""]
+${NOTIFICATION_DRAWER_CLOSE_BTN}=  //div[@class="pf-v6-c-drawer__panel"]/div/div//button
+${NOTIFICATION_DRAWER_CLOSED}=  //div[@class="pf-v6-c-drawer__panel" and @hidden=""]
 ${GROUPS_CONFIG_CM}=    groups-config
 ${RHODS_GROUPS_CONFIG_CM}=    rhods-groups-config
-${RHODS_LOGO_XPATH}=    //img[@alt="${ODH_DASHBOARD_PROJECT_NAME} Logo"]
+${RHODS_LOGO_XPATH}=    //img[@alt="${ODH_DASHBOARD_PROJECT_NAME}"]
 ${USER_MENU_TOGGLE}=    //button[@id="user-menu-toggle"]
 ${LOGOUT_BTN}=    //button[.="Log out"]
 @{ISV_TO_REMOVE_SELF_MANAGED}=      Create List     starburst   nvidia    rhoam
@@ -122,7 +122,7 @@ Wait For Dashboard Page Title
 Wait Until RHODS Dashboard ${dashboard_app} Is Visible
   # Ideally the timeout would be an arg but Robot does not allow "normal" and "embedded" arguments
   # Setting timeout to 30seconds since anything beyond that should be flagged as a UI bug
-  Wait Until Element Is Visible    xpath://div[contains(@class,'gallery')]/div//div[@class="pf-v5-c-card__title"]//*[text()="${dashboard_app}"]
+  Wait Until Element Is Visible    xpath://div[contains(@class,'gallery')]/div//div[@class="pf-v6-c-card__title"]//*[text()="${dashboard_app}"]
   ...    timeout=30s
 
 Launch ${dashboard_app} From RHODS Dashboard Link
@@ -134,9 +134,9 @@ Launch ${dashboard_app} From RHODS Dashboard Link
       Click Link   xpath:${CARDS_XP}//*[text()='${splits[0]} ']/../..//a
   ELSE
       IF    "${dashboard_app}" == "Jupyter"
-          Click Link    xpath://div[contains(@class,'pf-v5-l-gallery')]/div[contains(@class,'pf-v5-c-card')]/div[@class="pf-v5-c-card__title"]//span[text()="${dashboard_app}"]/../../..//div[contains(@class,"pf-v5-c-card__footer")]/a
+          Click Link    xpath://div[contains(@class,'pf-v6-l-gallery')]/div[contains(@class,'pf-v6-c-card')]/div[@class="pf-v6-c-card__title"]//span[text()="${dashboard_app}"]/../../..//div[contains(@class,"pf-v6-c-card__footer")]/a
       ELSE
-          Click Link    xpath://div[contains(@class,'pf-v5-l-gallery')]/div[contains(@class,'pf-v5-c-card')]/div[@class="pf-v5-c-card__title"]//span[text()="${dashboard_app}"]/../..//div[contains(@class,"pf-v5-c-card__footer")]/a
+          Click Link    xpath://div[contains(@class,'pf-v6-l-gallery')]/div[contains(@class,'pf-v6-c-card')]/div[@class="pf-v6-c-card__title"]//span[text()="${dashboard_app}"]/../..//div[contains(@class,"pf-v6-c-card__footer")]/a
       END
   END
   IF    "${dashboard_app}" != "Jupyter"
@@ -145,8 +145,8 @@ Launch ${dashboard_app} From RHODS Dashboard Link
 
 Launch ${dashboard_app} From RHODS Dashboard Dropdown
   Wait Until RHODS Dashboard ${dashboard_app} Is Visible
-  Click Button  xpath://div[@class="pf-v5-c-card__title" and .="${dashboard_app}"]/..//button[contains(@class,pf-v5-c-dropdown__toggle)]
-  Click Link  xpath://div[@class="pf-v5-c-card__title" and .="${dashboard_app}"]/..//a[.="Launch"]
+  Click Button  xpath://div[@class="pf-v6-c-card__title" and .="${dashboard_app}"]/..//button[contains(@class,pf-v6-c-dropdown__toggle)]
+  Click Link  xpath://div[@class="pf-v6-c-card__title" and .="${dashboard_app}"]/..//a[.="Launch"]
   Switch Window  NEW
 
 Verify Service Is Enabled
@@ -347,7 +347,7 @@ Open Get Started Sidebar And Return Status
     Mouse Down    ${card_locator}
     Mouse Up    ${card_locator}
     ${status}=    Run Keyword And Return Status    Wait Until Page Contains Element
-    ...    xpath://div[contains(@class,'pf-v5-c-drawer__panel-main')]
+    ...    xpath://div[contains(@class,'pf-v6-c-drawer__panel-main')]
     Sleep  1
     RETURN  ${status}
 
@@ -364,7 +364,7 @@ Check Get Started Sidebar Status
     END
 
 Get Sidebar Links
-    ${link_elements}=  Get WebElements    xpath://div[contains(@class,'pf-v5-c-drawer__panel-main')]//a
+    ${link_elements}=  Get WebElements    xpath://div[contains(@class,'pf-v6-c-drawer__panel-main')]//a
     RETURN  ${link_elements}
 
 Check Sidebar Links
@@ -409,7 +409,7 @@ Check Sidebar Header Text
     ...    message=Missing Sidebar Title for App Card ${app_id}
     ${header}=  Get Text    xpath:${SIDEBAR_TEXT_CONTAINER_XP}/h1
     Run Keyword And Continue On Failure  Should Be Equal  ${header}  ${sidebar_h1}
-    ${getstarted_title}=  Get Text  xpath://div[contains(@class,'pf-v5-c-drawer__head')]
+    ${getstarted_title}=  Get Text  xpath://div[contains(@class,'pf-v6-c-drawer__head')]
     ${titles}=    Split String    ${getstarted_title}   separator=\n    max_split=1
     Run Keyword And Continue On Failure  Should Be Equal   ${titles[0]}  ${expected_data}[${app_id}][title]
     Run Keyword And Continue On Failure  Should Be Equal   ${titles[1]}  ${expected_data}[${app_id}][provider]
@@ -538,9 +538,9 @@ Search Items In Resources Section
     Sleep   5
     ${version-check}=  Is RHODS Version Greater Or Equal Than    1.18.0
     IF    ${version-check} == True
-        Input Text  xpath://input[@class="pf-v5-c-text-input-group__text-input"]       ${element}
+        Input Text  xpath://input[@class="pf-v6-c-text-input-group__text-input"]       ${element}
     ELSE
-        Input Text  xpath://input[@class="pf-v5-c-search-input__text-input"]       ${element}
+        Input Text  xpath://input[@class="pf-v6-c-search-input__text-input"]       ${element}
     END
 
 Verify Username Displayed On RHODS Dashboard

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -192,7 +192,7 @@ Get Pipeline Run Step Log
     # the logs are full loaded when "The log window displays partial content" the message appeared
     Wait Until Page Contains Element    xpath=//h2[text()='The log window displays partial content']
     Capture Page Screenshot
-    ${log_with_tags}=    Get Element Attribute    xpath://div[@class="pf-v5-c-log-viewer__list"]    innerHTML
+    ${log_with_tags}=    Get Element Attribute    xpath://div[@class="pf-v6-c-log-viewer__list"]    innerHTML
     Log    ${log_with_tags}
     # we close the modal otherwise any othe step in the test case will need to close it
     Click Element    xpath=//button[@aria-label="Close drawer panel"]
@@ -202,7 +202,7 @@ Verify Pipeline Run Is Completed
     [Documentation]    Open the Pipeline detail and wait for the Completed Status
     [Arguments]    ${pipeline_run_name}    ${timeout}=10m   ${experiment_name}=Default
     Open Pipeline Run    ${pipeline_run_name}    ${experiment_name}
-    Wait Until Page Contains Element    //span[@class='pf-v5-c-label__text' and text()='Succeeded']    timeout=${timeout}
+    Wait Until Page Contains Element    //span[@class='pf-v6-c-label__text' and text()='Succeeded']    timeout=${timeout}
     Capture Page Screenshot
 
 # robocop: disable:line-too-long

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
@@ -16,7 +16,7 @@ ${S3_BUCKET_DC_INPUT_XP}=     xpath=//input[@aria-label="AWS field AWS_S3_BUCKET
 ${REPLICAS_PLUS_BTN_XP}=         xpath=//div/button[@aria-label="Plus"]
 ${REPLICAS_MIN_BTN_XP}=         xpath=//div/button[@aria-label="Minus"]
 ${SERVING_RUNTIME_NAME}=        xpath=//input[@id="serving-runtime-name-input"]
-${SERVING_ACCELERATOR_DROPDOWN_XPATH}=    xpath=//label[@for='modal-notebook-accelerator']/ancestor::div[@class='pf-v5-c-form__group-control']/descendant::button
+${SERVING_ACCELERATOR_DROPDOWN_XPATH}=    xpath=//label[@for='modal-notebook-accelerator']/ancestor::div[@class='pf-v6-c-form__group-control']/descendant::button
 ${SERVING_ACCELERATOR_INPUT_XPATH}=    xpath=//input[@aria-label='Number of accelerators']
 ${SERVING_ACCELERATOR_MINUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/preceding-sibling::button
 ${SERVING_ACCELERATOR_PLUS_BUTTON_XPATH}=    xpath=${SERVING_ACCELERATOR_INPUT_XPATH}/following-sibling::button

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -184,7 +184,7 @@ Pipeline Yaml Should Be Readonly
     Click Link      ${pipeline_name}
     Click Element     //button[@aria-label="Pipeline YAML Tab"]
     Press Keys    //div[contains(@class, 'lines-content')]    cannot_enter_read_only
-    Wait Until Element Is Visible    //div[@class="pf-v5-c-code-editor pf-m-read-only odh-dashboard__code-editor"]    timeout=10
+    Wait Until Element Is Visible    //div[@class="pf-v6-c-code-editor pf-m-read-only odh-dashboard__code-editor"]    timeout=10
     Capture Page Screenshot
     SeleniumLibrary.Set Selenium Implicit Wait    ${orig wait}
 

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
@@ -23,7 +23,7 @@ ${MS_TABLE_PROJECT}=    /../../td[@data-label="Project"]
 ${MS_TABLE_ENDPOINT_INPUT}=    /ancestor::tr//td[@data-label="Inference endpoint"]//input[contains(@id,"text-input-")]
 ${MS_TABLE_STATUS_SUCCESS}=     /ancestor::tr//td[@data-label="Status"]//span[contains(@class,"pf-m-success")]
 ${MS_TABLE_STATUS_FAILURE}=     /ancestor::tr//td[@data-label="Status"]//span[contains(@class,"pf-m-danger")]
-${KSERVE_MODAL_HEADER}=    //header[@class="pf-v5-c-modal-box__header"]/h1[.="Deploy model"]
+${KSERVE_MODAL_HEADER}=    //header[@class="pf-v6-c-modal-box__header"]/h1[.="Deploy model"]
 ${KSERVE_RUNTIME_DROPDOWN}=    //button[@data-testid="serving-runtime-template-selection"]
 ${LLM_RESOURCES_DIRPATH}=    tests/Resources/Files/llm
 ${DEPLOY_SINGLE_SV_MODEL_BTN}=    //button[@data-testid="single-serving-select-button"]
@@ -160,9 +160,9 @@ Select Existing Data Connection
     [Arguments]    ${data_connection_name}    ${retries}=1
 
     FOR  ${retry_idx}  IN RANGE  0  1+${retries}
-        Click Element    xpath://button[@class="pf-v5-c-menu-toggle__button"]
-        Click Element    xpath://button[@class="pf-v5-c-menu__item"]/span/span[contains(., "${data_connection_name}")]
-        ${selected}=    Get Element Attribute    //span[@class="pf-v5-c-text-input-group__text"]/input    value
+        Click Element    xpath://button[@class="pf-v6-c-menu-toggle__button"]
+        Click Element    xpath://button[@class="pf-v6-c-menu__item"]/span/span[contains(., "${data_connection_name}")]
+        ${selected}=    Get Element Attribute    //span[@class="pf-v6-c-text-input-group__text"]/input    value
         IF  "${selected}"=="${data_connection_name}"
             BREAK
         END

--- a/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0102__billing_metrics.robot
+++ b/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0102__billing_metrics.robot
@@ -137,7 +137,7 @@ Test Setup For Matrics Web Test
     Wait Until OpenShift Console Is Loaded
     Click Button    Observe
     Click Link    Metrics
-    Wait Until Element Is Visible    xpath://textarea[@class="pf-v5-c-form-control query-browser__query-input"]
+    Wait Until Element Is Visible    xpath://textarea[@class="pf-v6-c-form-control query-browser__query-input"]
 
 Test Teardown For Matrics Web Test
     [Documentation]     Closes all browsers
@@ -146,10 +146,10 @@ Test Teardown For Matrics Web Test
 Run Query On Metrics And Return Value
     [Documentation]    Fires query in metrics through web browser and returns value
     [Arguments]    ${query}    ${count_of_columns}    # count of columns + 1 like name,values example: ${count_of_columns}=3
-    Input Text    xpath://textarea[@class="pf-v5-c-form-control query-browser__query-input"]    ${query}
+    Input Text    xpath://textarea[@class="pf-v6-c-form-control query-browser__query-input"]    ${query}
     Click Button    Run queries
-    Wait Until Element is Visible    xpath://table[@class="pf-v5-c-table pf-m-compact"]    timeout=15seconds
-    @{data} =    Get WebElements    //table[@class="pf-v5-c-table pf-m-compact"] //tbody/tr/td[${count_of_columns}]
+    Wait Until Element is Visible    xpath://table[@class="pf-v6-c-table pf-m-compact"]    timeout=15seconds
+    @{data} =    Get WebElements    //table[@class="pf-v6-c-table pf-m-compact"] //tbody/tr/td[${count_of_columns}]
     RETURN    ${data[0].text}
 
 Fire Query On RHODS Prometheus And Return Value

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0404__ods_dashboard_resources.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0404__ods_dashboard_resources.robot
@@ -17,7 +17,7 @@ Test Tags         Dashboard
 ...                       pachyderm-beginner-tutorial-notebook    using-starburst-enterprise
 ...                       create-aikit-notebook    openvino-inference-notebook
 @{LIST_OF_IDS_FOR_COMBINATIONS}    documentation--check-box    Red Hat managed--check-box
-${SUCCESS_STEP}    h3[normalize-space(@class="pf-v5-c-title pf-m-md pfext-quick-start-task-header__title
+${SUCCESS_STEP}    h3[normalize-space(@class="pf-v6-c-title pf-m-md pfext-quick-start-task-header__title
 ...                pfext-quick-start-task-header__title-success")]
 
 
@@ -193,7 +193,7 @@ Set Expected Items Based On RHODS Type    # robocop: disable
 Validate App Name Is Present On Each Tile
     [Documentation]    Check that each Resource tile contains
     ...    the name of the application
-    ${elements}=    Get WebElements    //article[contains(@class, 'pf-v5-c-card')]//div[@class="pf-v5-c-content"]//small
+    ${elements}=    Get WebElements    //article[contains(@class, 'pf-v6-c-card')]//div[@class="pf-v6-c-content"]//small
     ${len}=    Get Length    ${elements}
     FOR    ${counter}    IN RANGE    ${len}
         ${name}=    Get Text    ${elements}[${counter}]
@@ -227,7 +227,7 @@ Verify Quick Starts Work As Expected When Restarted And Left In Between
         Run Keyword And Continue On Failure     Link Text On QuickStart Card Should Be  element=${element}
         ...    exp_link_text=Restart
         Open QuickStart Element In Resource Section By Name     ${element}
-        Page Should Not Contain    //article[@id="${element}"]//span[@class="pf-v5-c-label pf-m-green pf-m-outline"]
+        Page Should Not Contain    //article[@id="${element}"]//span[@class="pf-v6-c-label pf-m-green pf-m-outline"]
         ${count}=   Get The Count Of QuickStart Steps
         Run Keyword And Continue On Failure     Click Button    //button[@data-testid="qs-drawer-start"]
         Run Keyword And Continue On Failure     Wait Until Page Contains Element
@@ -247,7 +247,7 @@ Verify Quick Starts Work As Expected When Restarted And Left In Between
         Run Keyword And Continue On Failure     Click Element
         ...    //*[@id="${element}"]//button[@data-testid="quick-start-button"]
         Run Keyword And Continue On Failure     Wait Until Page Contains Element
-        ...    //div[@class="pf-v5-c-drawer__panel-main"]     5
+        ...    //div[@class="pf-v6-c-drawer__panel-main"]     5
         FOR     ${index}    IN RANGE    ${half_count}
             Run Keyword And Continue On Failure     Page Should Contain Element
             ...    //div[@class="pfext-quick-start-tasks__list"]//li[${index+1}]//${SUCCESS_STEP}
@@ -255,7 +255,7 @@ Verify Quick Starts Work As Expected When Restarted And Left In Between
         Run Keyword And Continue On Failure     Click Button    //button[@data-testid="qs-drawer-side-note-action"]
         FOR     ${index}    IN RANGE    ${count}
             Run Keyword And Continue On Failure     Page Should Contain Element
-            ...    //ul[@class="pf-v5-c-list pfext-quick-start-task-header__list"]/li[${index}+1]
+            ...    //ul[@class="pf-v6-c-list pfext-quick-start-task-header__list"]/li[${index}+1]
         END
         Run Keyword And Continue On Failure    Click Button        //button[@data-testid="qs-drawer-start"]
         FOR     ${index}    IN RANGE    ${count}

--- a/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
+++ b/ods_ci/tests/Tests/0400__ods_dashboard/0410__ods_dashboard_projects/0410__ods_dashboard_projects.robot
@@ -723,7 +723,7 @@ Environment Variables Should Be Displayed According To Their Type
 Environment Variable Type Should Be
     [Arguments]    ${expected_type}    ${var_idx}
     ${displayed_type}=    Get Text
-    ...    ${ENV_VARIABLES_SECTION_XP}/div[(contains(@class, "-l-split"))][${var_idx}]//div[contains(@class,"pf-v5-c-select")]/button//span[contains(@class,'toggle-text')]  # robocop: disable:line-too-long
+    ...    ${ENV_VARIABLES_SECTION_XP}/div[(contains(@class, "-l-split"))][${var_idx}]//div[contains(@class,"pf-v6-c-select")]/button//span[contains(@class,'toggle-text')]  # robocop: disable:line-too-long
     Run Keyword And Continue On Failure    Should Be Equal As Strings    ${displayed_type}    ${expected_type}
 
 Environment Variable Key/Value Fields Should Be Correctly Displayed

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
@@ -190,13 +190,13 @@ Verify Requested resources When Multiple Local Queue Exists
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingCPU-ChartLabel-title"]    timeout=180
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingCPU-ChartLegend-ChartLabel-0"]   timeout=180
     ${cpu_usage} =    Get Current CPU Usage    ${PRJ_TITLE}    Job
-    ${cpu_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v5-chart-donut--label--title--Fill')]])[1]
+    ${cpu_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v6-chart-donut--label--title--Fill')]])[1]
     Check Resource Consuming Usage    ${cpu_usage}    ${cpu_consuming}    CPU
 
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingMemory-ChartLabel-title"]    timeout=180
     Wait Until Element Is Visible    xpath=//*[@id="topResourceConsumingMemory-ChartLegend-ChartLabel-0"]    timeout=180
     ${memory_usage} =    Get Current Memory Usage    ${PRJ_TITLE}    Job
-    ${memory_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v5-chart-donut--label--title--Fill')]])[2]
+    ${memory_consuming} =    Get Text    xpath:(//*[@style[contains(., 'var(--pf-v6-chart-donut--label--title--Fill')]])[2]
     Check Resource Consuming Usage    ${memory_usage}    ${memory_consuming}    Memory
 
     Wait For Job With Status    ${JOB_NAME_QUEUE}    Succeeded    180

--- a/ods_ci/tests/Tests/2000__other_components/600__ai_apps/680__starburst/680__starburst_galaxy.robot
+++ b/ods_ci/tests/Tests/2000__other_components/600__ai_apps/680__starburst/680__starburst_galaxy.robot
@@ -13,7 +13,7 @@ Test Tags           ExcludeOnODH
 
 *** Variables ***
 ${SB_CARDS_XP}=     //div[@id="starburst"]
-${SB_BETA_DESC}=    //*[@class="pf-v5-c-drawer__panel-main"]//div[@class="pf-v5-c-alert pf-m-inline pf-m-info"]
+${SB_BETA_DESC}=    //*[@class="pf-v6-c-drawer__panel-main"]//div[@class="pf-v6-c-alert pf-m-inline pf-m-info"]
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/2000__other_components/700__sandbox/700__sandbox.robot
+++ b/ods_ci/tests/Tests/2000__other_components/700__sandbox/700__sandbox.robot
@@ -64,8 +64,8 @@ Verify That Idle JupyterLab Servers Are Culled In Sandbox Environment After 24h
 Check Only OpenShift Link Is Present In Application Launcher
      [Documentation]  Capture and check if only Openshift link is present
      Click Element     //button[@aria-label="Application launcher"]
-     Wait Until Element Is Visible        //a[@class="pf-m-external pf-v5-c-app-launcher__menu-item"]
-     ${link_elements}  Get WebElements    //a[@class='pf-m-external pf-v5-c-app-launcher__menu-item']
+     Wait Until Element Is Visible        //a[@class="pf-m-external pf-v6-c-app-launcher__menu-item"]
+     ${link_elements}  Get WebElements    //a[@class='pf-m-external pf-v6-c-app-launcher__menu-item']
      ${length}         Get Length    ${link_elements}
      ${href}   Get Element Attribute    ${link_elements}    href
      ${length}         Get Length    ${link_elements}
@@ -87,7 +87,7 @@ Available Container Sizes Should Be
 
 Verify None Of The Card Are Enabled
     [Documentation]    Verify none of the cards available in explore section is enabled
-    ${link_elements}  Get WebElements    //div[@class="pf-v5-c-card pf-m-selectable odh-card"]
+    ${link_elements}  Get WebElements    //div[@class="pf-v6-c-card pf-m-selectable odh-card"]
     ${length}      Get Length    ${link_elements}
     IF  ${length} != ${0}    Fail     '${length}' tiles in Explore section is Enabled
 
@@ -95,7 +95,7 @@ Verify Support Link Is Not Present in RHODS Dashbaord
     [Documentation]   Check suppurt url is not present in the sandbox RHODS dashabord
     Click Element    xpath=//*[@id="toggle-id"]
     ${links_available}   Get WebElements
-    ...    //a[@class="odh-dashboard__external-link pf-v5-c-dropdown__menu-item" and not(starts-with(@href, '#'))]
+    ...    //a[@class="odh-dashboard__external-link pf-v6-c-dropdown__menu-item" and not(starts-with(@href, '#'))]
     FOR  ${link}  IN  @{links_available}
          ${href}    Get Element Attribute    ${link}    href
          Run Keyword And Continue On Failure   Should Not Contain   ${href}   support   ignore_case=True


### PR DESCRIPTION
This is for [RHOAIENG-16689](https://issues.redhat.com/browse/RHOAIENG-16689)

Besides fixing all hardcoded xpaths of `pf5` to `pf6`, it is also fixing the global suites setup failure on RHOAI login, due to RHOAI image (alt) renamed.

![image](https://github.com/user-attachments/assets/ea8ed4b5-9bf9-4048-bcd0-8016b9e110b7)
