### PR TITLE
Add Feature Store smoke tests

### DIFF
--- a/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
+++ b/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
@@ -1,0 +1,18 @@
+*** Settings ***
+Documentation    This is a resource file for Distributed Workloads.
+Library          OperatingSystem
+Library          Process
+Resource         ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+
+
+*** Keywords ***
+Prepare Feature Store Test Suite
+    [Documentation]   Prepare Feature store setup by enabling component
+    RHOSi Setup
+    Enable Component    feastoperator
+    Wait Component Ready    feastoperator
+
+Cleanup Feature Store Setup
+    [Documentation]   cleanup Feature store setup by Disabling component
+    Disable Component    feastoperator
+    RHOSi Teardown

--- a/ods_ci/tests/Tests/0700__feature_store/test-smoke.robot
+++ b/ods_ci/tests/Tests/0700__feature_store/test-smoke.robot
@@ -1,0 +1,41 @@
+*** Settings ***
+Documentation     Smoke tests for Feature Store
+Library           Process
+Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
+Resource          ../../Resources/Page/FeatureStore/FeatureStore.resource
+Suite Setup       Prepare Feature Store Test Suite
+Suite Teardown    Cleanup Feature Store Setup
+
+
+*** Test Cases ***
+Feature Store Smoke Test
+    [Documentation]    Check that Feature Store deployment and its service are up and running
+    [Tags]    Smoke
+    ...       FeatureStore
+    ...       RHOAIENG-23588
+
+    # Verify feature store operator deployment available
+    Log To Console    Waiting for Feature store operator deployment to be available
+    ${result} =    Run Process    oc wait --for\=condition\=Available --timeout\=300s -n ${APPLICATIONS_NAMESPACE} deployment/feast-operator-controller-manager
+    ...    shell=true    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL    Timeout waiting for deployment/feast-operator-controller-manager to be available in ${APPLICATIONS_NAMESPACE}
+    END
+    Log To Console    feast-operator-controller-manager deployment is available
+
+    # Verify feature store oeprator metrics service exists
+    ${result} =    Run Process    oc get service -n ${APPLICATIONS_NAMESPACE} feast-operator-controller-manager-metrics-service
+    ...    shell=true    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL    Can not find feast-operator-controller-manager-metrics-service in ${APPLICATIONS_NAMESPACE}
+    END
+    Log To Console    feast-operator-controller-manager-metrics-service exists
+
+    #  Verify feature store operator container image referrence
+    Log To Console    Verifying feast-operator-controller-manager container image is referred from registry.redhat.io
+    ${pod} =    Find First Pod By Name  namespace=${APPLICATIONS_NAMESPACE}   pod_regex=feast-operator-controller-manager
+    Container Image Url Should Contain      ${APPLICATIONS_NAMESPACE}     ${pod}      manager
+    ...     registry.redhat.io/rhoai/odh-feast-operator
+    Log To Console    feast-operator-controller-manager's container image is verified


### PR DESCRIPTION
closes [RHOAIENG-23588](https://issues.redhat.com/browse/RHOAIENG-23588)
Added Feature Store smoke tests to validate the installation of the Feature Store operator pod deployment and ensure its services and image reference are functioning correctly.