### PR TITLE
[2.16.0] Add image references to the Distributed Workload image digests

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -10,11 +10,26 @@ ${CODEFLARE-SDK-RELEASE-TAG-3.9}         adjustments-release-0.21.1
 ${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/download/v2.16.0-RC4-05-12-2024
-${RAY_IMAGE_3.11}                        quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
-${RAY_IMAGE_3.9}                         quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
+# Corresponds to quay.io/modh/ray:2.35.0-py311-cu121
+${RAY_CUDA_IMAGE_3.11}                   quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
+# Corresponds to quay.io/rhoai/ray:2.35.0-py311-cu121-torch24-fa26
+${RAY_TORCH_CUDA_IMAGE_3.11}             quay.io/rhoai/ray@sha256:5077f9bb230dfa88f34089fecdfcdaa8abc6964716a8a8325c7f9dcdf11bbbb3
+# Corresponds to quay.io/modh/ray:2.35.0-py311-rocm61
+${RAY_ROCM_IMAGE_3.11}                   quay.io/modh/ray@sha256:f8b4f2b1c954187753c1f5254f7bb6a4286cec5a4f1b43def7ef4e009f2d28cb
+# Corresponds to quay.io/modh/ray:2.35.0-py39-cu121
+${RAY_CUDA_IMAGE_3.9}                    quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
+# Corresponds to quay.io/rhoai/ray:2.35.0-py39-cu121-torch24-fa26
+${RAY_TORCH_CUDA_IMAGE_3.9}              quay.io/rhoai/ray@sha256:158b481b8e9110008d60ac9fb8d156eadd71cb057ac30382e62e3a231ceb39c0
+# Corresponds to quay.io/modh/fms-hf-tuning:v2.1.2
 ${FMS_HF_TUNING_IMAGE}                   quay.io/modh/fms-hf-tuning@sha256:6f98907f9095db72932caa54094438eae742145f4b66c28d15887d5303ff1186
+# Corresponds to quay.io/modh/training:py311-cuda121-torch241
 ${CUDA_TRAINING_IMAGE}                   quay.io/modh/training@sha256:b98e373a972ff6f896a9dc054d56920e915675339c02ea7fa123e0f4bbef4d74
+# Corresponds to quay.io/modh/training:py311-rocm61-torch241
 ${ROCM_TRAINING_IMAGE}                   quay.io/modh/training@sha256:2efb6efba4ec08e63847d701e3062a5f6ddf51c91af5fbcef6378b9e6520a3bb
+# Corresponds to quay.io/modh/odh-generic-data-science-notebook:v3-2024b-20241111
+${NOTEBOOK_IMAGE_3.11}                   quay.io/modh/odh-generic-data-science-notebook@sha256:7c1a4ca213b71d342a2d1366171304e469da06d5f15710fab5dd3ce013aa1b73
+# Corresponds to quay.io/modh/odh-generic-data-science-notebook:v2-2024a-20241108
+${NOTEBOOK_IMAGE_3.9}                    quay.io/modh/odh-generic-data-science-notebook@sha256:b1066204611b4bcfa6172c3115650a8e8393089d5606458fa0d8c53633d2ce17
 ${NOTEBOOK_USER_NAME}                    ${TEST_USER_3.USERNAME}
 ${NOTEBOOK_USER_PASSWORD}                ${TEST_USER_3.PASSWORD}
 ${KFTO_CORE_BINARY_NAME}                 kfto

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
@@ -17,7 +17,7 @@ Run TestRayClusterSDKOauth test with Python 3.9
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
+    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.9    ${RAY_CUDA_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
 
 Run TestRayClusterSDKOauth test with Python 3.11
     [Documentation]    Run Python E2E test: TestRayClusterSDKOauth
@@ -26,7 +26,7 @@ Run TestRayClusterSDKOauth test with Python 3.11
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
+    Run Codeflare-SDK Test    e2e    mnist_raycluster_sdk_oauth_test.py    3.11    ${RAY_CUDA_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 Run TestRayLocalInteractiveOauth test with Python 3.9
     [Documentation]    Run Python E2E test: TestRayLocalInteractiveOauth
@@ -35,7 +35,7 @@ Run TestRayLocalInteractiveOauth test with Python 3.9
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.9    ${RAY_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
+    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.9    ${RAY_CUDA_IMAGE_3.9}    ${CODEFLARE-SDK-RELEASE-TAG-3.9}
 
 Run TestRayLocalInteractiveOauth test with Python 3.11
     [Documentation]    Run Python E2E test: TestRayLocalInteractiveOauth
@@ -44,7 +44,7 @@ Run TestRayLocalInteractiveOauth test with Python 3.11
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
+    Run Codeflare-SDK Test    e2e    local_interactive_sdk_oauth_test.py    3.11    ${RAY_CUDA_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 Run TestHeterogenousClustersOauth
     [Documentation]    Run Python E2E test: TestHeterogenousClustersOauth (workaround for 2.15)
@@ -54,7 +54,7 @@ Run TestHeterogenousClustersOauth
     ...     WorkloadsOrchestration
     ...     HeterogeneousCluster
     ...     Codeflare-sdk
-    Run Codeflare-SDK Test    e2e    heterogeneous_clusters_oauth_test.py    3.11    ${RAY_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
+    Run Codeflare-SDK Test    e2e    heterogeneous_clusters_oauth_test.py    3.11    ${RAY_CUDA_IMAGE_3.11}    ${CODEFLARE-SDK-RELEASE-TAG}
 
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
@@ -9,7 +9,6 @@ Resource          ../../../Resources/Page/DistributedWorkloads/DistributedWorklo
 
 *** Variables ***
 ${KUBERAY_RELEASE_ASSETS}     %{KUBERAY_RELEASE_ASSETS=https://github.com/opendatahub-io/kuberay/releases/latest/download}
-${KUBERAY_TEST_RAY_IMAGE}     quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
 
 *** Test Cases ***
 Run TestRayJob test
@@ -77,9 +76,9 @@ Run Kuberay E2E Test
     Log To Console    Running Kuberay E2E test: ${test_name}
     ${result} =    Run Process    ./e2e -test.timeout 30m -test.parallel 1 -test.run ${test_name}
     ...    env:KUBERAY_TEST_TIMEOUT_SHORT=2m
-    ...    env:KUBERAY_TEST_TIMEOUT_MEDIUM=7m
-    ...    env:KUBERAY_TEST_TIMEOUT_LONG=10m
-    ...    env:KUBERAY_TEST_RAY_IMAGE=${KUBERAY_TEST_RAY_IMAGE}
+    ...    env:KUBERAY_TEST_TIMEOUT_MEDIUM=10m
+    ...    env:KUBERAY_TEST_TIMEOUT_LONG=12m
+    ...    env:KUBERAY_TEST_RAY_IMAGE=${RAY_CUDA_IMAGE_3.11}
     ...    env:KUBERAY_TEST_OUTPUT_DIR=%{WORKSPACE}/kuberay-logs
     ...    shell=true
     ...    stderr=STDOUT

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
@@ -9,13 +9,6 @@ Resource          ../../Resources/Page/DistributedWorkloads/DistributedWorkloads
 Test Tags         DistributedWorkloads3.11
 
 
-*** Variables ***
-${RAY_CUDA_IMAGE_3.11}               quay.io/modh/ray@sha256:db667df1bc437a7b0965e8031e905d3ab04b86390d764d120e05ea5a5c18d1b4
-${RAY_TORCH_CUDA_IMAGE_3.11}         quay.io/rhoai/ray@sha256:5077f9bb230dfa88f34089fecdfcdaa8abc6964716a8a8325c7f9dcdf11bbbb3
-${RAY_ROCM_IMAGE_3.11}               quay.io/modh/ray@sha256:f8b4f2b1c954187753c1f5254f7bb6a4286cec5a4f1b43def7ef4e009f2d28cb
-${NOTEBOOK_IMAGE_3.11}               quay.io/modh/odh-generic-data-science-notebook@sha256:7c1a4ca213b71d342a2d1366171304e469da06d5f15710fab5dd3ce013aa1b73
-
-
 *** Test Cases ***
 Run TestKueueRayCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayCpu

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests_3.9.robot
@@ -12,9 +12,6 @@ Test Tags         DistributedWorkloads3.9
 *** Variables ***
 # This is the last and latest distributed workloads release assest which contains test binaries compatible with python 3.9
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS_3.9}   https://github.com/opendatahub-io/distributed-workloads/releases/download/v2.14.0-09-24-2024_adjustments_1
-${RAY_CUDA_IMAGE_3.9}                         quay.io/modh/ray@sha256:0d715f92570a2997381b7cafc0e224cfa25323f18b9545acfd23bc2b71576d06
-${RAY_TORCH_CUDA_IMAGE_3.9}                   quay.io/rhoai/ray@sha256:158b481b8e9110008d60ac9fb8d156eadd71cb057ac30382e62e3a231ceb39c0
-${NOTEBOOK_IMAGE_3.9}                         quay.io/modh/odh-generic-data-science-notebook@sha256:b1066204611b4bcfa6172c3115650a8e8393089d5606458fa0d8c53633d2ce17
 
 
 *** Test Cases ***


### PR DESCRIPTION
This cherrypick fixes upgrade test issues, also applies same changes as done on main branch.