### PR TITLE
Set parameter as_user when creating projects for DSP (backport to 2.16)

### DIFF
--- a/.github/workflows/dry_run.yml
+++ b/.github/workflows/dry_run.yml
@@ -30,7 +30,7 @@ jobs:
           mkdir -p ./pr
           cp -r ods_ci/test-output ./pr/test-output
           echo ${{ github.event.number }} > ./pr/NR
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: pr
           path: pr/

--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -45,7 +45,7 @@ Create Project And Configure Pipeline Server
     ...    configures a pipeline server using the default configuration and waits until the server is running
     [Arguments]    ${namespace}
     Projects.Delete Project Via CLI By Display Name    ${namespace}
-    Projects.Create Data Science Project From CLI    ${namespace}
+    Projects.Create Data Science Project From CLI    ${namespace}    as_user=${TEST_USER.USERNAME}
     DataSciencePipelinesBackend.Create Pipeline Server    namespace=${namespace}
     ...    object_storage_access_key=${S3.AWS_ACCESS_KEY_ID}
     ...    object_storage_secret_key=${S3.AWS_SECRET_ACCESS_KEY}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
@@ -48,7 +48,7 @@ Verify Hello World Pipeline Runs Successfully    # robocop: disable:too-long-tes
 Dsp Acceptance Suite Setup
     [Documentation]    Dsp Acceptance Suite Setup
     RHOSi Setup
-    Projects.Create Data Science Project From CLI    ${PROJECT}
+    Projects.Create Data Science Project From CLI    ${PROJECT}    as_user=${TEST_USER.USERNAME}
     DataSciencePipelinesBackend.Create Pipeline Server    namespace=${PROJECT}
     ...    object_storage_access_key=${S3.AWS_ACCESS_KEY_ID}
     ...    object_storage_secret_key=${S3.AWS_SECRET_ACCESS_KEY}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
@@ -107,7 +107,7 @@ End To End Pipeline Workflow Using Kfp
     ...    ${method_name}    ${pipeline_params}    ${status_check_timeout}=160    ${ray}=${FALSE}
 
     Projects.Delete Project Via CLI By Display Name    ${project}
-    Projects.Create Data Science Project From CLI    name=${project}
+    Projects.Create Data Science Project From CLI    name=${project}    as_user=${admin_username}
 
     DataSciencePipelinesBackend.Create PipelineServer Using Custom DSPA    ${project}
 

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
@@ -38,7 +38,7 @@ Verify Regular Users Can Create And Run a Data Science Pipeline Using The Api
 Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     [Documentation]    Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     [Tags]        Tier1    ODS-2234
-    Projects.Create Data Science Project From CLI    name=project-redirect-http
+    Projects.Create Data Science Project From CLI    name=project-redirect-http    as_user=${OCP_ADMIN_USER.USERNAME}
     DataSciencePipelinesBackend.Create PipelineServer Using Custom DSPA    project-redirect-http
     ${status} =    Login And Wait Dsp Route    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     ...         project-redirect-http
@@ -52,7 +52,7 @@ Verify DSPO Operator Reconciliation Retry
     [Tags]      Sanity    ODS-2477
 
     ${local_project_name} =    Set Variable    dsp-reconciliation-test
-    Projects.Create Data Science Project From CLI    name=${local_project_name}
+    Projects.Create Data Science Project From CLI    name=${local_project_name}    as_user=${OCP_ADMIN_USER.USERNAME}
 
     # Atempt to create a pipeline server with a custom DSPA. It should fail because there is a missing
     # secret with storage credentials (that's why, after, we don't use "Wait Until Pipeline Server Is Deployed"
@@ -80,7 +80,7 @@ End To End Pipeline Workflow Via Api
     ...    In the end, clean the pipeline resources.
     [Arguments]     ${username}    ${password}    ${project}
     Projects.Delete Project Via CLI By Display Name    ${project}
-    Projects.Create Data Science Project From CLI    name=${project}
+    Projects.Create Data Science Project From CLI    name=${project}    as_user=${username}
     Create PipelineServer Using Custom DSPA    ${project}
     ${status} =    Login And Wait Dsp Route    ${username}    ${password}    ${project}
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long

--- a/ods_ci/utils/scripts/ocm/ocm.py
+++ b/ods_ci/utils/scripts/ocm/ocm.py
@@ -1690,7 +1690,7 @@ if __name__ == "__main__":
         dest="cluster_name",
         metavar="",
         default="",
-        required=True
+        required=True,
     )
     cluster_exists_parser.set_defaults(func=ocm_obj.fail_if_cluster_does_not_exist)
 


### PR DESCRIPTION
- Needed when running the tests with the interop pipeline
- Tested successfully on rhoai-test-flow/2741
- Cherry-pick github action update to deprecation error