### PR TITLE
Fix interop tests test variables visibility

### DIFF
--- a/ods_ci/run_interop.sh
+++ b/ods_ci/run_interop.sh
@@ -4,6 +4,7 @@ export SET_ENVIRONMENT=1
 export USE_OCM_IDP=0
 export RUN_SCRIPT_ARGS="skip-oclogin true --set-urls-variables true"
 export ROBOT_EXTRA_ARGS="-i Smoke --dryrun"
+TEST_VARIABLES_FILE="test-variables.yml"
 
 if [[ -z "${TEST_SUITE}" ]]; then
   echo "Error: TEST_SUITE not set. Please define it. Exiting.."
@@ -19,7 +20,6 @@ run_tests() {
   echo "Running $1 testing"
 
   TEST_CASE_FILE="tests/Tests"
-  TEST_VARIABLES_FILE="test-variables.yml"
   TEST_SUITE=$1
 
   poetry run robot --include ${TEST_SUITE} --exclude "ExcludeOnRHOAI" --exclude "AutomationBug" --exclude "ProductBug" -d ${ARTIFACT_DIR}/${TEST_SUITE} -x xunit_test_result.xml -r test_report.html --variablefile ${TEST_VARIABLES_FILE} ${TEST_CASE_FILE} || true


### PR DESCRIPTION
Following the following job error: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_release/61959/rehearse-61959-periodic-ci-red-hat-data-services-ods-ci-release-2.10-rhoai-ocp4.18-lp-interop-rhoai-interop-aws/1901200052966133760