### PR TITLE
fix the jupyter workbench start for RHOAI 2.19+

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -222,14 +222,14 @@ Spawn Notebook
     Click Button  Start server
     # Waiting for 60 seconds, since a long wait seems to redirect the user to the control panel
     # if the spawn was successful
-    ${modal} =    Run Keyword And Return Status    Wait Until Page Contains
-    ...    Starting server    60s
+    ${modal} =    Run Keyword And Return Status    Wait Until Page Contains Element
+    ...    //*[@data-testid="notebook-status-modal"]
     IF  ${modal}==False
         Log    message=Starting server modal didn't appear after 60s    level=ERROR
         ${control_panel_visible} =  Control Panel Is Visible
         IF  ${control_panel_visible}==True
-         # If the user has been redirected to the control panel, move to the server and continue execution
-            Click Button    Return to server
+            # If the user has been redirected to the control panel, move to the server and continue execution
+            Click Element    xpath://*[@data-id="return-nb-button"]
             # If route annotation is empty redirect won't work, fail here
             Wait Until Page Does Not Contain Element    xpath:${KFNBC_CONTROL_PANEL_HEADER_XPATH}
             ...    timeout=15s    error=Redirect hasn't happened, check route annotation (opendatahub.io/link) in Notebook CR
@@ -259,7 +259,7 @@ Spawn Notebook
             ELSE IF  ${control_panel_visible}==True
                 # If the user has been redirected to the control panel,
                 # move to the server and continue execution
-                Click Button    Return to server
+                Click Element    xpath://*[@data-id="return-nb-button"]
                 RETURN
             ELSE IF  ${JL_Visible}==True
                 # We are in JL, return and let `Spawn Notebook With Arguments`
@@ -272,11 +272,13 @@ Spawn Notebook
             END
         END
     END
-    Wait Until Element Is Visible  xpath://div[@role="progressbar"]
+    Wait Until Element Is Visible  xpath://*[@data-testid="notebook-status-text"]
     IF    ${expect_autoscaling}
         Wait Until Page Contains    TriggeredScaleUp    timeout=120s
     END
-    Wait Until Page Contains    The notebook server is up and running.    ${spawner_timeout}
+    Wait Until Page Contains Element
+    ...    //*[@data-testid="notebook-status-text"]//*[text() = "Running"]
+    ...    ${spawner_timeout}
     IF  ${same_tab}
         Click Button    Open in current tab
     ELSE

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot
@@ -19,7 +19,7 @@ Logged Into OpenShift
     [Tags]   Smoke
     ...      ODS-127
     Open Page    ${OCP_CONSOLE_URL}
-    Wait Until Page Contains    Log in with
+    Wait Until Page Contains    Log in with    timeout=15s
     Login To Openshift  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
     Wait Until OpenShift Console Is Loaded
 


### PR DESCRIPTION
CI with RHOAI 2.19 nightly build:

```
./run_robot_test.sh --test-case ./tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot --open-report true
```
![image](https://github.com/user-attachments/assets/9be72404-b82b-4db1-87ee-5b4aad9b236b)
