### PR TITLE
Default GPU node replicas to 1 avoiding 0 nodes in SNO clusters

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
@@ -26,4 +26,6 @@ else
     echo "WARNING: I don't know the sha for $xyVersion. Re-using default 4.17 $imageUrl. It might not work!"
 fi
 sed -i'' -e "s/<imageUrl>/$imageUrl/g" $NFD_INSTANCE
+# temporary sleep until latest oc binary is available and --for=create is supported
+sleep 10s
 oc apply -f "$NFD_INSTANCE"

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AWS/gpu.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/AWS/gpu.yaml
@@ -1,3 +1,6 @@
 - op: replace
   path: /spec/template/spec/providerSpec/value/instanceType
   value: INSTANCE_TYPE
+- op: replace
+  path: /spec/replicas
+  value: 1

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/GCP/attach-gpu-to-n1/gpu.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/GCP/attach-gpu-to-n1/gpu.yaml
@@ -9,3 +9,6 @@
 - op: replace
   path: /spec/template/spec/providerSpec/value/machineType
   value: INSTANCE_TYPE
+- op: replace
+  path: /spec/replicas
+  value: 1

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/GCP/gpu.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/GCP/gpu.yaml
@@ -4,3 +4,6 @@
 - op: add
   path: /spec/template/spec/providerSpec/value/onHostMaintenance
   value: Terminate
+- op: replace
+  path: /spec/replicas
+  value: 1

--- a/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/IBM/gpu.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/GPU/overlays/IBM/gpu.yaml
@@ -1,3 +1,6 @@
 - op: replace
   path: /spec/template/spec/providerSpec/value/profile
   value: INSTANCE_TYPE
+- op: replace
+  path: /spec/replicas
+  value: 1


### PR DESCRIPTION
- When provisioning a GPU worker node in addition to the single node in a SNO OpenShift cluster, the MachineSet defaults to 0 because it copies the existing worker node machine set. 
- (Azure kustomization already has the patch)
- Adding a (temporary) sleep before applying NFD CR because it happened to hit a failure due to CRD was not created yet while applying the CRD. Thanks Andrej for capturing it. It is temporary because solution exists in kubectl v1.32 and we cannot use it yet

PR validation:
1. SNO 4.17 on AWS with 1 NVIDIA GPU: `rhoai-test-flow/2282` OK - the tests in the job failed because RHOAI wasn't installed (misconfig, my bad)
2. SNO 4.17 on GCP with 1 NVIDIA GPU: `rhoai-test-flow/2286` FAIL - found an issue and fixed. Retry: `rhoai-test-flow/2289` OK
3. SNO 4.16 on IBM Cloud with 1 NVIDIA GPU:  `rhoai-test-flow/2337` OK