### PR TITLE
post_upgrade: Add ExcludeOnDisconnected tag to the must-gather test

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -263,7 +263,7 @@ Run Training Operator FMS Run Sleep PyTorchJob Test Use Case
 
 Verify that the must-gather image provides RHODS logs and info
     [Documentation]    Tests the must-gather image for ODH/RHOAI after upgrading
-    [Tags]      Upgrade
+    [Tags]      Upgrade    ODS-505    ExcludeOnDisconnected
     Get Must-Gather Logs
     Verify Logs For ${APPLICATIONS_NAMESPACE}
     IF    "${PRODUCT}" == "RHODS"


### PR DESCRIPTION
Added the `ExcludeOnDisconnected` tag (including `ODS-505`) as these are also present on the smoke test:
https://github.com/red-hat-data-services/ods-ci/blob/9fe6bc6a806d81d54c114d1ea06eb7578699acfa/ods_ci/tests/Tests/0100__platform/0103__must_gather/test-must-gather-logs.robot#L11-L18