### PR TITLE
KubeRay: Make sure that ValidatingAdmissionPolicy is removed

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
@@ -60,6 +60,12 @@ Prepare Kuberay E2E Test Suite
     RHOSi Setup
     # This is a temporary workaround to avoid ValidatingAdmissionPolicy check
     Disable Component    kueue
+    ${vap_removed} =    Run Process    oc wait --for\=delete ValidatingAdmissionPolicy/kueue-validating-admission-policy --timeout\=60s
+    ...    shell=true
+    ...    stderr=STDOUT
+    IF    ${vap_removed.rc} != ${0}
+        FAIL    ValidatingAdmissionPolicy kueue-validating-admission-policy not removed
+    END
 
 Teardown Kuberay E2E Test Suite
     Log To Console    "Removing test binaries"


### PR DESCRIPTION
There is small delay between disabling Kueue component and removing ValidatingAdmissionPolicy. As a result the KubeRay tests can occasionally crash as ValidatingAdmissionPolicy is enforced.

Waiting for ValidatingAdmissionPolicy removal makes sure that the validation is gone and KubeRay tests may run.