### PR TITLE
KubeRay: Sleep for 3 seconds after disabling Kueue

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-kuberay-e2e.robot
@@ -60,6 +60,8 @@ Prepare Kuberay E2E Test Suite
     RHOSi Setup
     # This is a temporary workaround to avoid ValidatingAdmissionPolicy check
     Disable Component    kueue
+    # ValidatingAdmissionPolicy is supported just on newer OCP, using Sleep as a workaround to make sure that ValidatingAdmissionPolicy is removed if it exists
+    Sleep  3s
 
 Teardown Kuberay E2E Test Suite
     Log To Console    "Removing test binaries"


### PR DESCRIPTION
ValidatingAdmissionPolicy is supported just on newer OCP, using Sleep as a workaround to make sure that ValidatingAdmissionPolicy is removed if it exists.

The sleep is preventing race condition which would be caused by running KubeRay tests while ValidatingAdmissionPolicy is still available.