### PR TITLE
update KFTO tests to utilise storage bucket in case of disconnected e…

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -173,6 +173,13 @@ Run Training Operator KFTO Test
     ...    env:CODEFLARE_TEST_TIMEOUT_LONG=20m
     ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/codeflare-${KFTO_BINARY_NAME}-logs
     ...    env:CODEFLARE_TEST_TRAINING_IMAGE=${TRAINING_IMAGE}
+    ...    env:AWS_DEFAULT_ENDPOINT=${AWS_DEFAULT_ENDPOINT}
+    ...    env:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    ...    env:AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    env:AWS_STORAGE_BUCKET=${AWS_STORAGE_BUCKET}
+    ...    env:AWS_STORAGE_BUCKET_MNIST_DIR=${AWS_STORAGE_BUCKET_MNIST_DIR}
+    ...    env:PIP_INDEX_URL=${PIP_INDEX_URL}
+    ...    env:PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
     Log To Console    ${result.stdout}
     Check missing Go test    ${result.stdout}
     IF    ${result.rc} != 0

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-training-stack-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-training-stack-tests.robot
@@ -47,6 +47,9 @@ Run Training operator KFTO error handling test with AMD ROCm image
     ...     TrainingOperator
     Run Training Operator KFTO Test    TestPyTorchJobFailureWithROCm    ${ROCM_TRAINING_IMAGE}
 
+## Note : For the disconnected environment, the KFTO Pytorch multi-node tests added below needs additional temporary workaround as a pre-requisite mentioned here
+## Pre-requisite for disconnected : Update Kubeflow training operator deployment yaml to add additional arg in spec.containers.args : `--pytorch-init-container-image=quay.io/quay/busybox@sha256:92f3298bf80a1ba949140d77987f5de081f010337880cd771f7e7fc928f8c74d`
+
 Run Training operator KFTO_MNIST multi-node single-CPU test with NVIDIA CUDA image
     [Documentation]    Run Go KFTO_MNIST multi-node single-CPU test for Training operator using PyTorch job with NVIDIA CUDA image - It requires 2 cluster-nodes with at least 1 CPUs each
     [Tags]  RHOAIENG-16556


### PR DESCRIPTION
Update KFTO tests to utilise storage bucket in case of disconnected environment
Added note to follow temporary workaround before running KFTO pytorch multi-node tests in disconnected environment

Related PR : https://github.com/opendatahub-io/distributed-workloads/pull/310