### PR TITLE
Deprecate 'Verify Dashboard Is Shipped And Enabled Within ODS'

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0103__dashboard.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0103__dashboard.robot
@@ -15,6 +15,7 @@ Verify Dashboard Is Shipped And Enabled Within ODS
     [Tags]    Sanity
     ...       Tier1
     ...       ODS-233
+    ...       deprecatedTest
     [Setup]     Set Expected Replicas Based On Version
     @{dashboard_pods_info} =    Fetch Dashboard Pods
     @{dashboard_deployments_info} =    Fetch Dashboard Deployments


### PR DESCRIPTION
As discussed on Slack, this test is now obsolete and should be deprecated.