### PR TITLE
Fix the check of the workbench size GiB vs Gi

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -545,10 +545,15 @@ Get Container Size
    Wait Until Page Contains Element    ${KFNBC_CONTAINER_SIZE_TITLE}
    ...    timeout=30   error=Container size selector is not present in KFNBC Spawner
    Click Element    xpath:${KFNBC_CONTAINER_SIZE_DROPDOWN_XPATH}
-   Wait Until Page Contains Element    xpath://span[.="${container_size}"]/../..  timeout=10
+   Wait Until Page Contains Element    xpath://button[@role="option"]/span[.="${container_size}"]  timeout=10
+   Wait Until Page Contains Element
+   ...    xpath://li[@data-testid="${container_size}"]//span[contains(text(), "Limits")]  timeout=10
+   Sleep    1
    ${data}   Get Text  xpath://li[@data-testid="${container_size}"]//span[contains(text(), "Limits")]
    ${l_data}   Convert To Lower Case    ${data}
-   ${data}    Get Formated Container Size To Dictionary     ${l_data}
+   # Our Dashboard shows GiB, but the native interface of OpenShift uses just Gi
+   ${l_data_gi}    Replace String    ${l_data}    gib    gi
+   ${data}    Get Formated Container Size To Dictionary     ${l_data_gi}
    RETURN  ${data}
 
 Get Formated Container Size To Dictionary

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/notebook_size_verification.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/notebook_size_verification.robot
@@ -25,7 +25,7 @@ Test Tags          JupyterHub
 *** Variables ***
 ${NAMESPACE}        ${NOTEBOOKS_NAMESPACE}
 # Anything above Small requires more memory than our standard testsing cluster can provide.
-# TODO: We shall come up with some solution in the future.
+# TODO: We shall come up with some solution in the future. E.g. just check the created Notebook CR only.
 @{NOTEBOOK_SIZE}    Small    # Medium    Large    X Large
 ${DEFAULT_SIZE}     {"limits":{"cpu":"2","memory":"8gi"},"requests":{"cpu":"1","memory":"8gi"}}
 ${CUSTOME_SIZE}     {"limits":{"cpu":"6","memory":"9gi"},"requests":{"cpu":"2","memory":"6gi"}}
@@ -86,7 +86,7 @@ Spawn Notebook And Verify Size
         ${dict_pod_data}    Evaluate    json.loads('''${data}''')    json
         IF    &{dict_pod_data} != &{jh_container_size}    Run Keyword And Continue On Failure
         ...    Fail    Container size didn't match.
-        ...    Pod container size '${dict_pod_data}' and JH conaintainer is '${jh_container_size}'
+        ...    Pod container size '${dict_pod_data}' and JH container is '${jh_container_size}'
         Fix Spawner Status
     END
 


### PR DESCRIPTION
CI:
```
$ ./run_robot_test.sh --extra-robot-args '-i ODS-1072' --open-report true --skip-oclogin
```
![image](https://github.com/user-attachments/assets/d3bb00c6-bfbe-49c6-980e-f0fab8563274)
