### PR TITLE
rhods_operator_logs: Check return code for easier failure analysis

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0108__rhods_operator_logs_verification.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0108__rhods_operator_logs_verification.robot
@@ -30,7 +30,8 @@ Verify RHODS Operator Logs After Restart
    #Get the POD name
    ${data}       Run Keyword   Oc Get   kind=Pod     namespace=${OPERATOR_NAMESPACE}   label_selector=${OPERATOR_LABEL_SELECTOR}
    #Capture the logs based on containers
-   ${val}        Run   oc logs --tail=-1 ${data[0]['metadata']['name']} -n ${OPERATOR_NAMESPACE} -c ${OPERATOR_POD_CONTAINER_NAME}
+   ${rc}    ${val}    Run And Return Rc And Output   oc logs --tail=-1 ${data[0]['metadata']['name']} -n ${OPERATOR_NAMESPACE} -c ${OPERATOR_POD_CONTAINER_NAME}
+   Run Keyword And Continue On Failure    Should Be Equal As Integers    ${rc}    0    oc command didn't end successfully
    #To check if command has been successfully executed and the logs have been captured
    IF    len($val)==${0}     FAIL   Either OC command has not been executed successfully or Logs are not present
    #Filter the error msg from the log captured


### PR DESCRIPTION
I encountered that the oc logs command returned empty output. This could be perfectly valid if there is no log in the beginning when the container is started though I am adding further checks for possible failure analysis in the future.