### PR TITLE
Use OCP_API_URL parameter for Login To OCP function

### DIFF
--- a/ods_ci/tests/Resources/Page/OCPLogin/OCPLogin.robot
+++ b/ods_ci/tests/Resources/Page/OCPLogin/OCPLogin.robot
@@ -13,11 +13,13 @@ Login To OCP
 Login To OCP Using API
   [Documentation]   Login to openshitf using username and password
   [Arguments]    ${username}      ${password}
-  ${rc}    ${out}=    Run And Return Rc And Output    oc login $(oc whoami --show-server) -u ${username} -p ${password}  #robocop:disable
+  ${rc}    ${out}=    Run And Return Rc And Output    oc login ${OCP_API_URL} -u ${username} -p ${password}  #robocop:disable
+  Run Keyword If    ${rc} == ${1}        Log To Console    "Error logging into cluster ${OCP_API_URL} : " ${out}
   Should Be Equal As Integers    ${rc}    ${0}
 
 Login To OCP Using API And Kubeconfig
   [Documentation]   Login to openshift using username and password, storing credentials to Kubeconfig file
   [Arguments]    ${username}      ${password}      ${kubeconfig}
-  ${rc}    ${out}=    Run And Return Rc And Output    oc login $(oc whoami --show-server) -u ${username} -p ${password} --kubeconfig=${kubeconfig} --insecure-skip-tls-verify=true    #robocop:disable
+  ${rc}    ${out}=    Run And Return Rc And Output    oc login ${OCP_API_URL} -u ${username} -p ${password} --kubeconfig=${kubeconfig} --insecure-skip-tls-verify=true    #robocop:disable
+  Run Keyword If    ${rc} == ${1}        Log To Console    "Error logging into cluster ${OCP_API_URL} : " ${out}
   Should Be Equal As Integers    ${rc}    ${0}


### PR DESCRIPTION
That will make sure that OCP URL from `test-variables.yml` is used regardless of current `oc` session.
Also printing the output to console in case of logging error to simplify analysis of possible errors.