### PR TITLE
fix: change operator name to opendatahub-operator when ODH-nigthlies

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -134,7 +134,7 @@ Assign Vars According To Product
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/rhods-operator.${OPERATOR_NAMESPACE}
             Set Suite Variable    ${IMAGE_PULL_PATH}        registry.redhat.io
             Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        quay.io
-            ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.  ${RHODS_VERSION}
+            ${CSV_NAME} =   Catenate    SEPARATOR=   opendatahub-operator.  ${RHODS_VERSION}
             Set Suite Variable      ${CSV_NAME}
             # ODH COMMUNITY
         ELSE IF     "${OPERATOR_NAME}" == "opendatahub-operator"


### PR DESCRIPTION
need to use the opendatahub-operator name for the ODH-nightlies CSV always, not the operator name, because this one points to rhods-operator