### PR TITLE
Add KFTO_MNIST training operator tests

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-training-stack-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-training-stack-tests.robot
@@ -10,7 +10,7 @@ Resource          ../../../../tests/Resources/Page/DistributedWorkloads/Distribu
 
 *** Test Cases ***
 Run Training operator KFTO test with NVIDIA CUDA image
-    [Documentation]    Run Go KFTO tests for Training operator using PyTorch job with NVIDIA CUDA image
+    [Documentation]    Run Go KFTO test for Training operator using PyTorch job with NVIDIA CUDA image
     [Tags]  Resources-GPU    NVIDIA-GPUs
     ...     RHOAIENG-16035
     ...     Tier1
@@ -20,7 +20,7 @@ Run Training operator KFTO test with NVIDIA CUDA image
     Run Training Operator KFTO Test    TestPyTorchJobWithCuda    ${CUDA_TRAINING_IMAGE}
 
 Run Training operator KFTO test with AMD ROCm image
-    [Documentation]    Run Go KFTO tests for Training operator using PyTorch job with AMD ROCm image
+    [Documentation]    Run Go KFTO test for Training operator using PyTorch job with AMD ROCm image
     [Tags]  Resources-GPU    AMD-GPUs    ROCm
     ...     RHOAIENG-16035
     ...     Tier1
@@ -30,7 +30,7 @@ Run Training operator KFTO test with AMD ROCm image
     Run Training Operator KFTO Test    TestPyTorchJobWithROCm    ${ROCM_TRAINING_IMAGE}
 
 Run Training operator KFTO error handling test with NVIDIA CUDA image
-    [Documentation]    Run Go KFTO error handling tests for Training operator using PyTorch job with NVIDIA CUDA image
+    [Documentation]    Run Go KFTO error handling test for Training operator using PyTorch job with NVIDIA CUDA image
     [Tags]  RHOAIENG-14542
     ...     Tier1
     ...     DistributedWorkloads
@@ -39,10 +39,39 @@ Run Training operator KFTO error handling test with NVIDIA CUDA image
     Run Training Operator KFTO Test    TestPyTorchJobFailureWithCuda    ${CUDA_TRAINING_IMAGE}
 
 Run Training operator KFTO error handling test with AMD ROCm image
-    [Documentation]    Run Go KFTO error handling tests for Training operator using PyTorch job with AMD ROCm image
+    [Documentation]    Run Go KFTO error handling test for Training operator using PyTorch job with AMD ROCm image
     [Tags]  RHOAIENG-14542
     ...     Tier1
     ...     DistributedWorkloads
     ...     Training
     ...     TrainingOperator
     Run Training Operator KFTO Test    TestPyTorchJobFailureWithROCm    ${ROCM_TRAINING_IMAGE}
+
+Run Training operator KFTO_MNIST multi-node CPU test with NVIDIA CUDA image
+    [Documentation]    Run Go KFTO_MNIST multi-node CPU test for Training operator using PyTorch job with NVIDIA CUDA image
+    [Tags]  RHOAIENG-16556
+    ...     Sanity
+    ...     DistributedWorkloads
+    ...     Training
+    ...     TrainingOperator
+    Run Training Operator KFTO Test    TestPyTorchJobMnistCpu    ${CUDA_TRAINING_IMAGE}
+
+Run Training operator KFTO_MNIST multi-node test with NVIDIA CUDA image
+    [Documentation]    Run Go KFTO_MNIST multi-node test for Training operator using PyTorch job with NVIDIA CUDA image
+    [Tags]  Resources-GPU    NVIDIA-GPUs
+    ...     RHOAIENG-16556
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     TrainingOperator
+    Run Training Operator KFTO Test    TestPyTorchJobMnistWithCuda    ${CUDA_TRAINING_IMAGE}
+
+Run Training operator KFTO_MNIST multi-node test with AMD ROCm image
+    [Documentation]    Run Go KFTO_MNIST multi-node test for Training operator using PyTorch job with AMD ROCm image
+    [Tags]  Resources-GPU    AMD-GPUs    ROCm
+    ...     RHOAIENG-16556
+    ...     Tier1
+    ...     DistributedWorkloads
+    ...     Training
+    ...     TrainingOperator
+    Run Training Operator KFTO Test    TestPyTorchJobMnistWithROCm    ${ROCM_TRAINING_IMAGE}


### PR DESCRIPTION
Closes [RHOAIENG-16556](https://issues.redhat.com/browse/RHOAIENG-16556)

This PR adds 

- Sanity test for Training operator

-  multi node KFTO_MNIST training operator tests