### PR TITLE
Improve Component Should Be Enabled robustness

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -436,13 +436,19 @@ Wait For DataScienceCluster CustomResource To Be Ready
 
 Component Should Be Enabled
     [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
-    ${status} =    Is Component Enabled    ${component}    ${dsc_name}
-    IF    '${status}' != 'true'    Fail
+    ${status} =   Set Variable   False
+    WHILE   '${status}' != 'true'    limit=60 seconds
+        ${status} =    Is Component Enabled    ${component}    ${dsc_name}
+        IF    '${status}' == 'true'    BREAK
+    END
 
 Component Should Not Be Enabled
     [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
-    ${status} =    Is Component Enabled    ${component}    ${dsc_name}
-    IF    '${status}' != 'false'    Fail
+    ${status} =   Set Variable   True
+    WHILE   '${status}' != 'false'    limit=60 seconds
+        ${status} =    Is Component Enabled    ${component}    ${dsc_name}
+        IF    '${status}' == 'false'    BREAK
+    END
 
 Is Component Enabled
     [Documentation]    Returns the enabled status of a single component (true/false)


### PR DESCRIPTION
Improve the 'Component Should /Not Be Enabled' Keyword robustness through a WHILE loop to allow time and several tries for the DSC to leave the component in the final Managed/Removed state