### PR TITLE
[2.19] RHOSi.resource: Include rhaiseng domain as a selfmanaged cluster

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -95,7 +95,7 @@ Required Global Variables Should Exist
 
 Fetch Cluster Type By Domain
     [Documentation]    This Keyword outputs the kind of cluster depending on the console URL domain
-    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods
+    ${matches}=    Get Regexp Matches    ${OCP_CONSOLE_URL}    rh-ods|rhaiseng
     ${matches_len}=     Get Length      ${matches}
     IF  '${matches_len}' == '0'
         Set Global Variable    ${CLUSTER_TYPE}    managed


### PR DESCRIPTION
Backport of #2444 for release-2.19.