### PR TITLE
Skip FMS Training operator tests for version less than 2.12.0

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -579,7 +579,7 @@ Clone Git Repository
 Get Operator Starting Version
     [Documentation]    Returns the starting version of the operator in the upgrade chain
     ${rc}    ${out}=    Run And Return RC And Output
-    ...    oc get subscription rhods-operator -n ${OPERATOR_NAMESPACE} -o yaml | yq '.spec.startingCSV' | awk -F. '{print $2"."$3"."$4}'    # robocop: disable
+    ...    oc get subscription rhods-operator -n ${OPERATOR_NAMESPACE} -o yaml | yq -r '.spec.startingCSV' | awk -F. '{print $2"."$3"."$4}'    # robocop: disable
     Should Be Equal As Integers    ${rc}    0
     RETURN    ${out}
 

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -224,6 +224,7 @@ Run Training Operator FMS Setup PyTorchJob Test Use Case
     [Documentation]    Run Training Operator FMS Setup PyTorchJob Test Use Case
     [Tags]      Upgrade
     [Setup]     Prepare Training Operator FMS E2E Test Suite
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test    TestSetupPytorchjob
     [Teardown]    Teardown Training Operator FMS E2E Test Suite
 
@@ -231,6 +232,7 @@ Run Training Operator FMS Setup Sleep PyTorchJob Test Use Case
     [Documentation]    Setup PyTorchJob which is kept running for 24 hours
     [Tags]      Upgrade
     [Setup]     Prepare Training Operator FMS E2E Test Suite
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test    TestSetupSleepPytorchjob
     [Teardown]    Teardown Training Operator FMS E2E Test Suite
 

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -234,6 +234,7 @@ Run Training Operator FMS Run PyTorchJob Test Use Case
     [Documentation]    Run Training Operator FMS Run PyTorchJob Test Use Case
     [Tags]      Upgrade
     [Setup]     Prepare Training Operator FMS E2E Test Suite
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test          TestRunPytorchjob
     [Teardown]      Teardown Training Operator FMS E2E Test Suite
 
@@ -241,6 +242,7 @@ Run Training Operator FMS Run Sleep PyTorchJob Test Use Case
     [Documentation]    Verify that running PyTorchJob Pod wasn't restarted
     [Tags]      Upgrade
     [Setup]     Prepare Training Operator FMS E2E Test Suite
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test      TestVerifySleepPytorchjob
     [Teardown]      Teardown Training Operator FMS E2E Test Suite
 


### PR DESCRIPTION
Purpose is to skip tests when testing upgrade path from 2.8 EUS to latest.

Also using raw form to retrieve `startingCSV` to get rid of quotes messing up comparison between versions.