### PR TITLE
fix the selfmanaged uninstall of rhoai operator

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/oc_uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/oc_uninstall.robot
@@ -11,21 +11,11 @@ Trigger RHODS Uninstall
   Log  Triggered RHODS uninstallation
 
 Verify RHODS Uninstallation
-  IF  "${cluster_type}" == "managed"
-        Run Keyword And Expect Error  *Not Found*
-        ...  Oc Get  kind=CatalogSource  namespace=${OPERATOR_NAMESPACE}
-        ...       field_selector=metadata.name=${CATALOG_NAME}
-  ELSE IF  "${cluster_type}" == "selfmanaged"
-        Run Keyword And Expect Error  *Not Found*
-        ...  Oc Get  kind=CatalogSource  namespace=openshift-marketplace
-        ...       field_selector=metadata.name=rhoai-catalog-dev
-  END
   Verify Project Does Not Exists  ${MONITORING_NAMESPACE}
   Verify Project Does Not Exists  ${APPLICATIONS_NAMESPACE}
   IF  "${OPERATOR_NAMESPACE}" != "openshift-marketplace"
        Verify Project Does Not Exists  ${OPERATOR_NAMESPACE}
   END
-
 
 Verify Project Does Not Exists
   [Arguments]  ${project}

--- a/ods_ci/tasks/Tasks/rhods_olm.robot
+++ b/ods_ci/tasks/Tasks/rhods_olm.robot
@@ -3,6 +3,7 @@ Documentation    Perform and verify RHODS OLM tasks
 Metadata         RHODS OLM Version    1.0.0
 Resource         ../Resources/RHODS_OLM/RHODS_OLM.resource
 Resource         ../../tests/Resources/Common.robot
+Resource         ../../tests/Resources/RHOSi.resource
 Library          OpenShiftLibrary
 Library          OperatingSystem
 Library          String
@@ -22,6 +23,7 @@ ${CATALOG_SOURCE}               redhat-operators
 *** Tasks ***
 Can Install RHODS Operator
   [Tags]  install
+  RHOSi Setup
   IF  "${PRODUCT}" == "ODH"
       Set Global Variable  ${OPERATOR_NAMESPACE}  opendatahub-operators
       Set Global Variable  ${OPERATOR_NAME_LABEL}  opendatahub-operator
@@ -43,6 +45,7 @@ Can Install RHODS Operator
 
 Can Uninstall RHODS Operator
   [Tags]  uninstall
+  RHOSi Setup
   IF  "${PRODUCT}" == "ODH"
       Set Global Variable  ${OPERATOR_NAMESPACE}  opendatahub-operators
       IF  "${UPDATE_CHANNEL}" == "odh-nightlies"

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -84,6 +84,7 @@ Initialize Global Variables
     Set Global Variable   ${RHODS_VERSION}
     Set Prometheus Variables
     Set Global Variable    ${DASHBOARD_APP_NAME}    ${PRODUCT.lower()}-dashboard
+    Set Global Variable    ${RHODS_PACKAGE_NAME}    rhods-operator
 
 Required Global Variables Should Exist
     [Documentation]   Fails if new required global variables are not set


### PR DESCRIPTION
Since we moved to using Konflux, we don't have the same CATALOG_SOURCE_NAME and OPERATOR_NAME for Stage and Red Hat.

Stage:
Operator name: rhoai-operator-dev, CatalogSource: rhoai-catalog-dev

Red Hat:
Operator name: rhods-operator, CatalogSource: redhat-operators

So the uninstall didn't work as expected.

Related to Jira ticket: RHOAIENG-2720