### PR TITLE
[2.19] create different upgrade configmap for user groups to avoid collisions

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -37,6 +37,7 @@ ${DW_PROJECT_CREATED}       False
 ${CODE}     while True: import time ; time.sleep(10); print ("Hello")
 ${UPGRADE_NS}    upgrade
 ${UPGRADE_CONFIG_MAP}    upgrade-config-map
+${USERGROUPS_CONFIG_MAP}    usergroups-config-map
 
 
 *** Test Cases ***
@@ -77,7 +78,7 @@ Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
     Clear User Management Settings
     # Create a configmap and store both groups
     ${return_code}    ${cmd_output}=    Run And Return Rc And Output
-    ...    oc create configmap ${UPGRADE_CONFIG_MAP} -n ${UPGRADE_NS} --from-literal=adm_groups="['rhods-admins', 'rhods-users']" --from-literal=allwd_groups="['system:authenticated']"
+    ...    oc create configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} --from-literal=adm_groups="['rhods-admins', 'rhods-users']" --from-literal=allwd_groups="['system:authenticated']"
     Should Be Equal As Integers     ${return_code}      0       msg=${cmd_output}
 
     Add OpenShift Groups To Data Science Administrators     rhods-admins    rhods-users


### PR DESCRIPTION
(cherry picked from commit f59e1020980720ff85f39af89a4bdf05dd1afb81)

This is a backport of #2483