### PR TITLE
fix the data id selector for the connection selection for RHOAI 2.20+

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Pipelines.resource
@@ -44,8 +44,8 @@ Select Data Connection
     ...                in the modal for Pipeline Server creation
     [Arguments]    ${dc_name}
     # robocop: off=line-too-long
-    Wait Until Page Contains Element    xpath://button[@data-testid="select-data-connection"]
-    Click Button                        xpath://button[@data-testid="select-data-connection"]
+    Wait Until Page Contains Element    xpath://button[@data-testid="select-connection"]
+    Click Button                        xpath://button[@data-testid="select-connection"]
     Wait Until Page Contains Element    xpath://button//*[text()="${dc_name}"]
     Click Element    xpath://button//*[text()="${dc_name}"]
 


### PR DESCRIPTION
The xpath changed with the RHOAI 2.20 nighlty build, so this change fix it for our tests.

CI:
![image](https://github.com/user-attachments/assets/d7ba8659-383d-4bdd-bea3-5296fa5e3c10)
