### PR TITLE
Add keyword to find cluster type based on cluster infrastructure

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -601,14 +601,14 @@ Skip If Operator Starting Version Is Not Supported
     Skip If    condition="${supported}"=="${FALSE}"    msg=This test is skipped because starting operator version < ${minimum_version}
 
 Skip If Cluster Type Is Self-Managed
-    [Documentation]    Skips test if cluster type  is Self-managed
-    ${cluster_type}=    Is Cluster Type Self-Managed
-    Skip If    condition=${cluster_type}==True    msg=This test is skipped for Self-managed cluster
+    [Documentation]    Skips test if cluster type is Self-managed
+    ${cluster_type}=    Is Cluster Type Managed
+    Skip If    condition=${cluster_type}==False    msg=This test is skipped for Self-managed cluster
 
 Skip If Cluster Type Is Managed
-    [Documentation]    Skips test if cluster type  is Managed
-    ${cluster_type}=    Is Cluster Type Self-Managed
-    Skip If    condition=${cluster_type}==False    msg=This test is skipped for Managed cluster
+    [Documentation]    Skips test if cluster type is Managed
+    ${cluster_type}=    Is Cluster Type Managed
+    Skip If    condition=${cluster_type}==True    msg=This test is skipped for Managed cluster
 
 Delete All ${resource_type} In Namespace By Name
     [Documentation]    Force delete all ${resource_type} named '${resource_type}' in namespace '${namespace}'

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -333,17 +333,15 @@ Wait For Namespace To Be Active
     Log    ${value}
     Should Be Equal As Integers    ${rc}    0
 
-Is Cluster Type Self-Managed
-    [Documentation]    Get the value of cluster type depending on the console URL domain
-    ...    Returns ${TRUE} if cluster type is Self-Managed
-    ...    Returns ${FALSE} if cluster type is Managed
-    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods
-    ${size}=    Get Length    ${matches}
-    IF    ${size}>0
-        ${domain}=    Get From List    ${matches}    0
-        IF    "${domain}" == "rh-ods"
-            RETURN    ${TRUE}
-        END
+Is Cluster Type Managed
+    [Documentation]    Find the cluster type based on output of the infrastructure of the cluster
+    ...    Returns ${TRUE} if cluster type is Managed
+    ...    Returns ${FALSE} if cluster type is Self-Managed
+    ${rc}    ${output}=    Run And Return Rc And Output
+    ...    oc get infrastructure cluster -o jsonpath='{.status.platformStatus.*.resourceTags[?(@.key=="red-hat-managed")].value}'
+    Should Be Equal As Integers    ${rc}    0
+    IF    "${output}" == "true"
+        RETURN    ${TRUE}
     ELSE
         RETURN    ${FALSE}
     END


### PR DESCRIPTION
This PR

- Removes keyword "Is Cluster Type Self-Managed" as it was suggested not to rely on console url to find cluster type
- In all self-managed clusters, there is no common key in "oc get infrastructure cluster" output which can be used to 
  identify the cluster-type 
- There is one common key in all managed clusters and this is used to find the cluster-type
   ```
   {
                        "key": "red-hat-managed",
                        "value": "true"
                    }
```

- Adds a keyword "Is Cluster Type Managed" to find the cluster type based on cluster infrastructure

 
