### PR TITLE
RHOAIENG-23490 - Create test to verify images used by RHOAI are corre…

### DIFF
--- a/ods_ci/tests/Resources/Page/Components/Components.resource
+++ b/ods_ci/tests/Resources/Page/Components/Components.resource
@@ -94,15 +94,24 @@ Check Image Pull Path Is Redhatio
         RETURN
     END
 
-    ${rc}   ${image}=    Run And Return Rc And Output
+    ${rc}   ${images}=    Run And Return Rc And Output
     ...    oc get deployment/${deployment_name} -n ${APPLICATIONS_NAMESPACE} -o jsonpath="{..image}"
-    Should Be Equal As Integers    ${rc}    0    msg=${image}
+    Should Be Equal As Integers    ${rc}    0    msg=${images}
+    ${images}=    Split String    ${images}    ${SPACE}
 
-    Log To Console    Check deployment ${deployment_name} pull path for image ${image}
-    IF  "registry.redhat.io" in $image
-        Log To Console    Deployment ${deployment_name} image contains pull path registry.redhat.io
-    ELSE
-        Fail    Deployment image  ${deployment_name} does not contain pull path registry.redhat.io
+    ${rc}   ${relatedImages}=    Run And Return Rc And Output
+    ...    oc get csv ${OPERATOR_NAME}.${RHODS_VERSION} -n ${OPERATOR_NAMESPACE} -o jsonpath="{.spec.relatedImages[*].image}"
+    Should Be Equal As Integers    ${rc}    0    msg=${relatedImages}
+    ${relatedImages}=    Split String    ${relatedImages}    ${SPACE}
+
+    FOR  ${image}    IN    @{images}
+        Log To Console    Check deployment ${deployment_name} pull path for image ${image}
+        Run Keyword And Continue On Failure
+        ...    Should Start With    ${image}    registry.redhat.io    msg=Deployment image pull path ${image} does not start with registry.redhat.io
+        Run Keyword And Continue On Failure
+        ...    Should Match Regexp    ${image}    @sha256:[a-f0-9]{64}$    msg=Deployment image pull path ${image} does not contain sha256 digest
+        Run Keyword And Continue On Failure
+        ...    Should Contain    ${relatedImages}    ${image}    msg=Deployment image pull path ${image} is not in CSV's relatedImages
     END
 
 Check Model Registry Namespace


### PR DESCRIPTION
…ct - Platform Team

**JIRA:** [RHOAIENG-23490](https://issues.redhat.com/browse/RHOAIENG-23490)

FYI @asanzgom this will generate conflict with #2486.


This PR enhances image verification tests to include verification that digest is used and that each image is in the operator CSV's relatedImages section.

Test run: rhoai-test-flow/4900
I ran all `Validate <COMPONENT> Managed State` test cases which call `Check Image Pull Path Is Redhatio`.