### PR TITLE
Skip Training operator smoke check for RHOAI < 2.19.0

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-smoke.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-smoke.robot
@@ -58,6 +58,7 @@ Training operator smoke test
     [Tags]    Smoke
     ...       DistributedWorkloads
     ...       Training
+    Skip If Operator Starting Version Is Not Supported      minimum_version=2.19.0
     Log To Console    Waiting for kubeflow-training-operator to be available
     ${result} =    Run Process    oc wait --for\=condition\=Available --timeout\=300s -n ${APPLICATIONS_NAMESPACE} deployment/kubeflow-training-operator
     ...    shell=true    stderr=STDOUT


### PR DESCRIPTION
Check is skipped for older versions to prevent smoke tests after upgrade to fail, as before 2.19.0 Training operator was disabled by default.