### PR TITLE
update the references with regards the new IDE image versions

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -31,9 +31,9 @@ ${KFNBC_MODAL_X_XPATH} =    ${KFNBC_MODAL_HEADER_XPATH}//button[@aria-label="Clo
 ${KFNBC_CONTROL_PANEL_HEADER_XPATH} =    //h1[.="Notebook server control panel"]
 ${KFNBC_ENV_VAR_NAME_PRE} =    //span[.="Variable name"]/../../../div[@class="pf-v6-c-form__group-control"]
 ${DEFAULT_PYTHON_VER} =    3.11
-${PREVIOUS_PYTHON_VER} =    3.9
-${DEFAULT_NOTEBOOK_VER} =    2024.2
-${PREVIOUS_NOTEBOOK_VER} =    2024.1
+${PREVIOUS_PYTHON_VER} =    3.11
+${DEFAULT_NOTEBOOK_VER} =    2025.1
+${PREVIOUS_NOTEBOOK_VER} =    2024.2
 
 
 *** Keywords ***
@@ -78,25 +78,10 @@ Select Notebook Image
         END
     END
 
-    IF  "${version}"=="previous"
-        # Let's reset the JupyterLibrary settings so that global variables for Jupyter 3 (default) are in place.
-        Update Globals For JupyterLab 3 Custom
-    ELSE
-        # For Jupyter 4, we need to update global default variable values (images 2024b and newer)
-        # This calls method from JupyterLibrary Version.resource module
-        # https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/9e25fcb89a5f1a723c59e9b96706e4c638e0d9be/src/JupyterLibrary/clients/jupyterlab/Version.resource
-        Update Globals For JupyterLab 4
-    END
-
-Update Globals For JupyterLab 3 Custom
-    [Documentation]    Replace current selectors with JupyterLab 3-specific ones.
-    ...    This is the custom implementation since the original one doesn't really
-    ...    reverts defaults if they had been set to Jupyter 4 in the past already.
-    Set Global Variable    ${CM VERSION}    ${5}
-    Set Global Variable    ${CM CSS EDITOR}    .CodeMirror
-    Set Global Variable    ${CM JS INSTANCE}    .CodeMirror
-    Set Global Variable    ${JLAB CSS ACTIVE INPUT}    ${JLAB CSS ACTIVE CELL} ${CM CSS EDITOR}
-    Log    JupyterLab 3 is now the current version.
+    # For Jupyter 4, we need to update global default variable values (images 2024b and newer)
+    # This calls method from JupyterLibrary Version.resource module
+    # https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/9e25fcb89a5f1a723c59e9b96706e4c638e0d9be/src/JupyterLibrary/clients/jupyterlab/Version.resource
+    Update Globals For JupyterLab 4
 
 Verify Version Dropdown Is Present
     [Documentation]    Validates the version dropdown for a given Notebook image

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -1,5 +1,6 @@
 *** Settings ***
 Documentation    Collection of keywords to interact with Workbenches
+Library        JupyterLibrary
 Resource       ../../../../Page/Components/Components.resource
 Resource       ../../../../Common.robot
 Resource       ../ODHDataScienceProject/Storages.resource
@@ -214,16 +215,10 @@ Select Workbench Image
             Fail    ${version} does not exist, use default/previous
         END
     END
-    IF  "${version}"=="previous"
-        # Let's reset the JupyterLibrary settings so that global variables for Jupyter 3 (default) are in place.
-        Update Globals For JupyterLab 3 Custom
-    # TODO: Create the missing Keyword "Update Globals For JupyterLab 4"
-    # ELSE
-        # For Jupyter 4, we need to update global default variable values (images 2024b and newer)
-        # This calls method from JupyterLibrary Version.resource module
-        # https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/9e25fcb89a5f1a723c59e9b96706e4c638e0d9be/src/JupyterLibrary/clients/jupyterlab/Version.resource
-        # Update Globals For JupyterLab 4
-    END
+    # For Jupyter 4, we need to update global default variable values (images 2024b and newer)
+    # This calls method from JupyterLibrary Version.resource module
+    # https://github.com/robots-from-jupyter/robotframework-jupyterlibrary/blob/9e25fcb89a5f1a723c59e9b96706e4c638e0d9be/src/JupyterLibrary/clients/jupyterlab/Version.resource
+    Update Globals For JupyterLab 4
 
 Verify Version Selection Dropdown
     [Documentation]    Verifies the version selection dropdown is present

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
@@ -13,8 +13,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         minimal-gpu
-${EXPECTED_CUDA_VERSION} =  12.4
-${EXPECTED_CUDA_VERSION_N_1} =  12.1
+${EXPECTED_CUDA_VERSION} =  12.6
+${EXPECTED_CUDA_VERSION_N_1} =  12.4
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
@@ -15,8 +15,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         pytorch
-${EXPECTED_CUDA_VERSION} =  12.4
-${EXPECTED_CUDA_VERSION_N_1} =  12.1
+${EXPECTED_CUDA_VERSION} =  12.6
+${EXPECTED_CUDA_VERSION_N_1} =  12.4
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
@@ -16,8 +16,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         tensorflow
-${EXPECTED_CUDA_VERSION} =  12.4
-${EXPECTED_CUDA_VERSION_N_1} =  12.1
+${EXPECTED_CUDA_VERSION} =  12.6
+${EXPECTED_CUDA_VERSION_N_1} =  12.4
 
 
 *** Test Cases ***


### PR DESCRIPTION
With RHOAI 2.19 the IDE workbenches 2025.1 were introduced.

Tested locally with:
```
./run_robot_test.sh --extra-robot-args '-i JupyterHub -e AutomationBug -e ProductBug -e ExcludeOnRHOAI -e Resources-GPU -e Resources-2GPUS -e NVIDIA-GPUs' --open-report true
```