### PR TITLE
Fix Ray cluster upgrade tests Ray Image variable initialization

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -181,7 +181,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     ...    upgrade
     ...    raycluster_sdk_upgrade_test.py::TestMNISTRayClusterUp
     ...    3.11
-    ...    ${RAY_CUDA_IMAGE_3.11}
+    ...    ${RAY_IMAGE_3.11}
     ...    ${CODEFLARE-SDK-RELEASE-TAG}
     Set Library Search Order        SeleniumLibrary
     RHOSi Setup

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -203,7 +203,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     ...    upgrade
     ...    raycluster_sdk_upgrade_test.py::TestMnistJobSubmit
     ...    3.11
-    ...    ${RAY_CUDA_IMAGE_3.11}
+    ...    ${RAY_IMAGE_3.11}
     ...    ${CODEFLARE-SDK-RELEASE-TAG}
     Set Global Variable     ${DW_PROJECT_CREATED}       True        # robocop: disable:replace-set-variable-with-var
     Set Library Search Order        SeleniumLibrary


### PR DESCRIPTION
Fixed Ray cluster upgrade tests Ray Image variable initialisation as Back ported incorrect variables names from the [PR](https://github.com/red-hat-data-services/ods-ci/pull/2115) as these variables names differ in 2.16 release branch 