### PR TITLE
[2.15.0] update the install type to cli instead of CLi

### DIFF
--- a/ods_ci/rhods_install_configuration.yaml.example
+++ b/ods_ci/rhods_install_configuration.yaml.example
@@ -1,5 +1,5 @@
 RHODS_INSTALL:
-    INSTALL_TYPE: CLi
+    INSTALL_TYPE: Cli
     TEST_ENV: AWS
     cluster_type: managed
     operator_version: quay.io/modh/qe-catalog-source:latest

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -44,7 +44,7 @@ Install RHODS
       ${csv_display_name} =    Set Variable    ${RHODS_CSV_DISPLAY}
   END
   IF  "${cluster_type}" == "selfmanaged"
-      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi"
+      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "Cli"
              Install RHODS In Self Managed Cluster Using CLI  ${cluster_type}     ${image_url}
       ELSE IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "OperatorHub"
           ${file_path} =    Set Variable    tasks/Resources/RHODS_OLM/install/
@@ -63,12 +63,12 @@ Install RHODS
            FAIL    Provided test environment and install type is not supported
       END
   ELSE IF  "${cluster_type}" == "managed"
-      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi" and "${UPDATE_CHANNEL}" == "odh-nightlies"
+      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "Cli" and "${UPDATE_CHANNEL}" == "odh-nightlies"
           # odh-nightly is not build for Managed, it is only possible for Self-Managed
           Set Global Variable    ${OPERATOR_NAMESPACE}    openshift-marketplace
           Install RHODS In Self Managed Cluster Using CLI  ${cluster_type}     ${image_url}
           Set Global Variable    ${OPERATOR_NAME}         opendatahub-operator
-      ELSE IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi"
+      ELSE IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "Cli"
           Install RHODS In Managed Cluster Using CLI  ${cluster_type}     ${image_url}
       ELSE
           FAIL    Provided test environment is not supported

--- a/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
@@ -2,7 +2,7 @@
 Is RHODS Installed
   Log   Checking if RHODS is installed with "${clusterType}" "${UPDATE_CHANNEL}" "${INSTALL_TYPE}"      console=yes
   IF  "${cluster_type}" == "selfmanaged"
-      IF  "${INSTALL_TYPE}" == "CLi"
+      IF  "${INSTALL_TYPE}" == "Cli"
           ${result}=  Run Keyword And Return Status
           ...  Run Keywords
           ...  Check A RHODS Family Operator Is Installed  namespace=${OPERATOR_NAMESPACE}

--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -40,7 +40,7 @@ Uninstall RHODS In OSD
 
 Uninstall RHODS In Self Managed Cluster
   [Documentation]  Uninstall rhods from self-managed cluster
-  IF  "${INSTALL_TYPE}" == "CLi"
+  IF  "${INSTALL_TYPE}" == "Cli"
       Uninstall RHODS In Self Managed Cluster Using CLI
   ELSE IF  "${INSTALL_TYPE}" == "OperatorHub"
       Uninstall RHODS In Self Managed Cluster For Operatorhub

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0110__service_mesh.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0110__service_mesh.robot
@@ -18,7 +18,7 @@ ${SERVICE_MESH_OPERATOR_NS}                 openshift-operators
 ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
 ${SERVICE_MESH_CR_NS}                       istio-system
 ${SERVICE_MESH_CR_NAME}                     data-science-smcp
-${INSTALL_TYPE}                             CLi
+${INSTALL_TYPE}                             Cli
 ${TEST_ENV}                                 PSI
 ${IS_PRESENT}                               0
 ${IS_NOT_PRESENT}                           1

--- a/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
@@ -19,7 +19,7 @@ ${SERVICE_MESH_OPERATOR_DEPLOYMENT_NAME}    istio-operator
 ${SERVICE_MESH_CR_NS}                       istio-system
 ${SERVICE_MESH_CR_NAME}                     data-science-smcp
 ${OLM_DIR}                                  olm
-${INSTALL_TYPE}                             CLi
+${INSTALL_TYPE}                             Cli
 ${TEST_ENV}                                 PSI
 ${IS_PRESENT}                               0
 ${IS_NOT_PRESENT}                           1


### PR DESCRIPTION
To make it easier to use the Install/Uninstall type which currently is CLi in part of the code and Cli in another part of the code.
changing it from CLi to Cli everywhere.

related to Jira ticket: RHOAIENG-2720

cherry-picked https://github.com/red-hat-data-services/ods-ci/pull/2144