### PR TITLE
fix the xpath for the Application launcher button in OCP4.18+

### DIFF
--- a/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
@@ -5,7 +5,7 @@ Library  String
 Library  OpenShiftLibrary
 
 *** Variables ***
-${APP_LAUNCHER_ELEMENT}                 xpath=//*[@aria-label='Application launcher']/button
+${APP_LAUNCHER_ELEMENT}                 xpath://button[@aria-label="Application launcher"]
 ${PERSPECTIVE_SWITCHER_BUTTON_ELEMENT}  xpath=//*[@data-test-id="perspective-switcher-toggle"]
 ${PERSPECTIVE_SWITCHER_TEXT_ELEMENT}  xpath=//*[@data-test-id="perspective-switcher-toggle"]/span/h2
 ${PERSPECTIVE_ADMINISTRATOR_BUTTON}  xpath=//*[@data-test-id="perspective-switcher-menu-option"][starts-with(., "Administrator")]


### PR DESCRIPTION
CI:
![image](https://github.com/user-attachments/assets/d00761ac-d06b-490a-a003-452820f50bf8)
