### PR TITLE
Run KFTO upgrade tests for RHOAI 2.19 onwards

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -229,7 +229,7 @@ Run Training Operator KFTO Setup PyTorchJob Test Use Case
     [Documentation]    Run Training Operator KFTO Setup PyTorchJob Test Use Case
     [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator KFTO E2E Test Suite
-    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.19.0
     Run Training Operator KFTO Test    TestSetupPytorchjob    ${CUDA_TRAINING_IMAGE}
     [Teardown]    Teardown Training Operator KFTO E2E Test Suite
 
@@ -237,7 +237,7 @@ Run Training Operator KFTO Setup Sleep PyTorchJob Test Use Case
     [Documentation]    Setup PyTorchJob which is kept running for 24 hours
     [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator KFTO E2E Test Suite
-    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.19.0
     Run Training Operator KFTO Test    TestSetupSleepPytorchjob    ${CUDA_TRAINING_IMAGE}
     [Teardown]    Teardown Training Operator KFTO E2E Test Suite
 

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -253,7 +253,7 @@ Run Training Operator KFTO Run PyTorchJob Test Use Case
     [Documentation]    Run Training Operator KFTO Run PyTorchJob Test Use Case
     [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator KFTO E2E Test Suite
-    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.19.0
     Run Training Operator KFTO Test          TestRunPytorchjob    ${CUDA_TRAINING_IMAGE}
     [Teardown]      Teardown Training Operator KFTO E2E Test Suite
 
@@ -261,7 +261,7 @@ Run Training Operator KFTO Run Sleep PyTorchJob Test Use Case
     [Documentation]    Verify that running PyTorchJob Pod wasn't restarted
     [Tags]      Upgrade    Training
     [Setup]     Prepare Training Operator KFTO E2E Test Suite
-    Skip If Operator Starting Version Is Not Supported      minimum_version=2.12.0
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.19.0
     Run Training Operator KFTO Test      TestVerifySleepPytorchjob    ${CUDA_TRAINING_IMAGE}
     [Teardown]      Teardown Training Operator KFTO E2E Test Suite
 


### PR DESCRIPTION
Enabling Training operator upgrade testing from version when operator is GA.
This will make sure that upgrade tests won't mess up operator disabling/enabling.