### PR TITLE
[2.8.0] update the install type to cli instead of CLi

### DIFF
--- a/ods_ci/rhods_install_configuration.yaml.example
+++ b/ods_ci/rhods_install_configuration.yaml.example
@@ -1,5 +1,5 @@
 RHODS_INSTALL:
-    INSTALL_TYPE: CLi
+    INSTALL_TYPE: Cli
     TEST_ENV: AWS
     cluster_type: managed
     operator_version: quay.io/modh/qe-catalog-source:latest

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -24,7 +24,7 @@ Install RHODS
   Clone OLM Install Repo
   ${csv_display_name} =    Set Variable    ${RHODS_CSV_DISPLAY}
   IF  "${cluster_type}" == "selfmanaged"
-      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi"
+      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "Cli"
             IF  "${UPDATE_CHANNEL}" != "odh-nightlies"
                  Install RHODS In Self Managed Cluster Using CLI  ${cluster_type}     ${image_url}
             ELSE
@@ -42,7 +42,7 @@ Install RHODS
            FAIL    Provided test envrioment and install type is not supported
       END
   ELSE IF  "${cluster_type}" == "managed"
-      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "CLi"
+      IF  "${TEST_ENV}" in "${SUPPORTED_TEST_ENV}" and "${INSTALL_TYPE}" == "Cli"
            IF  "${UPDATE_CHANNEL}" != "odh-nightlies"
                 Install RHODS In Managed Cluster Using CLI  ${cluster_type}     ${image_url}
            ELSE

--- a/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/pre-tasks/oc_is_operator_installed.robot
@@ -11,7 +11,7 @@ Is RHODS Installed
           ...  Oc Get  kind=CatalogSource  namespace=openshift-marketplace
           ...          field_selector=metadata.name=redhat-operators
       ELSE
-          IF  "${INSTALL_TYPE}" == "CLi"
+          IF  "${INSTALL_TYPE}" == "Cli"
               ${result}=  Run Keyword And Return Status
               ...  Run Keywords
               ...  Check A RHODS Family Operator Is Installed  namespace=redhat-ods-operator

--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -33,7 +33,7 @@ Uninstall RHODS In OSD
 
 Uninstall RHODS In Self Managed Cluster
   [Documentation]  Uninstall rhods from self-managed cluster
-  IF  "${INSTALL_TYPE}" == "CLi"
+  IF  "${INSTALL_TYPE}" == "Cli"
       Uninstall RHODS In Self Managed Cluster Using CLI
   ELSE IF  "${INSTALL_TYPE}" == "OperatorHub"
       Uninstall RHODS In Self Managed Cluster For Operatorhub


### PR DESCRIPTION
To make it easier to use the Install/Uninstall type which currently is CLi in part of the code and Cli in another part of the code.
changing it from CLi to Cli everywhere.

related to Jira ticket: RHOAIENG-2720