### PR TITLE
Add missing PATH for poetry in Dockerfile - Interop testing

### DIFF
--- a/ods_ci/build/Dockerfile_interop
+++ b/ods_ci/build/Dockerfile_interop
@@ -43,7 +43,7 @@ RUN dnf install epel-release -y &&\
 RUN alternatives --install /usr/local/bin/python3 python3 /usr/bin/python${PYTHON_VERSION} 1
 RUN python3 --version
 RUN curl -sSL https://install.python-poetry.org | python3 -
-ENV PATH="${PATH}:${HOME}/.local/bin"
+ENV PATH="/root/.local/bin:${HOME}/.local/bin:${PATH}"
 RUN poetry install
 
 RUN chgrp -R 0 ${ODS_VENV} && \


### PR DESCRIPTION
Following this [error log](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/red-hat-data-services_ods-ci/2247/pull-ci-red-hat-data-services-ods-ci-release-2.16-rhoai-ocp4.18-lp-interop-images/1899122845363998720):
` STEP 19/25: ENV PATH="${PATH}:${HOME}/.local/bin"
STEP 20/25: RUN poetry install
/bin/sh: line 1: poetry: command not found ` 