### PR TITLE
Update ods-ci branch name

### DIFF
--- a/ods_ci/docs/release.md
+++ b/ods_ci/docs/release.md
@@ -1,6 +1,6 @@
 # How To Create An ods-ci Release
 
-As an example, for RHODS release 1.21.0-21 we would create a branch releases/1.21.0-21 and add a 1.21.0 tag (without -21).
+As an example, for RHODS release 1.21-21 we would create a branch release-1.21-21 and add a 1.21 tag (without -21).
 
 ## Steps:
     Use the main repo instead of a fork
@@ -16,20 +16,20 @@ As an example, for RHODS release 1.21.0-21 we would create a branch releases/1.2
 
     Create a branch and tag for this release.
     Note that the tag format should be x.y.z (without -16). This is required in order to make the automatic release notes work properly
-    4. git checkout -b releases/1.21.0-21
-    5. git tag 1.21.0
+    4. git checkout -b release-1.21-21
+    5. git tag 1.21
 
     Add also the “stable” tag (ISV team needs it) 
     6. git tag stable
 
     Finally, push branch and tags
-    7. git push --set-upstream origin releases/1.21.0-21
+    7. git push --set-upstream origin release-1.21-21
     8. git push --tags
 
     Go to GitHub and publish the release
     9. Go to https://github.com/red-hat-data-services/ods-ci/tags
-    10. In tag 1.21.0, click on the three dots and then Create release
-    11. Release title: 1.21.0
+    10. In tag 1.21, click on the three dots and then Create release
+    11. Release title: 1.21
     12. Auto-generate release notes
     13. Publish release
 

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -595,7 +595,7 @@ Skip If Operator Starting Version Is Not Supported
     [Documentation]    Skips test if ODH/RHOAI operator starting version is < ${minimum_version}
     ...    Usage example: add    Skip If Operator Starting Version Is Not Supported    minimum_version=2.14.0
     ...    in your post-upgrade tests if the resources needed by them were added in the pre-upgrade suite
-    ...    in ods-ci releases/2.14.0
+    ...    in ods-ci release-2.14
     [Arguments]    ${minimum_version}
     ${supported}=    Is Starting Version Supported    minimum_version=${minimum_version}
     Skip If    condition="${supported}"=="${FALSE}"    msg=This test is skipped because starting operator version < ${minimum_version}

--- a/ods_ci/utils/scripts/fetch_tests.py
+++ b/ods_ci/utils/scripts/fetch_tests.py
@@ -3,16 +3,16 @@
 """
 Examples
 Input:
-poetry run ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 releases/2.8.0 --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
+poetry run ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 release-2.8 --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
 Output:
 ---| Computing differences |----
-Done. Found 30 new tests in releases/2.8.0 which were not present in origin/releases/2.7.0
+Done. Found 30 new tests in release-2.8 which were not present in origin/release-2.7
 
 Input:
 poetry run ods_ci/utils/scripts/fetch_tests.py --test-repo git@github.com:red-hat-data-services/ods-ci.git --ref1 master  --ref2-auto true --selector-attribute creatordate -A new-arg-file.txt
 Output:
 ---| Computing differences |----
-Done. Found 14 new tests in master which were not present in origin/releases/2.9.0
+Done. Found 14 new tests in master which were not present in origin/release-2.9
 
 """
 
@@ -66,7 +66,7 @@ def get_branch(ref_to_exclude, selector_attribute):
     List the remote branches and sort by selector_attribute date (ASC order), exclude $ref_to_exclude and get latest
     """
     ref_to_exclude_esc = ref_to_exclude.replace("/", r"\/")
-    cmd = f"git branch -r --sort={selector_attribute} | grep releases/"
+    cmd = f"git branch -r --sort={selector_attribute} | grep release-"
     if "master" not in ref_to_exclude and "main" not in ref_to_exclude:
         cmd += rf" | sed  's/.*{ref_to_exclude_esc}$/current/g' |  grep -zPo '[\S\s]+(?=current)'"
     ret = execute_command(cmd)
@@ -181,7 +181,7 @@ if __name__ == "__main__":
         help="second branch or commit to use for comparison (e.g., newer one)",
         action="store",
         dest="ref_2",
-        default="releases/2.8.0",
+        default="release-2.8",
     )
     parser.add_argument(
         "--ref2-auto",


### PR DESCRIPTION
We want to rename github.com/red-hat-data-services/ods-ci repo branch from releases/2..0 to release-2., so that we can dynamically build the test image from the branch to minimize the effort of building and mapping the image.
Since we release very frequently, this step would save us significant effort by reducing the need for additional PRs to map the image from Quay to OpenShift CI. OpenShift CI does not accept branch names containing /.
