### PR TITLE
Update Ray image references

### DIFF
--- a/ods_ci/tests/Resources/Files/pipeline-samples/v1/ray_integration.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v1/ray_integration.py
@@ -23,7 +23,7 @@ def ray_fn(openshift_server: str, openshift_token: str) -> int:
             min_memory=1,
             max_memory=1,
             num_gpus=0,
-            image="quay.io/project-codeflare/ray:latest-py39-cu118",
+            image="quay.io/modh/ray:2.47.1-py311-cu121",
             instascale=False,
         )
     )

--- a/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/ray_integration.py
+++ b/ods_ci/tests/Resources/Files/pipeline-samples/v2/cache-disabled/ray_integration.py
@@ -24,7 +24,8 @@ def ray_fn() -> int:
             worker_cpu_limits=1,
             worker_memory_requests=1,
             worker_memory_limits=2,
-            image="quay.io/modh/ray@sha256:a5b7c04a14f180d7ca6d06a5697f6bb684e40a26b95a0c872cac23b552741707",
+            # Corresponds to quay.io/modh/ray:2.47.1-py311-cu121
+            image="quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e",
             verify_tls=False
         )
     )

--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -10,12 +10,12 @@ ${CODEFLARE-SDK-RELEASE-TAG}             v0.28.1
 ${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/latest/download
-# Corresponds to quay.io/modh/ray:2.44.1-py311-cu121
-${RAY_CUDA_IMAGE_3.11}                   quay.io/modh/ray@sha256:a5b7c04a14f180d7ca6d06a5697f6bb684e40a26b95a0c872cac23b552741707
+# Corresponds to quay.io/modh/ray:2.47.1-py311-cu121
+${RAY_CUDA_IMAGE_3.11}                   quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e
 # Corresponds to quay.io/rhoai/ray:2.35.0-py311-cu121-torch24-fa26
 ${RAY_TORCH_CUDA_IMAGE_3.11}             quay.io/rhoai/ray@sha256:5077f9bb230dfa88f34089fecdfcdaa8abc6964716a8a8325c7f9dcdf11bbbb3
-# Corresponds to quay.io/modh/ray:2.44.1-py311-rocm62
-${RAY_ROCM_IMAGE_3.11}                   quay.io/modh/ray@sha256:48c7864989c8f22ef07772c698b761f5c1b58c6781e7a99518204d521bf56a4c
+# Corresponds to quay.io/modh/ray:2.47.1-py311-rocm62
+${RAY_ROCM_IMAGE_3.11}                   quay.io/modh/ray@sha256:6091617d45d5681058abecda57e0ee33f57b8855618e2509f1a354a20cc3403c
 # Corresponds to quay.io/rhoai/ray:2.35.0-py311-rocm61-torch24-fa26
 ${RAY_TORCH_ROCM_IMAGE_3.11}             quay.io/rhoai/ray@sha256:b0e129cd2f4cdea7ad7a7859031357ffd9915410551f94fbcb942af2198cdf78
 # Corresponds to quay.io/modh/fms-hf-tuning:v2.8.2


### PR DESCRIPTION
I'm unsure what `ods_ci/tests/Resources/Files/pipeline-samples/v1/ray_integration.py` is used for. If anyone knows please shout, I updated the image nonetheless as the ray version being used there is a 2 year old image...

I also updated ROCm here @pawelpaszki 