### PR TITLE
Fix the user access test for jupyter hub

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -102,7 +102,7 @@ Apply Access Groups Settings
 Set Access Groups Settings
     [Documentation]    Changes the rhods-groups config map to set the new access configuration
     [Arguments]     ${admins_group}   ${users_group}
-    ${return_code}    ${output}    Run And Return Rc And Output    oc patch OdhDashboardConfig odh-dashboard-config -n ${APPLICATIONS_NAMESPACE} --type=merge -p '{"spec": {"groupsConfig": {"adminGroups": "${admins_group}","allowedGroups": "${users_group}"}}}'   #robocop:disable
+    ${return_code}    ${output}    Run And Return Rc And Output    oc patch Auth auth --type=merge -p '{"spec": {"adminGroups": ["${admins_group}"], "allowedGroups": ["${users_group}"]}}'   #robocop:disable
     Should Be Equal As Integers        ${return_code}   0    msg=Patch to group settings failed
 
 Set Default Access Groups Settings

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot
@@ -30,7 +30,7 @@ Verify User Can Set Custom RHODS Groups
     ...                command. There is an another test that changes users/groups
     ...                via ODH Dashboard UI in `Settings -> User management` section, see:
     ...                `Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook` in
-    ...                tests/Tests/400__ods_dashboard/413__ods_dashboard_user_mgmt.robot
+    ...                tests/Tests/400__ods_dashboard/405__ods_dashboard_user_mgmt.robot
     [Tags]  Tier1
     ...     ODS-293    ODS-503
     [Setup]      Set Standard RHODS Groups Variables


### PR DESCRIPTION
CI:
```
$ ./run_robot_test.sh --extra-robot-args '-i ODS-503' --open-report true --skip-oclogin
```
![image](https://github.com/user-attachments/assets/247dc314-ce80-4781-8994-dd3afd375a3c)
