### PR TITLE
enhancement: revert auth hack as the bug is not present anymore in devel

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -152,11 +152,6 @@ Verify RHODS Installation
       Apply DataScienceCluster CustomResource    dsc_name=${DSC_NAME}    dsc_template=${DSC_TEMPLATE}
   END
 
-  # Workaround for 2.21, add the default groups in the Auth instance
-  # Once the release-2.21 branch is cut, will revert this change, as its not needed for 2.22+
-  ${return_code}    ${output} =       Run And Return Rc And Output
-  ...    oc patch Auth auth -p '{"spec":{"adminGroups":["rhods-admins"],"allowedGroups":["system:authenticated"]}}' --type=merge
-
   ${dashboard} =    Is Component Enabled    dashboard    ${DSC_NAME}
   IF    "${dashboard}" == "true"
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}


### PR DESCRIPTION
Follow up for: https://github.com/red-hat-data-services/ods-ci/pull/2501

this workaround was added for 2.21 due to a known bug. Now that release-2.21 branch has been cut, we can revert this as the bug is not present anymore in 2.22+