### PR TITLE
Modify DSP backend tests not to use the UI to assign user permissions to projects

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -411,3 +411,19 @@ Wait For DSC Ready State
     ...    oc wait --timeout=${wait_time} --for jsonpath='{.status.conditions[].type}'=Ready -n ${namespace} dsc ${dsc_name}    # robocop: disable
     Should Be Equal As Integers    ${rc}     ${0}
     Log    ${out}    console=${out}
+
+Assign ${permission_type} Permissions To User ${username} In Project ${project_title} Using CLI
+    [Documentation]     Adds permissions to Data Science Projects using the CLI same as the ones added with the UI
+    # robocop: off=line-too-long,unnecessary-string-conversion
+    IF  "${permission_type}" == "Admin"
+        ${cluster_role}=   Set Variable    "admin"
+    ELSE IF   "${permission_type}" == "Contributor"
+        ${cluster_role}=   Set Variable    "edit"
+    ELSE
+        Fail    Usupported permission type ${permission_type}
+    END
+    ${rolebinding_suffix}=    Generate Random String    6   [LOWER]
+    ${rolebinding_name}=    Catenate    SEPARATOR=-    dashboard-permission    ${rolebinding_suffix}
+    Run And Verify Command    oc create rolebinding ${rolebinding_name} --clusterrole=${cluster_role} --user=${username} -n ${project_title}
+    Run And Verify Command    oc label rolebinding ${rolebinding_name} opendatahub.io/dashboard=true -n ${project_title}
+    Run And Verify Command    oc label rolebinding ${rolebinding_name} opendatahub.io/project-sharing=true -n ${project_title}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -299,7 +299,6 @@ Verify That DSC And DSCI Release.Version Attribute matches the value in the subs
 Data Science Pipelines Post Upgrade Verifications
     [Documentation]    Verifies the status of the resources created in project dsp-test-upgrade after the upgradea
     [Tags]      Upgrade     DataSciencePipelines-Backend
-    Skip If Operator Starting Version Is Not Supported      minimum_version=2.14.0
     DataSciencePipelinesUpgradeTesting.Verify Resources After Upgrade
 
 Model Registry Post Upgrade Verification

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-pipelines-integration.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-pipelines-integration.robot
@@ -4,9 +4,6 @@ Documentation       Test suite for OpenShift Pipeline using kfp python package
 Resource            ../../../Resources/RHOSi.resource
 Resource            ../../../Resources/ODS.robot
 Resource            ../../../Resources/Common.robot
-Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
-Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
-Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Permissions.resource
 Resource            ../../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 Resource            ../../../Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
 Resource            ../../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -97,8 +94,7 @@ End To End Pipeline Workflow Using Kfp
     END
     # The run_robot_test.sh is sending the --variablefile ${TEST_VARIABLES_FILE} which may contain the `PIP_INDEX_URL`
     # and `PIP_TRUSTED_HOST` variables, e.g. for disconnected testing.
-    Launch Data Science Project Main Page    username=${admin_username}    password=${admin_password}
-    Assign Contributor Permissions To User ${username} in Project ${project}
+    ODS.Assign Contributor Permissions To User ${username} In Project ${project} Using CLI
     ${pip_index_url} =    Get Variable Value    ${PIP_INDEX_URL}    ${NONE}
     ${pip_trusted_host} =    Get Variable Value    ${PIP_TRUSTED_HOST}    ${NONE}
     Log    pip_index_url = ${pip_index_url} / pip_trusted_host = ${pip_trusted_host}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
@@ -3,10 +3,8 @@ Documentation       Test suite for OpenShift Pipeline API
 Resource            ../../Resources/RHOSi.resource
 Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 Resource            ../../Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
 Library             DateTime
 Library             ../../../libs/DataSciencePipelinesAPI.py
 Library             ../../../libs/DataSciencePipelinesKfp.py
@@ -65,8 +63,7 @@ Verify DSPO Operator Reconciliation Retry
     # Add the missing secret with storage credentials. The DSPO will reconcile and start the pipeline server pods
     # Note: as the credentials are dummy, the DSPA status won't be ready, but it's ok because in this test
     # we are just testing the DSPO reconciliation
-    ${rc}  ${out} =    Run And Return Rc And Output   oc apply -f ${DSPA_PATH}/dummy-storage-creds.yaml -n ${local_project_name}    # robocop: disable:line-too-long
-    IF    ${rc}!=0    Fail
+    Run And Verify Command    oc apply -f ${DSPA_PATH}/dummy-storage-creds.yaml -n ${local_project_name}
 
     # After reconciliation, the project should have at least one pod running
     Wait For Pods Number  1    namespace=${local_project_name}    timeout=60
@@ -94,8 +91,7 @@ End To End Pipeline Workflow Via Api
 Double Check If DSPA Was Created
     [Documentation]    Double check if DSPA was created
     [Arguments]     ${local_project_name}
-    ${rc}  ${out} =    Run And Return Rc And Output   oc get datasciencepipelinesapplications -n ${local_project_name}
-    IF    ${rc}!=0    Fail
+    Run And Verify Command    oc get datasciencepipelinesapplications -n ${local_project_name}
 
 Verify DSPO Logs Show Error Encountered When Parsing DSPA
     [Documentation]    DSPA must find an error because not all components were deployed
@@ -116,5 +112,4 @@ Verify DSPO Logs Show Error Encountered When Parsing DSPA
 
 Data Science Pipelines Suite Setup
     [Documentation]    Data Science Pipelines Suite Setup
-    Set Library Search Order    SeleniumLibrary
     RHOSi Setup

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1103__data-science-pipelines-project-sharing.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1103__data-science-pipelines-project-sharing.robot
@@ -4,11 +4,7 @@ Documentation       Test suite for OpenShift Pipeline API
 Resource            ../../Resources/RHOSi.resource
 Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
 Resource            ../../Resources/CLI/DataSciencePipelines/DataSciencePipelinesBackend.resource
 Library             DateTime
 Library             ../../../libs/DataSciencePipelinesAPI.py


### PR DESCRIPTION
- Adds keyword `Assign ${permission_type} Permissions To User ${username} In Project ${project_title} Using CLI`
- Modifies DSP Backend tests to use it
- In DSP upgrade test, remove Operator Starting Version skip

Tested successfully in rhoai-test-flow/3401  (2 tests failed because of unrelated reasons)