### PR TITLE
Use full machineset CRD name when provisioning GPUs

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -20,6 +20,8 @@ oc wait --timeout=3m --for jsonpath='{.status.state}'=AtLatestKnown -n nvidia-gp
 
 oc wait --timeout=3m --for condition=Installed -n nvidia-gpu-operator installplan --all
 
+sleep 5
+
 oc rollout status --watch --timeout=3m -n nvidia-gpu-operator deploy gpu-operator
 
 oc wait --timeout=3m --for jsonpath='{.status.components.labelSelector.matchExpressions[].operator}'=Exists operator gpu-operator-certified.nvidia-gpu-operator


### PR DESCRIPTION
We've started hitting an issue while provisioning GPUs on GCP clusters. It is caused by the presence of another CRD with name MachineSet

<img width="594" height="97" alt="image" src="https://github.com/user-attachments/assets/d0de6ebd-5ffe-48e4-9f4d-825f5e75c013" />


So the solution it to use the full CRD name

Additional change: short sleep before checking the NVIDIA deployment status. I've seen failing it sometimes because the deployment wasn't created immediately

PR validation: `rhoai-generalpurpose-gpu/7` OK