### PR TITLE
Omit image check for Unmanaged Kueue

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -163,10 +163,7 @@ Validate Kueue Removed To Unmanaged State Transition
     ...    ${KUEUE_DEPLOYMENT_NAME}
     ...    ${KUEUE_LABEL_SELECTOR}
     ...    namespace=${KUEUE_NS}
-    Check That Image Pull Path Is Correct
-    ...    ${KUEUE_DEPLOYMENT_NAME}
-    ...    ${IMAGE_PULL_PATH}
-    ...    namespace=${KUEUE_NS}
+    # Omit the image pull path check because Kueue is now running as a dependent operator, its image is not managed by us
 
     [Teardown]      Restore Kueue Initial State
 


### PR DESCRIPTION
The test is failing as the image is not among `relatedImages`. It is expected as it comes from a dependent operator.