### PR TITLE
Adjust fms-hf-tuning tests to use Granite model

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -174,6 +174,11 @@ Run Training Operator FMS Test
     ...    env:CODEFLARE_TEST_TIMEOUT_LONG=20m
     ...    env:CODEFLARE_TEST_OUTPUT_DIR=%{WORKSPACE}/codeflare-${FMS_BINARY_NAME}-logs
     ...    env:FMS_HF_TUNING_IMAGE=${FMS_HF_TUNING_IMAGE}
+    ...    env:AWS_DEFAULT_ENDPOINT=${AWS_DEFAULT_ENDPOINT}
+    ...    env:AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+    ...    env:AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ...    env:AWS_STORAGE_BUCKET_DOWNLOAD=${AWS_STORAGE_BUCKET}
+    ...    env:AWS_STORAGE_BUCKET_DOWNLOAD_MODEL_PATH=models/granite-3b-code-base-2k
     Log To Console    ${result.stdout}
     Check missing Go test    ${result.stdout}
     IF    ${result.rc} != 0

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-tuning-stack-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-run-tuning-stack-tests.robot
@@ -16,6 +16,7 @@ Run Training operator FMS test base finetuning use case
     ...     DistributedWorkloads
     ...     Training
     ...     TrainingOperator
+    ...     Resources-GPU    NVIDIA-GPUs
     Run Training Operator FMS Test    TestPytorchjobWithSFTtrainerFinetuning
 
 Run Training operator FMS test base LoRA use case
@@ -25,6 +26,7 @@ Run Training operator FMS test base LoRA use case
     ...     DistributedWorkloads
     ...     Training
     ...     TrainingOperator
+    ...     Resources-GPU    NVIDIA-GPUs
     Run Training Operator FMS Test    TestPytorchjobWithSFTtrainerLoRa
 
 ## Note : This test is disabled because the required model supported for QLoRA test is not available
@@ -45,4 +47,5 @@ Run Training operator FMS test with Kueue quota
     ...     DistributedWorkloads
     ...     Training
     ...     TrainingOperator
+    ...     Resources-GPU    NVIDIA-GPUs
     Run Training Operator FMS Test    TestPytorchjobUsingKueueQuota


### PR DESCRIPTION
Needed due to changes in fms-hf-tuning 2.6.0 image.