### PR TITLE
Skip pipeline tests on ROSA HCP and deprecate pipeline UI test

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -6,6 +6,7 @@ Library   DependencyLibrary
 Library   Process
 Library   RequestsLibrary
 Library   ../../libs/Helpers.py
+Resource  OCP.resource
 Resource  Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource  Page/ODH/JupyterHub/JupyterHubSpawner.robot
 Resource  ../../tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -335,6 +336,16 @@ Skip If Namespace Does Not Exist
        Skip If    condition="${rc}"!="${0}"    msg=${msg}
     ELSE
        Skip If    condition="${rc}"!="${0}"    msg=This test is skipped because namespace ${namespace} does not exist
+    END
+
+Skip If Test Enviroment Is ROSA-HCP
+    [Documentation]    Skips test if test environment is ROSA_HCP
+    [Arguments]    ${msg}=${EMPTY}
+    ${is_rosa_hcp}=    Is Test Enviroment ROSA-HCP
+    IF    "${msg}" != "${EMPTY}"
+       Skip If    condition=${is_rosa_hcp}==${TRUE}    msg=${msg}
+    ELSE
+       Skip If    condition=${is_rosa_hcp}==${TRUE}    msg=This test is skipped for ROSA-HCP clusters
     END
 
 Run Keyword If RHODS Is Managed

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1100__data-science-pipelines-acceptance.robot
@@ -23,6 +23,7 @@ Verify Hello World Pipeline Runs Successfully    # robocop: disable:too-long-tes
     [Documentation]    Runs a quick hello-world pipeline and verifies that it finishes successfully
     [Tags]    Smoke
 
+    Skip If Test Enviroment Is ROSA-HCP    msg=Skipped due to automation bug on ROSA-HCP (tracked at RHOAIENG-16414)
     ${pipeline_run_params}=    Create Dictionary    message=Hello world!
 
     ${pipeline_id}    ${pipeline_version_id}    ${pipeline_run_id}    ${experiment_id}=

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1101__data-science-pipelines-kfp.robot
@@ -25,6 +25,7 @@ Verify Users Can Create And Run A Pipeline That Uses Only Packages From Base Ima
     ...   This is a simple pipeline, where the tasks doesn't have any packages_to_install and just needs
     ...   the python packages included in the base_image
     [Tags]      Smoke    ODS-2203
+    Skip If Test Enviroment Is ROSA-HCP    msg=Skipped due to automation bug on ROSA-HCP (tracked at RHOAIENG-16414)
     ${emtpy_dict}=    Create Dictionary
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}
@@ -43,6 +44,7 @@ Verify Users Can Create And Run A Pipeline That Uses Custom Python Packages To I
     ...   In this pipeline there are tasks defining with packages_to_install some custom python packages to
     ...   be installed at execution time
     [Tags]      Smoke
+    Skip If Test Enviroment Is ROSA-HCP    msg=Skipped due to automation bug on ROSA-HCP (tracked at RHOAIENG-16414)
     ${emtpy_dict}=    Create Dictionary
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}
@@ -60,6 +62,7 @@ Verify Upload Download In Data Science Pipelines Using The kfp Python Package
     [Documentation]    Creates, runs pipelines with regular user. Double check the pipeline result and clean
     ...    the pipeline resources.
     [Tags]    Sanity    ODS-2683
+    Skip If Test Enviroment Is ROSA-HCP    msg=Skipped due to automation bug on ROSA-HCP (tracked at RHOAIENG-16414)
     ${upload_download_dict}=    Create Dictionary    mlpipeline_minio_artifact_secret=value    bucket_name=value
     End To End Pipeline Workflow Using Kfp
     ...    admin_username=${TEST_USER.USERNAME}

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1102__data-science-pipelines-api.robot
@@ -22,6 +22,7 @@ Verify Admin Users Can Create And Run a Data Science Pipeline Using The Api
     [Documentation]    Creates, runs pipelines with admin user. Double check the pipeline result and clean
     ...    the pipeline resources.
     [Tags]      Sanity    ODS-2083
+    Skip If Test Enviroment Is ROSA-HCP    msg=Skipped due to automation bug on ROSA-HCP (tracked at RHOAIENG-16414)
     End To End Pipeline Workflow Via Api    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    pipelinesapi1
     [Teardown]   Projects.Delete Project Via CLI By Display Name    pipelinesapi1
 

--- a/ods_ci/tests/Tests/1100__data_science_pipelines/1150__data-science-pipelines-ui.robot
+++ b/ods_ci/tests/Tests/1100__data_science_pipelines/1150__data-science-pipelines-ui.robot
@@ -32,7 +32,7 @@ Verify User Can Create, Run and Delete A DS Pipeline From DS Project Details Pag
     ...    The pipeline to run will be using the values for pip_index_url and pip_trusted_host
     ...    availables in a ConfigMap created in the SuiteSetup.
     ...    AutomationBug: RHOAIENG-10941
-    [Tags]    Smoke
+    [Tags]    Smoke    deprecatedTest
     ...       ODS-2206    ODS-2226    ODS-2633
 
     Open Data Science Project Details Page    ${PRJ_TITLE}


### PR DESCRIPTION
- When running on ROSA HCP, skip some pipeline tests as they are broken (will be fixed in https://issues.redhat.com/browse/RHOAIENG-16414)
- Deprecate DSP UI test, as there is already a cypress test doing the same (discussed on [slack](https://redhat-internal.slack.com/archives/C03V3J222D7/p1746173625276269)) 