### PR TITLE
Exclude FeatureStore tests on ODH

### DIFF
--- a/ods_ci/tests/Tests/0700__feature_store/test-run-feast-operator-e2e.robot
+++ b/ods_ci/tests/Tests/0700__feature_store/test-run-feast-operator-e2e.robot
@@ -6,7 +6,7 @@ Library           Process
 Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 Resource          ../../../tests/Resources/Common.robot
 Resource          ../../Resources/Page/FeatureStore/FeatureStore.resource
-
+Test Tags         ExcludeOnODH
 
 *** Test Cases ***
 Run runTestDeploySimpleCRFunc test

--- a/ods_ci/tests/Tests/0700__feature_store/test-smoke.robot
+++ b/ods_ci/tests/Tests/0700__feature_store/test-smoke.robot
@@ -6,7 +6,7 @@ Resource          ../../Resources/Page/FeatureStore/FeatureStore.resource
 Resource          ../../../tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
 Suite Setup       Prepare Feature Store Test Suite
 Suite Teardown    Cleanup Feature Store Setup
-
+Test Tags         ExcludeOnODH
 
 *** Test Cases ***
 Feature Store Smoke Test


### PR DESCRIPTION
The component FeatureStore is not supported on ODH.
ODH is built in CPaaS while FeatureStore only in Konflux.