### PR TITLE
RHOAIENG-17979: feat(tests/ide): assert that "authorize access" oauth page is not present after RHOAIENG-11155 got into the product

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -33,8 +33,7 @@ Begin Web Test
     IF    ${jupyter_login}
         Launch Jupyter From RHODS Dashboard Link
         Login To Jupyterhub  ${username}  ${password}  ${auth_type}
-        ${authorization_required}=   Is Service Account Authorization Required
-        IF  ${authorization_required}  Authorize JupyterLab Service Account
+        Verify Service Account Authorization Not Required
         Fix Spawner Status
         Go To  ${ODH_DASHBOARD_URL}
     END

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
@@ -121,8 +121,7 @@ Switch To Pipeline Execution Page
     IF  ${oauth_prompt_visible}  Click Button  Log in with OpenShift
     ${login-required} =  Is OpenShift Login Visible
     IF  ${login-required}  Login To Openshift  ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     RETURN    ${handle}
 
 Set Runtime Image In All Nodes

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -358,8 +358,7 @@ Spawn Notebook With Arguments  # robocop: disable
             ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
             IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
             Run Keyword And Warn On Failure   Login To Openshift  ${username}  ${password}  ${auth_type}
-            ${authorization_required} =  Is Service Account Authorization Required
-            IF  ${authorization_required}  Authorize JupyterLab Service Account
+            Verify Service Account Authorization Not Required
 
             Wait Notebook To Be Loaded  ${image}    ${version}
             ${spawn_fail} =  Has Spawn Failed
@@ -396,8 +395,7 @@ Launch JupyterHub Spawner From Dashboard
     Menu.Navigate To Page    Applications    Enabled
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub  ${username}  ${password}  ${auth}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
     Wait Until Page Contains   Start server
@@ -686,8 +684,7 @@ Log In N Users To JupyterLab And Launch A Notebook For Each Of Them
         Launch Jupyter From RHODS Dashboard Link
         Login To Jupyterhub    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
         Page Should Not Contain    403 : Forbidden
-        ${authorization_required} =    Is Service Account Authorization Required
-        IF    ${authorization_required}    Authorize JupyterLab Service Account
+        Verify Service Account Authorization Not Required
         Fix Spawner Status
         Spawn Notebook With Arguments
     END
@@ -704,8 +701,7 @@ CleanUp JupyterHub For N Users
         Launch Jupyter From RHODS Dashboard Link
         Login To Jupyterhub    ${username}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
         Page Should Not Contain    403 : Forbidden
-        ${authorization_required} =    Is Service Account Authorization Required
-        IF    ${authorization_required}    Authorize JupyterLab Service Account
+        Verify Service Account Authorization Not Required
         #Fix Spawner Status stops the current notebook, handling the different possible states
         Fix Spawner Status
     END

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/LoginJupyterHub.robot
@@ -13,15 +13,9 @@ Login To Jupyterhub
    ${login_required} =  Is OpenShift Login Visible
    IF  ${login_required}  Login To Openshift  ${ocp_user_name}  ${ocp_user_pw}  ${ocp_user_auth_type}
 
-Is Service Account Authorization Required
+Verify Service Account Authorization Not Required
    ${title} =  Get Title
-   ${result} =  Run Keyword And Return Status  Should Start With  ${title}  Authorize service account
-   RETURN  ${result}
-
-Authorize JupyterLab Service Account
-  Wait Until Page Contains  Authorize Access
-  Checkbox Should Be Selected  user:info
-  Click Element  approve
+   Should Not Start With  ${title}  Authorize service account
 
 Verify Jupyter Access Level
    [Arguments]    ${expected_result}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -50,8 +50,7 @@ Launch Dashboard And Check User Management Option Is Available For The User
     [Arguments]    ${username}  ${password}  ${auth_type}  ${settings_should_be}=${TRUE}
     Launch Dashboard    ocp_user_name=${username}  ocp_user_pw=${password}  ocp_user_auth_type=${auth_type}
     ...    dashboard_url=${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  browser_options=${BROWSER.OPTIONS}
-    ${authorization_required}=  Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     IF    ${settings_should_be}
         # Wait up to 2 minutes as a workaround for bug RHOAIENG-11116
         Menu.Navigate To Page    Settings    User management    timeout=2m

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -338,8 +338,7 @@ Access To Workbench
     ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
     IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
     Run Keyword And Warn On Failure   Login To Openshift  ${username}  ${password}  ${auth_type}
-    ${authorization_required}=  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     IF  "${expected_ide}"=="VSCode"
         Wait Until Page Contains Element  xpath://div[@class="menubar-menu-button"]  timeout=60s
         Wait Until Page Contains Element  xpath://div[@class="monaco-dialog-box"]  timeout=60s

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
@@ -553,8 +553,7 @@ Launch Notebook And Stop It    # robocop: disable
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains    Start a notebook server
     Fix Spawner Status
     Spawn Notebook With Arguments    image=minimal-notebook

--- a/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0101__metrics.robot
+++ b/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0101__metrics.robot
@@ -281,8 +281,7 @@ Iterative Image Test
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
     Page Should Not Contain    403 : Forbidden
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     Spawn Notebook With Arguments    image=${image}
     Run Cell And Check Output    print("Hello World!")    Hello World!

--- a/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0102__billing_metrics.robot
+++ b/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0101__metrics/0102__billing_metrics.robot
@@ -201,8 +201,7 @@ Iterative Image Test
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
     Page Should Not Contain    403 : Forbidden
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     Spawn Notebook With Arguments    image=${image}
     Run Cell And Check Output    print("Hello World!")    Hello World!
@@ -223,8 +222,7 @@ CleanUp JupyterHub
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
     Page Should Not Contain    403 : Forbidden
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     # Additional check on running server
     ${control_panel_visible} =  Control Panel Is Visible
     IF  ${control_panel_visible}==True

--- a/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0102__alerts/0102__alerts.robot
+++ b/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0102__alerts/0102__alerts.robot
@@ -234,8 +234,7 @@ Fill Up User PVC    # robocop: disable:too-many-calls-in-keyword
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     Spawn Notebook With Arguments    image=science-notebook
     Clone Git Repository And Run    ${notebook_repo}    ${notebook_path}

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/autoscaling-gpus.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/autoscaling-gpus.robot
@@ -66,8 +66,7 @@ Spawn Notebook And Trigger Autoscale
     ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
     IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
     Run Keyword And Warn On Failure   Login To Openshift  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains Element  xpath://div[@id="jp-top-panel"]  timeout=60s
     Maybe Close Popup
     Open New Notebook In Jupyterlab Menu

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot
@@ -47,8 +47,7 @@ Iterative Image Test
     [Arguments]  ${image}  ${REPO_URL}  ${NOTEBOOK_TO_RUN}
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     Spawn Notebook With Arguments  image=${image}
     Run Cell And Check Output  print("Hello World!")  Hello World!

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/long-running-test-generic-ds.robot
@@ -30,7 +30,6 @@ Launch JupyterLab
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Fix Spawner Status
     Spawn Notebooks And Set S3 Credentials    image=science-notebook

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot
@@ -38,8 +38,7 @@ Open Browser And Start Notebook As First User
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains    Start a notebook server
     Fix Spawner Status
     Spawn Notebook With Arguments    image=minimal-notebook
@@ -60,8 +59,7 @@ Open Browser And Start Notebook As Second User With Env Vars
     Wait For RHODS Dashboard To Load
     Launch Jupyter From RHODS Dashboard Link
     Login To Jupyterhub    ${TEST_USER_2.USERNAME}    ${TEST_USER_2.PASSWORD}    ${TEST_USER_2.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains    Start a notebook server
     Fix Spawner Status
     &{first_pod_details} =  Create Dictionary  pod_ip=${pod_ip}  pod_login=${pod_login_name}

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/plugin-verification.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/plugin-verification.robot
@@ -29,8 +29,7 @@ Test User Notebook Plugin in JupyterLab
     Open Browser  ${ODH_DASHBOARD_URL}  browser=${BROWSER.NAME}  options=${BROWSER.OPTIONS}
     Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Launch JupyterHub Spawner From Dashboard
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Remove All Spawner Environment Variables
     Get the List of Plugins from RHODS notebook images
     Verify the Plugins for each JL images

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-flask-notebook.robot
@@ -23,8 +23,7 @@ Can Launch Jupyterhub
 Can Login to Jupyterhub
   [Tags]  Tier2
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  ${authorization_required} =  Is Service Account Authorization Required
-  IF  ${authorization_required}  Authorize JupyterLab Service Account
+  Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a notebook server
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot
@@ -23,8 +23,7 @@ Can Launch Jupyterhub
 Can Login to Jupyterhub
   [Tags]  Tier1
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  ${authorization_required} =  Is Service Account Authorization Required
-  IF  ${authorization_required}  Authorize JupyterLab Service Account
+  Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a notebook server
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot
@@ -26,8 +26,7 @@ Can Launch Jupyterhub
 Can Login to Jupyterhub
   [Tags]  Sanity
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  ${authorization_required} =  Is Service Account Authorization Required
-  IF  ${authorization_required}  Authorize JupyterLab Service Account
+  Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a notebook server
 
@@ -64,8 +63,7 @@ Verify A Default Image Is Provided And Starts Successfully
     Launch JupyterHub Spawner From Dashboard
     Spawn Notebook
     Run Keyword And Warn On Failure   Login To Openshift  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Run Keyword And Continue On Failure  Wait Until Page Contains Element  xpath://div[@id="jp-top-panel"]  timeout=60s
     Open New Notebook In Jupyterlab Menu
     Verify Notebook Name And Image Tag  user_data=${user_data}

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-time.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-time.robot
@@ -73,8 +73,7 @@ Spawn and Stop Server
     ${time1} =    Get Time    format=%H:%M:%S.%f
     Spawn Notebook
     Run Keyword And Warn On Failure   Login To Openshift  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     # If this fails we waited for 60s. Avg. time will be thrown off, might be acceptable
     # given that we weren't able to spawn?
     Run Keyword And Continue On Failure  Wait Until Page Contains Element  xpath://div[@id="jp-top-panel"]  timeout=60s

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot
@@ -25,8 +25,7 @@ Can Launch Jupyterhub
 
 Can Login to Jupyterhub
     Login To Jupyterhub    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}    ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =    Is Service Account Authorization Required
-    IF    ${authorization_required}    Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     #Wait Until Page Contains Element    xpath://span[@id='jupyterhub-logo']
     Wait Until Page Contains  Start a notebook server
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-s3-cc-fraud.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-s3-cc-fraud.robot
@@ -23,8 +23,7 @@ Can Launch Jupyterhub
 Can Login to Jupyterhub
   [Tags]  Sanity
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-  ${authorization_required} =  Is Service Account Authorization Required
-  IF  ${authorization_required}  Authorize JupyterLab Service Account
+  Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a notebook server
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
@@ -36,8 +36,7 @@ Can Login To Jupyterhub
     [Tags]   Smoke
     ...      ODS-936
     Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains  Start a notebook server
 
 Can Spawn Notebook
@@ -75,8 +74,7 @@ Can Spawn Notebook
     ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
     IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
     Login To Openshift  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
-    ${authorization_required} =  Is Service Account Authorization Required
-    IF  ${authorization_required}  Authorize JupyterLab Service Account
+    Verify Service Account Authorization Not Required
     Wait Until Page Contains Element  xpath://div[@id="jp-top-panel"]  timeout=60s
     Sleep  3
     Maybe Close Popup


### PR DESCRIPTION
* https://issues.redhat.com/browse/RHOAIENG-11155
* https://issues.redhat.com/browse/RHOAIENG-17979

checked in job/devops/job/rhoai-test-flow/2614/console

depends on this odh-notebook-controller to get into nightlies firs
* https://github.com/opendatahub-io/kubeflow/pull/449