### PR TITLE
fix: remove the -k option in the cleanup command

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -30,7 +30,7 @@ Uninstall RHODS
 
 Uninstall RHODS In OSD
   Clone OLM Install Repo
-  ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t addon -k   #robocop:disable
+  ${return_code}    ${output}    Run And Return Rc And Output   cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t addon   #robocop:disable
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing RHODS
   Log To Console   ${output}
 
@@ -51,7 +51,7 @@ RHODS Operator Should Be Uninstalled
 Uninstall RHODS In Self Managed Cluster Using CLI
   [Documentation]   UnInstall rhods on self-managedcluster using cli
   Clone OLM Install Repo
-  ${return_code}    Run and Watch Command    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator -k    timeout=10 min
+  ${return_code}    Run and Watch Command    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator    timeout=10 min
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing RHODS
 
 Uninstall RHODS In Self Managed Cluster For Operatorhub


### PR DESCRIPTION
We are running into several issues due to not deleting the CRDs when running the cleanup script.

If a CRD is updated, and its available in the cluster, olm wont update the CRD, causing compatibility issues