### PR TITLE
must-gather cleanup for manual tests

### DIFF
--- a/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
@@ -1,6 +1,14 @@
 #!/bin/sh
 # Redirecting stdout/stderr of must-gather to a file, as it fills up the
 # process buffer and prevents the script from running further.
+#clean up must-gather.local* 
+for dir in must-gather.local*; do
+    if [ -d "$dir" ]; then
+        echo "Removing existing directory: $dir"
+        rm -rf "$dir"
+    fi
+done
+
 oc adm must-gather --image=quay.io/modh/must-gather@sha256:9d5988f45c3b00ec7fbbe7a8a86cc149a2768c9c47e207694fdb6e87ef44adf3 -- "export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE};export APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}; /usr/bin/gather" &> must-gather-results.txt
 
 if [ $? -eq 0 ]


### PR DESCRIPTION
Before:
`Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must-gather i...
==============================================================================
Verify that the must-gather image provides RHODS logs and info :: ... | FAIL |
Directory '/root/ods-ci/ods_ci/must-gather.local.2845850710066585704
must-gather.local.3520028717659021870' does not exist.

Also teardown failed:
Evaluating expression '"must-gather.local.2845850710066585704
must-gather.local.3520028717659021870" != ""' failed: SyntaxError: unterminated string literal (detected at line 1) (<string>, line 1)
------------------------------------------------------------------------------
Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must... | FAIL |
1 test, 0 passed, 1 failed
==============================================================================
Tests.Platform.Must Gather                                            | FAIL |
1 test, 0 passed, 1 failed
==============================================================================
Tests.Platform                                                        | FAIL |
9 tests, 8 passed, 1 failed
==============================================================================
Tests                                                                 | FAIL |
9 tests, 8 passed, 1 failed
==============================================================================
Output:  /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-10-07-02-pouS2ZWYWV/output.xml
XUnit:   /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-10-07-02-pouS2ZWYWV/xunit_test_result.xml
Log:     /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-10-07-02-pouS2ZWYWV/log.html
Report:  /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-10-07-02-pouS2ZWYWV/test_report.html
1
[root@odh-ogvinhd-robot-78939-bastion-0 ods_ci]# ls -l | grep must
-rw-r--r--.  1 root root 1333418 Mar 10 07:22 must-gather-results.txt
drwxr-xr-x.  3 root root    4096 Mar 10 07:20 must-gather.local.2845850710066585704
drwxr-xr-x.  3 root root    4096 Mar 10 07:22 must-gather.local.3520028717659021870
[root@odh-ogvinhd-robot-78939-bastion-0 ods_ci]#`


After:
`Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must-gather i...
==============================================================================
Verify that the must-gather image provides RHODS logs and info :: ... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform.Must Gather                                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform                                                        | PASS |
9 tests, 9 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
9 tests, 9 passed, 0 failed
==============================================================================
Output:  /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-11-04-03-HdS02Sez9F/output.xml
XUnit:   /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-11-04-03-HdS02Sez9F/xunit_test_result.xml
Log:     /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-11-04-03-HdS02Sez9F/log.html
Report:  /root/ods-ci/ods_ci/test-output/ods-ci-2025-03-11-04-03-HdS02Sez9F/test_report.html
`