### PR TITLE
RHOAIENG-12886 - ODS-2170: Verify Data Science Pipelines Application …

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -368,3 +368,9 @@ Is Test Enviroment ROSA-HCP
     ELSE
         RETURN    ${FALSE}
     END
+
+Get Access Token
+    [Documentation]    Fetch the current users's token
+    ${rc}    ${out}=    Run And Return Rc And Output    oc whoami -t
+    Should Be Equal As Integers    ${rc}    ${0}    Command 'oc whoami -t' returned non-zero exit code: ${rc}
+    RETURN    ${out}


### PR DESCRIPTION
…Alerts

**JIRA:** [RHOAIENG-12886 - ODS-2170: Verify Data Science Pipelines Application Alerts](https://issues.redhat.com/browse/RHOAIENG-12886)

I revised the test case a bit as opposed to how it was defined in Polarion. In the end I omitted these steps because of a low added value and unnecessarily prolonging the test (which already takes 8 and a half minutes):
1. "Verify alerts are firing also in Alertmanager" - I implemented this first but as it is a part of Prometheus, I then realized that it would be testing Prometheus and Alertmanager communication, not RHOAI. Also, Alertmanager config is already tested by other tests.
2. "Verify that the alert can be seen in OpenShift Cluster Monitoring Prometheus" - RHOAI Prometheus already consumes OpenShift Cluster Prometheus metrics via `/federate` endpoint, so we are effectively testing that.
3. "(Optionally) verify that the alert can be seen in Telemeter" - This would be testing that a managed cluster is able to send alerts to Red Hat Console, so again not testing RHOAI.

Test runs:
* Single test: /job/rhoai/job/2.20/job/managed/job/cli/job/aws/job/rhoai-tier2/3/
* All Monitoring test cases (failures are expected as those test cases are not stabilized yet): /job/rhoai/job/2.20/job/managed/job/cli/job/aws/job/rhoai-tier2/4/