### PR TITLE
chore(elyra): update pipeline name to match recent restrictions

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -45,7 +45,7 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Image
     Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     ...    img=Jupyter | Data Science | CPU | Python 3.11
     ...    runtime_image=Datascience with Python 3.11 (UBI9)
-    ...    experiment_name=standard data science pipeline
+    ...    experiment_name=standard-data-science-pipeline
 
 Verify Pipelines Integration With Elyra When Using Standard Data Science Based Images
     [Documentation]    Verifies that a workbench using an image based on the Jupyter | Data Science | CPU | Python 3.11 Image
@@ -55,9 +55,9 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Based I
     [Template]    Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     [Tags]        Tier1    ODS-2271
     [Timeout]     30m
-    Jupyter | PyTorch | CUDA | Python 3.11       Datascience with Python 3.11 (UBI9)    pytorch pipeline
-    Jupyter | TensorFlow | CUDA | Python 3.11    Datascience with Python 3.11 (UBI9)    tensorflow pipeline
-    Jupyter | TrustyAI | CPU | Python 3.11       Datascience with Python 3.11 (UBI9)    trustyai pipeline
+    Jupyter | PyTorch | CUDA | Python 3.11       Datascience with Python 3.11 (UBI9)    pytorch-pipeline
+    Jupyter | TensorFlow | CUDA | Python 3.11    Datascience with Python 3.11 (UBI9)    tensorflow-pipeline
+    Jupyter | TrustyAI | CPU | Python 3.11       Datascience with Python 3.11 (UBI9)    trustyai-pipeline
 
 
 *** Keywords ***


### PR DESCRIPTION
There were some changes in the kubeflow pipelines backend recently that restricts the pipeline name to contain just kubernetes valid characters:

* https://github.com/kubeflow/pipelines/pull/11952

```
kfp_server_api.exceptions.ApiException: (500)
Reason: Internal Server Error
HTTP response headers: HTTPHeaderDict({'content-length': '591', 'content-type': 'application/json', 'date': 'Fri, 29 Aug 2025 14:58:51 GMT', 'gap-auth': 'system:serviceaccount:elyra-test-8940:elyrajupyter-data-science-cpu@cluster.local', 'gap-upstream-address': 'ds-pipeline-dspa.elyra-test-8940.svc.cluster.local:8888', 'set-cookie': 'b21f1410306366615759d860340282b0=8a2d00db16d694e96410976d89e195e8; path=/; HttpOnly; Secure; SameSite=None'})
HTTP response body: {"error_message":"Failed to create a pipeline and a pipeline version: Failed to create a pipeline and a pipeline version: BadRequestError: Invalid pipeline name: pipeline names must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character","error_details":"Failed to create a pipeline and a pipeline version: Failed to create a pipeline and a pipeline version: BadRequestError: Invalid pipeline name: pipeline names must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character"}
```

CI:
```
$ ./run_robot_test.sh --extra-robot-args '-i ODS-2197' --open-report true --skip-oclogin
```

https://issues.redhat.com/browse/RHOAIENG-32365