### PR TITLE
Interop tests - update exclude args

### DIFF
--- a/ods_ci/run_interop.sh
+++ b/ods_ci/run_interop.sh
@@ -22,7 +22,14 @@ run_tests() {
   TEST_CASE_FILE="tests/Tests"
   TEST_SUITE=$1
 
-  poetry run robot --include ${TEST_SUITE} --exclude "ExcludeOnRHOAI" --exclude "AutomationBug" --exclude "ProductBug" -d ${ARTIFACT_DIR}/${TEST_SUITE} -x xunit_test_result.xml -r test_report.html --variablefile ${TEST_VARIABLES_FILE} ${TEST_CASE_FILE}
+  poetry run robot \
+    --include ${TEST_SUITE} \
+    --exclude "ExcludeOnRHOAI" \
+    --exclude "AutomationBug" \
+    --exclude "ProductBug" \
+    --exclude "Dashboard" \
+    --exclude "deprecatedTest" \
+    -d ${ARTIFACT_DIR}/${TEST_SUITE} -x xunit_test_result.xml -r test_report.html --variablefile ${TEST_VARIABLES_FILE} ${TEST_CASE_FILE}
 }
 
 if [[ ${TEST_SUITE} == "PostUpgrade" ]]; then


### PR DESCRIPTION
Multiple errors from deprecated tests at:  https://prow.ci.openshift.org/view/gs/test-platform-results/logs/periodic-ci-red-hat-data-services-ods-ci-release-2.19-rhoai-ocp4.19-interop-rhoai-interop-aws/1916734339152875520