### PR TITLE
add teams tag for upgrade tests

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -42,21 +42,21 @@ ${UPGRADE_CONFIG_MAP}    upgrade-config-map
 *** Test Cases ***
 Set PVC Size Via UI
     [Documentation]    Sets a Pod toleration via the admin UI
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     [Setup]     Begin Web Test
     Set PVC Value In RHODS Dashboard        ${S_SIZE}
     [Teardown]      Dashboard Test Teardown
 
 Set Culler Timeout
     [Documentation]     Sets a culler timeout via the admin UI
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     [Setup]     Begin Web Test
     Modify Notebook Culler Timeout      ${CUSTOM_CULLER_TIMEOUT}
     [Teardown]      Dashboard Test Teardown
 
 Setting Pod Toleration Via UI
     [Documentation]    Sets a Pod toleration via the admin UI
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     [Setup]     Begin Web Test
     Menu.Navigate To Page       Settings        Cluster settings
     Wait Until Page Contains        Notebook pod tolerations
@@ -67,7 +67,7 @@ Setting Pod Toleration Via UI
 Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
     [Documentation]    Verify that users can set multiple admin groups and
     ...    check OdhDashboardConfig CRD gets updated according to Admin UI
-    [Tags]      Upgrade     RHOAIENG-14306
+    [Tags]      Upgrade     RHOAIENG-14306    Platform
     [Setup]     Begin Web Test
     # robocop: disable
     Launch Dashboard And Check User Management Option Is Available For The User
@@ -82,19 +82,19 @@ Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
 
 Verify Custom Image Can Be Added
     [Documentation]    Create Custome notebook using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     Oc Apply        kind=ImageStream        src=tests/Tests/0200__rhoai_upgrade/custome_image.yaml
 
 Verify User Can Disable The Runtime
     [Documentation]    Disable the Serving runtime using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade    ModelServing
     Disable Model Serving Runtime Using CLI     namespace=redhat-ods-applications
 
 Verify Model Can Be Deployed Via UI For Upgrade
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    Verify Model Can Be Deployed Via UI For Upgrade
-    [Tags]                  Upgrade
+    [Tags]                  Upgrade    ModelServing
     [Setup]                 Begin Web Test
     ${PRJ_TITLE}=           Set Variable            model-serving-upgrade
     ${PRJ_DESCRIPTION}=     Set Variable            project used for model serving tests
@@ -160,7 +160,7 @@ Verify Model Can Be Deployed Via UI For Upgrade
 
 Verify User Can Deploy Custom Runtime For Upgrade
     [Documentation]     Verify User Can Deploy Custom Runtime For Upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    ModelServing
     Create Custom Serving Runtime Using Template By CLI
     ...    tests/Resources/Files/caikit_runtime_template.yaml
     Begin Web Test
@@ -173,7 +173,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    Creates the Ray Cluster and verify resource usage
-    [Tags]      Upgrade
+    [Tags]      Upgrade    WorkloadOrchestration
     [Setup]     Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}=     Set Variable        test-ns-rayupgrade
     ${JOB_NAME}=        Set Variable        mnist
@@ -227,7 +227,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
 
 Run Training Operator FMS Setup PyTorchJob Test Use Case
     [Documentation]    Run Training Operator FMS Setup PyTorchJob Test Use Case
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator FMS E2E Test Suite
     Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test    TestSetupPytorchjob
@@ -235,7 +235,7 @@ Run Training Operator FMS Setup PyTorchJob Test Use Case
 
 Run Training Operator FMS Setup Sleep PyTorchJob Test Use Case
     [Documentation]    Setup PyTorchJob which is kept running for 24 hours
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator FMS E2E Test Suite
     Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test    TestSetupSleepPytorchjob
@@ -253,7 +253,7 @@ Model Registry Pre Upgrade Set Up
 
 Long Running Jupyter Notebook
     [Documentation]    Launch a long running notebook before the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     Launch Notebook
     Add And Run JupyterLab Code Cell In Active Notebook     ${CODE}
 

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
@@ -17,7 +17,7 @@ Test Tags           DuringUpgrade
 *** Test Cases ***
 Upgrade RHODS
     [Documentation]    Approve the install plan for the upgrade and make sure that upgrade has completed
-    [Tags]      ODS-1766        Upgrade
+    [Tags]      ODS-1766        Upgrade    Platform
     ${initial_version} =    Get RHODS Version
     ${initial_creation_date} =      Get Operator Pod Creation Date
     # robocop:disable
@@ -36,7 +36,7 @@ Upgrade RHODS
 
 TensorFlow Image Test
     [Documentation]    Run basic tensorflow notebook during upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     Launch Notebook
     ...    tensorflow
     ...    ${TEST_USER.USERNAME}
@@ -46,7 +46,7 @@ TensorFlow Image Test
 
 PyTorch Image Workload Test
     [Documentation]    Run basic pytorch notebook during upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     Launch Notebook
     ...    pytorch
     ...    ${TEST_USER.USERNAME}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -41,21 +41,21 @@ ${UPGRADE_CONFIG_MAP}    upgrade-config-map
 *** Test Cases ***
 Verify PVC Size
     [Documentation]    Verify PVC Size after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     Get Dashboard Config Data
     ${size}     Set Variable        ${payload[0]['spec']['notebookController']['pvcSize']}[:-2]
     Should Be Equal As Strings      '${size}'       '${S_SIZE}'
 
 Verify Pod Toleration
     [Documentation]    Verify Pod toleration after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     ${enable}    Set Variable
     ...    ${payload[0]['spec']['notebookController']['notebookTolerationSettings']['enabled']}
     Should Be Equal As Strings      '${enable}'     'True'
 
 Verify RHODS User Groups
     [Documentation]    Verify User Configuration after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Platform
     ${admin}        Set Variable        ${payload[0]['spec']['groupsConfig']['adminGroups']}
     ${user}     Set Variable        ${payload[0]['spec']['groupsConfig']['allowedGroups']}
     Should Be Equal As Strings      '${admin}'      'rhods-admins,rhods-users'
@@ -64,7 +64,7 @@ Verify RHODS User Groups
 
 Verify Culler is Enabled
     [Documentation]    Verify Culler Configuration after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     ${status}    Check If ConfigMap Exists
     ...    ${APPLICATIONS_NAMESPACE}
     ...    notebook-controller-culler-config
@@ -74,7 +74,7 @@ Verify Culler is Enabled
 
 Verify Notebook Has Not Restarted
     [Documentation]    Verify Notebook pod has not restarted after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     ${notebook_name}=    Get User CR Notebook Name    ${TEST_USER2.USERNAME}
     ${notebook_pod_name}=    Get User Notebook Pod Name    ${TEST_USER2.USERNAME}
 
@@ -96,7 +96,7 @@ Verify Notebook Has Not Restarted
 
 Verify Custom Image Is Present
     [Documentation]    Verify Custom Noteboook is not deleted after the upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    IDE
     ${status}       Run Keyword And Return Status
     ...    Oc Get
     ...    kind=ImageStream
@@ -107,28 +107,28 @@ Verify Custom Image Is Present
 
 Verify Disable Runtime Is Present
     [Documentation]    Disable the Serving runtime using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade    ModelServing
     ${rn}       Set Variable        ${payload[0]['spec']['templateDisablement']}
     List Should Contain Value       ${rn}       ovms-gpu
     [Teardown]      Enable Model Serving Runtime Using CLI      namespace=redhat-ods-applications
 
 Reset PVC Size Via UI
     [Documentation]    Sets a Pod toleration via the admin UI
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     [Setup]     Begin Web Test
     Set PVC Value In RHODS Dashboard        20
     [Teardown]      Dashboard Test Teardown
 
 Reset Culler Timeout
     [Documentation]    Sets a culler timeout via the admin UI
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Dashboard
     [Setup]     Begin Web Test
     Disable Notebook Culler
     [Teardown]      Dashboard Test Teardown
 
 Resetting Pod Toleration Via UI
     [Documentation]    Sets a Pod toleration via the admin UI
-    [Tags]                  Upgrade
+    [Tags]                  Upgrade    Dashboard
     [Setup]                 Begin Web Test
     Menu.Navigate To Page       Settings        Cluster settings
     Wait Until Page Contains        Notebook pod tolerations
@@ -141,7 +141,7 @@ Resetting Pod Toleration Via UI
 
 Verify POD Status
     [Documentation]    Verify all the pods are up and running
-    [Tags]                  Upgrade
+    [Tags]                  Upgrade    Platform
     Wait For Pods Status    namespace=${APPLICATIONS_NAMESPACE}     timeout=60
     Log     Verified ${APPLICATIONS_NAMESPACE}      console=yes
     Wait For Pods Status    namespace=${OPERATOR_NAMESPACE}     timeout=60
@@ -155,7 +155,7 @@ Test Inference Post RHODS Upgrade
     # robocop: off=too-many-calls-in-test-case
     # robocop: off=too-long-test-case
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
-    [Tags]                  Upgrade
+    [Tags]                  Upgrade    ModelServing
     [Setup]                 Begin Web Test
     ${PRJ_TITLE}            Set Variable        model-serving-upgrade
     ${PRJ_DESCRIPTION}      Set Variable        project used for model serving tests        # robocop: off=unused-variable      # robocop: disable:line-too-long
@@ -181,7 +181,7 @@ Test Inference Post RHODS Upgrade
 
 Verify Custom Runtime Exists After Upgrade
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
-    [Tags]      Upgrade
+    [Tags]      Upgrade    ModelServing
     [Setup]     Begin Web Test
     Menu.Navigate To Page       Settings        Serving runtimes
     Wait Until Page Contains        Add serving runtime     timeout=15s
@@ -194,7 +194,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    check the Ray Cluster exists , submit ray job and    verify resource usage after upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade    WorkloadOrchestration
     [Setup]     Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}      Set Variable        test-ns-rayupgrade
     ${LOCAL_QUEUE}      Set Variable        local-queue-mnist
@@ -249,7 +249,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
 
 Run Training Operator FMS Run PyTorchJob Test Use Case
     [Documentation]    Run Training Operator FMS Run PyTorchJob Test Use Case
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator FMS E2E Test Suite
     Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test          TestRunPytorchjob
@@ -257,7 +257,7 @@ Run Training Operator FMS Run PyTorchJob Test Use Case
 
 Run Training Operator FMS Run Sleep PyTorchJob Test Use Case
     [Documentation]    Verify that running PyTorchJob Pod wasn't restarted
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator FMS E2E Test Suite
     Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
     Run Training Operator FMS Test      TestVerifySleepPytorchjob
@@ -265,7 +265,7 @@ Run Training Operator FMS Run Sleep PyTorchJob Test Use Case
 
 Verify that the must-gather image provides RHODS logs and info
     [Documentation]    Tests the must-gather image for ODH/RHOAI after upgrading
-    [Tags]      Upgrade    ODS-505    ExcludeOnDisconnected
+    [Tags]      Upgrade    ODS-505    ExcludeOnDisconnected    Platform
     Get Must-Gather Logs
     Verify Logs For ${APPLICATIONS_NAMESPACE}
     IF    "${PRODUCT}" == "RHODS"
@@ -279,13 +279,13 @@ Verify That DSC And DSCI Release.Name Attribute matches ${expected_release_name}
     ...    ODH: Open Data Hub
     ...    RHOAI managed: OpenShift AI Cloud Service
     ...    RHOAI selfmanaged: OpenShift AI Self-Managed
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Platform
     Should Be Equal As Strings      ${DSC_RELEASE_NAME}     ${expected_release_name}
     Should Be Equal As Strings      ${DSCI_RELEASE_NAME}    ${expected_release_name}
 
 Verify That DSC And DSCI Release.Version Attribute matches the value in the subscription        # robocop: disable:not-allowed-char-in-name
     [Documentation]    Tests the release.version attribute from the DSC and DSCI matches the value in the subscription.
-    [Tags]      Upgrade
+    [Tags]      Upgrade    Platform
     ${rc}    ${csv_name}    Run And Return Rc And Output
     ...    oc get subscription -n ${OPERATOR_NAMESPACE} -l ${OPERATOR_SUBSCRIPTION_LABEL} -ojson | jq '.items[0].status.currentCSV' | tr -d '"'     # robocop: disable:line-too-long
     Should Be Equal As Integers     ${rc}       ${0}        ${rc}


### PR DESCRIPTION
I often wonder who owns the specific tests in the upgrade test files since they aren't part of the team's folder. 

To make it easier to identify the owner of each test, I’ve added a team tag to each one.



