### PR TITLE
Update multi-arch must-gather image

### DIFF
--- a/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
@@ -9,7 +9,7 @@ for dir in must-gather.local*; do
     fi
 done
 
-oc adm must-gather --image=quay.io/modh/must-gather@sha256:9d5988f45c3b00ec7fbbe7a8a86cc149a2768c9c47e207694fdb6e87ef44adf3 -- "export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE};export APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}; /usr/bin/gather" &> must-gather-results.txt
+oc adm must-gather --image=quay.io/modh/must-gather:rhoai-2.19 -- "export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE};export APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}; /usr/bin/gather" &> must-gather-results.txt
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
Must-gather tests pass with multi-arch image for PPC64LE

[root@abhinav-rabari-21-bastion-0 ods_ci]#  sh run_robot_test.sh --skip-oclogin true --extra-robot-args '-i SmokeANDOperator  -e AutomationBug -e ProductBug -e ExcludeOnRHOAI -e Resources-*'
test-variables.yml
INFO: we found a yq executable
skipping OC login as per parameter --skip-oclogin
Git revision refname='HEAD', venvdir='HEAD'.
Checking whether '/root/.local/ods-ci/HEAD/.venv' exists.
Checking whether '/root/.local/ods-ci/master/.venv' exists.
Pre-created virtual environment has not been found in '/root/.local/ods-ci/master/.venv'. All dependencies will be installed from scratch.
Python '/root/.cache/pypoetry/virtualenvs/ods-ci-s2o86PBC-py3.11/bin/python' will be used
Installing dependencies from lock fileNo dependencies to install or updateInstalling the current project: ods-ci (0.1.0)
==============================================================================
Tests
==============================================================================
Tests.Platform
==============================================================================
Tests.Platform.Deploy
==============================================================================
Tests.Platform.Deploy.Installation
==============================================================================
 - RPA.core.certificates - INFO - Truststore not in use, HTTPS traffic validated against `certifi` package. (requires Python 3.10.12 and 'pip' 23.2.1 at minimum)
Tests.Platform.Deploy.Installation.Post Install :: Post install test cases ...
==============================================================================
[ WARN ] No Prometheus namespace found
Verify All The Pods Are Using Image Digest Instead Of Tags :: Veri... | PASS |
------------------------------------------------------------------------------
Verify No Application Pods Run With Anyuid SCC Or As Root :: Verif... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Deploy.Installation.Post Install :: Post install te... | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Installation.Operator :: Post install test cases that...
==============================================================================
[ WARN ] No Prometheus namespace found
DataScienceCluster default-dsc in the namespace redhat-ods-operator attribute .status.release.name value is OpenShift AI Self-Managed
DSCInitialization default-dsci in the namespace redhat-ods-operator attribute .status.release.name value is OpenShift AI Self-Managed
DataScienceCluster default-dsc in the namespace redhat-ods-operator attribute .status.release.version value is 2.19.0
DSCInitialization default-dsci in the namespace redhat-ods-operator attribute .status.release.version value is 2.19.0
Verify That DSC And DSCI Release.Name Attribute matches OpenShift ... | PASS |
------------------------------------------------------------------------------
Verify That DSC And DSCI Release.Version Attribute matches the val... ..ClusterServiceVersion rhods-operator.2.19.0 in the namespace redhat-ods-operator attribute .spec.version value is 2.19.0
Verify That DSC And DSCI Release.Version Attribute matches the val... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Deploy.Installation.Operator :: Post install test c... | PASS |
2 tests, 2 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Installation                                    | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators
==============================================================================
Tests.Platform.Deploy.Operators.Rhods Operator
==============================================================================
Tests.Platform.Deploy.Operators.Rhods Operator.Trusted Ca Bundles :: Test C...
==============================================================================
[ WARN ] No Prometheus namespace found
Validate Trusted CA Bundles State Managed :: The purpose of this t... | PASS |
------------------------------------------------------------------------------
Validate Trusted CA Bundles State Unmanaged :: The purpose of this... | PASS |
------------------------------------------------------------------------------
Validate Trusted CA Bundles State Removed :: The purpose of this t... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Deploy.Operators.Rhods Operator.Trusted Ca Bundles ... | PASS |
3 tests, 3 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators.Rhods Operator.Component Images :: Test Sui...
==============================================================================
[ WARN ] No Prometheus namespace found
Check For Correct Component Images :: The purpose is to enforce th... ........IMAGE ON CSV IS registry.redhat.io/rhoai/odh-dashboard-rhel8@sha256:9480b536042bee82632114749d1dadec0c47c4f0782fb7e02524620ec8ad8fb8
status:PASS
SUCCESS: Both CSV and Deployment odh_dashboard_image images match
Check For Correct Component Images :: The purpose is to enforce th... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Deploy.Operators.Rhods Operator.Component Images ::... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators.Rhods Operator                        | PASS |
4 tests, 4 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators.Serverless Operator
==============================================================================
Tests.Platform.Deploy.Operators.Serverless Operator.Serverless Operator :: ...
==============================================================================
[ WARN ] No Prometheus namespace found
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc condition met
Component kserve.serving state Removed
"Suite Setup: KServe.serving state: Removed"
Check value for serverless cert on CSV :: Check value for serverle... .{
  "apiVersion": "datasciencecluster.opendatahub.io/v1",
  "kind": "DataScienceCluster",
  "metadata": {
    "name": "default-dsc",
    "labels": {
      "app.kubernetes.io/name": "datasciencecluster",
      "app.kubernetes.io/instance": "default-dsc",
      "app.kubernetes.io/part-of": "rhods-operator",
      "app.kubernetes.io/managed-by": "kustomize",
      "app.kubernetes.io/created-by": "rhods-operator"
    }
  },
  "spec": {
    "components": {
      "codeflare": {
        "managementState": "Managed"
      },
      "dashboard": {
        "managementState": "Managed"
      },
      "datasciencepipelines": {
        "managementState": "Managed"
      },
      "kserve": {
        "managementState": "Managed",
        "serving": {
          "ingressGateway": {
            "certificate": {
              "type": "OpenshiftDefaultIngress"
            }
          },
          "managementState": "Managed",
          "name": "knative-serving"
        }
      },
      "kueue": {
        "managementState": "Managed"
      },
      "modelmeshserving": {
        "managementState": "Managed"
      },
      "modelregistry": {
        "managementState": "Removed",
        "registriesNamespace": "rhoai-model-registries"
      },
      "ray": {
        "managementState": "Managed"
      },
      "workbenches": {
        "managementState": "Managed"
      },
      "trainingoperator": {
        "managementState": "Managed"
      },
      "trustyai": {
        "managementState": "Managed"
      }
    }
  }
}
Check value for serverless cert on CSV :: Check value for serverle... | PASS |
------------------------------------------------------------------------------
Component kserve/serving state was set to Removed
"Restored Saved State: Removed"
datasciencecluster.datasciencecluster.opendatahub.io/default-dsc condition met
Tests.Platform.Deploy.Operators.Serverless Operator.Serverless Ope... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators.Serverless Operator                   | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform.Deploy.Operators                                       | PASS |
5 tests, 5 passed, 0 failed
==============================================================================
Tests.Platform.Deploy                                                 | PASS |
9 tests, 9 passed, 0 failed
==============================================================================
Tests.Platform.Monitor And Manage
==============================================================================
Tests.Platform.Monitor And Manage.Alerts
==============================================================================
Tests.Platform.Monitor And Manage.Alerts.Alerts :: RHODS monitoring alerts ...
==============================================================================
Verify All Alerts Severity :: Verifies that all alerts have the ex... | SKIP |
Skipped in parent suite setup:
This test is skipped for Self-managed RHODS
------------------------------------------------------------------------------
Tests.Platform.Monitor And Manage.Alerts.Alerts :: RHODS monitorin... | SKIP |
Skipped in suite teardown:
This test is skipped for Self-managed RHODSEarlier message:
Skipped in suite setup:
This test is skipped for Self-managed RHODS1 test, 0 passed, 0 failed, 1 skipped
==============================================================================
Tests.Platform.Monitor And Manage.Alerts                              | SKIP |
1 test, 0 passed, 0 failed, 1 skipped
==============================================================================
Tests.Platform.Monitor And Manage                                     | SKIP |
1 test, 0 passed, 0 failed, 1 skipped
==============================================================================
Tests.Platform.Must Gather
==============================================================================
Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must-gather i...
==============================================================================
Verify that the must-gather image provides RHODS logs and info :: ... | PASS |
------------------------------------------------------------------------------
Tests.Platform.Must Gather.Test-Must-Gather-Logs :: Tests the must... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform.Must Gather                                            | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Platform                                                        | PASS |
11 tests, 10 passed, 0 failed, 1 skipped
==============================================================================
Tests                                                                 | PASS |
11 tests, 10 passed, 0 failed, 1 skipped
================================================== 