### PR TITLE
Add new images for ovms and caikit tgis runtime for 2.19

### DIFF
--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_grpc.yaml
@@ -23,7 +23,7 @@ spec:
       ## Note: cannot add readiness/liveness probes to this container because knative will refuse them.
       # multi-container probing will be available after https://github.com/knative/serving/pull/14853 is merged
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:3cbd01ca3c79de84eec111fa451fef6e2071d11c74550692d04862e45bc95e0a
+      image: quay.io/modh/caikit-tgis-serving@sha256:2c7eef73708b5d73de33153459ac7238fdcf517cdc3544c775981f5814b4b6ed
       env:
         - name: RUNTIME_LOCAL_MODELS_DIR
           value: /mnt/models

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/caikit_tgis_servingruntime_http.yaml
@@ -21,7 +21,7 @@ spec:
       #     cpu: 8
       #     memory: 16Gi
     - name: transformer-container
-      image: quay.io/modh/caikit-tgis-serving@sha256:3cbd01ca3c79de84eec111fa451fef6e2071d11c74550692d04862e45bc95e0a
+      image: quay.io/modh/caikit-tgis-serving@sha256:2c7eef73708b5d73de33153459ac7238fdcf517cdc3544c775981f5814b4b6ed
       env:
         - name: TRANSFORMERS_CACHE
           value: /tmp/transformers_cache

--- a/ods_ci/tests/Resources/Files/llm/serving_runtimes/ovms_servingruntime_http.yaml
+++ b/ods_ci/tests/Resources/Files/llm/serving_runtimes/ovms_servingruntime_http.yaml
@@ -17,7 +17,7 @@ spec:
         - --rest_bind_address=0.0.0.0
         - --target_device=AUTO
         - --metrics_enable
-      image: quay.io/modh/openvino_model_server@sha256:f1140e9d987580d1aab1ccc62519b48b1d2673308b2db496e9e505e3be788d9f
+      image: quay.io/modh/openvino_model_server@sha256:53b7fcf95de9b81e4c8652d0bf4e84e22d5b696827a5d951d863420c68b9cfe8
       name: kserve-container
       ports:
         - containerPort: 8888


### PR DESCRIPTION
Need to be Backported to release-2.19 branch once merged 