### PR TITLE
Fix DSC Component version verification

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
@@ -408,8 +408,7 @@ Verify DSC Contains Correct Component Versions  # robocop: disable:too-long-test
             END
             ${component_metadata_content} =  Get File  ${component_metadata_file}
             ${component_metadata} =    Evaluate     yaml.safe_load("""${component_metadata_content}""")    yaml
-            Dictionaries Should Be Equal    ${component_versions_json}[${c}]   ${component_metadata}
-            ...    ignore_keys=['managementState', 'defaultDeploymentMode', 'serverlessMode']
+            Lists Should Be Equal    ${component_versions_json}[${c}][releases]   ${component_metadata}[releases]
             ...    msg=Component versions in DSC don't match component metadata in repo
         ELSE
             Log  ${c} does not provide component_metadata.yaml


### PR DESCRIPTION
Only consider the `releases` part of the component status to prevent false positives caused by any additional entries in the status.