### PR TITLE
[2.19] add whole gateway name to differentiate between the other gateway CR

### DIFF
--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -223,7 +223,7 @@ Wait Until CRD Exists
     ...    Oc Get    kind=CustomResourceDefinition    name=${crd_fullname}
 
 Resource Should Exist
-    [Documentation]    Check resource existson a namespace
+    [Documentation]    Check resource exists on a namespace
     [Arguments]       ${resource}     ${resource_name}    ${namespace}
     ${rc}    ${out}=     Run and Return Rc And Output
     ...  oc get ${resource} ${resource_name} -n ${namespace}

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0105__serverless_operator/0105__serverless_operator.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0105__serverless_operator/0105__serverless_operator.robot
@@ -40,13 +40,13 @@ Validate DSC creates all Serverless CRs
     Wait Knative Serving CR To Be In Ready State
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Resource Should Exist     Gateway    knative-ingress-gateway     ${KNATIVESERVING_NS}
+    ...    Resource Should Exist     gateway.networking.istio.io    knative-ingress-gateway     ${KNATIVESERVING_NS}
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Resource Should Exist     Gateway    knative-local-gateway     ${KNATIVESERVING_NS}
+    ...    Resource Should Exist     gateway.networking.istio.io    knative-local-gateway     ${KNATIVESERVING_NS}
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Resource Should Exist     Gateway    kserve-local-gateway     ${ISTIO_NS}
+    ...    Resource Should Exist     gateway.networking.istio.io    kserve-local-gateway     ${ISTIO_NS}
 
     Wait Until Keyword Succeeds    5 min    0 sec
     ...    Resource Should Exist     Service    kserve-local-gateway     ${ISTIO_NS}
@@ -100,13 +100,13 @@ Validate DSC Kserve Serving Removed State When Mode Is RawDeployment
     Wait For DSC Ready State    ${OPERATOR_NAMESPACE}    default-dsc
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Is Resource Present     Gateway    knative-ingress-gateway     ${KNATIVESERVING_NS}   ${IS_NOT_PRESENT}
+    ...    Is Resource Present     gateway.networking.istio.io    knative-ingress-gateway     ${KNATIVESERVING_NS}   ${IS_NOT_PRESENT}
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Is Resource Present     Gateway    knative-ingress-gateway     ${KNATIVESERVING_NS}   ${IS_NOT_PRESENT}
+    ...    Is Resource Present     gateway.networking.istio.io    knative-ingress-gateway     ${KNATIVESERVING_NS}   ${IS_NOT_PRESENT}
 
     Wait Until Keyword Succeeds    5 min    0 sec
-    ...    Is Resource Present     Gateway    kserve-local-gateway     ${ISTIO_NS}    ${IS_NOT_PRESENT}
+    ...    Is Resource Present     gateway.networking.istio.io    kserve-local-gateway     ${ISTIO_NS}    ${IS_NOT_PRESENT}
 
     Wait Until Keyword Succeeds    5 min    0 sec
     ...    Is Resource Present     Service    kserve-local-gateway     ${ISTIO_NS}    ${IS_NOT_PRESENT}
@@ -183,7 +183,7 @@ Restore Kserve Mode And Serving State
 
         # Note: May not need the following, as it is just a sanity-check
         Wait Until Keyword Succeeds    5 min    0 sec
-        ...    Resource Should Exist     Gateway    knative-ingress-gateway     ${KNATIVESERVING_NS}
+        ...    Resource Should Exist     gateway.networking.istio.io    knative-ingress-gateway     ${KNATIVESERVING_NS}
 
     ELSE
         Wait Until Keyword Succeeds    5 min    0 sec


### PR DESCRIPTION
backport of https://github.com/red-hat-data-services/ods-ci/pull/2475 to release-2.19 branch