### PR TITLE
Fix dsp tests on interop 2.17 & fix variable conflict in Permissions provoking xpath issue

### DIFF
--- a/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
+++ b/ods_ci/tests/Resources/CLI/DataSciencePipelines/DataSciencePipelinesUpgradeTesting.resource
@@ -45,7 +45,7 @@ Create Project And Configure Pipeline Server
     ...    configures a pipeline server using the default configuration and waits until the server is running
     [Arguments]    ${namespace}
     Projects.Delete Project Via CLI By Display Name    ${namespace}
-    Projects.Create Data Science Project From CLI    ${namespace}
+    Projects.Create Data Science Project From CLI    ${namespace}    as_user=${TEST_USER.USERNAME}
     DataSciencePipelinesBackend.Create Pipeline Server    namespace=${namespace}
     ...    object_storage_access_key=${S3.AWS_ACCESS_KEY_ID}
     ...    object_storage_secret_key=${S3.AWS_SECRET_ACCESS_KEY}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
@@ -4,7 +4,7 @@ Resource       ./Projects.resource
 
 
 *** Variables ***
-${SAVE_BUTTON}=    xpath://button[@data-id="save-rolebinding-button"]
+${SAVE_PERMISSION_BUTTON}=    xpath://button[@data-id="save-rolebinding-button"]
 ${PERMISSIONS_DROPDOWN}=    xpath://td[@data-label="Permission"]//button[@aria-label="Options menu"]
 ${IS_CLUSTER_ADMIN}=    ${FALSE}
 ${USERS_TABLE}=    //table[@data-testid="role-binding-table User"]
@@ -19,7 +19,7 @@ Assign ${permission_type} Permissions To User ${username}
     ...    to the currently open DS Project in UI
     Log     ${username} - ${permission_type}
     Click Element    //button[@data-testid="add-button user"]
-    Element Should Be Disabled    ${SAVE_BUTTON}
+    Element Should Be Disabled    ${SAVE_PERMISSION_BUTTON}
     Input Text    xpath:${INPUT_USER}    ${username}
     Select Permission Type    permission_type=${permission_type}
     Save Permission
@@ -51,16 +51,16 @@ Select Permission Type
     Click Element    xpath://button[@role="option"]//*[.="${permission_type}"]
 
 Save Permission
-    Element Should Be Enabled    ${SAVE_BUTTON}
-    Click Element    ${SAVE_BUTTON}
-    Wait Until Page Does Not Contain Element    ${SAVE_BUTTON}    timeout=30s
+    Element Should Be Enabled    ${SAVE_PERMISSION_BUTTON}
+    Click Element    ${SAVE_PERMISSION_BUTTON}
+    Wait Until Page Does Not Contain Element    ${SAVE_PERMISSION_BUTTON}    timeout=30s
 
 Assign ${permission_type} Permissions To Group ${group_name}
     [Documentation]    Assign the user ${group_name} and level of permission ${permission_type}
     ...    to the currently open DS Project in UI
     Log     ${group_name} - ${permission_type}
     Click Element    //button[@data-testid="add-button group"]
-    Element Should Be Disabled    ${SAVE_BUTTON}
+    Element Should Be Disabled    ${SAVE_PERMISSION_BUTTON}
     IF    ${IS_CLUSTER_ADMIN} == ${FALSE}
         Input Text    xpath:${INPUT_GROUP}    ${group_name}
     ELSE

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
@@ -48,7 +48,7 @@ Verify Hello World Pipeline Runs Successfully    # robocop: disable:too-long-tes
 Dsp Acceptance Suite Setup
     [Documentation]    Dsp Acceptance Suite Setup
     RHOSi Setup
-    Projects.Create Data Science Project From CLI    ${PROJECT}
+    Projects.Create Data Science Project From CLI    ${PROJECT}    as_user=${TEST_USER.USERNAME}
     DataSciencePipelinesBackend.Create Pipeline Server    namespace=${PROJECT}
     ...    object_storage_access_key=${S3.AWS_ACCESS_KEY_ID}
     ...    object_storage_secret_key=${S3.AWS_SECRET_ACCESS_KEY}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
@@ -86,7 +86,7 @@ End To End Pipeline Workflow Using Kfp
     ...    ${method_name}    ${pipeline_params}    ${status_check_timeout}=160    ${ray}=${FALSE}
 
     Projects.Delete Project Via CLI By Display Name    ${project}
-    Projects.Create Data Science Project From CLI    name=${project}
+    Projects.Create Data Science Project From CLI    name=${project}    as_user=${admin_username}
 
     DataSciencePipelinesBackend.Create PipelineServer Using Custom DSPA    ${project}
 

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
@@ -38,7 +38,7 @@ Verify Regular Users Can Create And Run a Data Science Pipeline Using The Api
 Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     [Documentation]    Verify Ods Users Can Do Http Request That Must Be Redirected to Https
     [Tags]        Tier1    ODS-2234
-    Projects.Create Data Science Project From CLI    name=project-redirect-http
+    Projects.Create Data Science Project From CLI    name=project-redirect-http    as_user=${OCP_ADMIN_USER.USERNAME}
     DataSciencePipelinesBackend.Create PipelineServer Using Custom DSPA    project-redirect-http
     ${status} =    Login And Wait Dsp Route    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     ...         project-redirect-http
@@ -52,7 +52,7 @@ Verify DSPO Operator Reconciliation Retry
     [Tags]      Sanity    ODS-2477
 
     ${local_project_name} =    Set Variable    dsp-reconciliation-test
-    Projects.Create Data Science Project From CLI    name=${local_project_name}
+    Projects.Create Data Science Project From CLI    name=${local_project_name}    as_user=${OCP_ADMIN_USER.USERNAME}
 
     # Atempt to create a pipeline server with a custom DSPA. It should fail because there is a missing
     # secret with storage credentials (that's why, after, we don't use "Wait Until Pipeline Server Is Deployed"
@@ -80,7 +80,7 @@ End To End Pipeline Workflow Via Api
     ...    In the end, clean the pipeline resources.
     [Arguments]     ${username}    ${password}    ${project}
     Projects.Delete Project Via CLI By Display Name    ${project}
-    Projects.Create Data Science Project From CLI    name=${project}
+    Projects.Create Data Science Project From CLI    name=${project}    as_user=${username}
     Create PipelineServer Using Custom DSPA    ${project}
     ${status} =    Login And Wait Dsp Route    ${username}    ${password}    ${project}
     Should Be True    ${status} == 200    Could not login to the Data Science Pipelines Rest API OR DSP routing is not working    # robocop: disable:line-too-long


### PR DESCRIPTION
- When creating a project in DSP tests, set the `as_user` parameter for compatibility with the interop pipeline
- Modify variable name in Permissions.resource  to fix an xpath error due to variable name conflict


Currently being tested in rhoai-test-flow/2751

