### PR TITLE
Add ProductBug Tag to Validate SMCP Already created and negative TC

### DIFF
--- a/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
@@ -70,7 +70,7 @@ Validate DSC and DSCI Created With Errors When Serverless Operator Is Not Instal
 Validate DSC and DSCI Created With Errors When Service Mesh And Serverless Operators Are Not Installed   #robocop:disable
     [Documentation]    The purpose of this Test Case is to validate that DSC and DSCI are created
     ...                without dependant operators ((servicemesh, serverless) installed, but with errors
-    [Tags]    Operator    Tier3    ODS-2527     RHOAIENG-2518
+    [Tags]    Operator    Tier3    ODS-2527     RHOAIENG-2518       ProductBug
 
     Remove DSC And DSCI Resources
     Uninstall Service Mesh Operator CLI

--- a/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2003__smcp_already_created.robot
@@ -29,7 +29,7 @@ ${MSG_REGEX}                                denied the request: only one service
 *** Test Cases ***
 Validate Service Mesh Control Plane Already Created
     [Documentation]    This Test Case validates that only one ServiceMeshControlPlane is allowed to be installed per project/namespace
-    [Tags]      RHOAIENG-2517       Operator    Tier3
+    [Tags]      RHOAIENG-2517       Operator    Tier3       ProductBug
     Fetch Image Url And Update Channel
     Check Whether DSC Exists And Save Component Statuses
     IF    "${CLUSTER_TYPE}" == "selfmanaged"


### PR DESCRIPTION
Adding `ProductBug` Tag to both Test Cases until fix is delivered so Pipelines stay green