### PR TITLE
fix: Pass ENABLE_NEW_OBSERVABILITY_STACK to tests

### DIFF
--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -267,6 +267,7 @@ def generate_test_config_file(
     data["NOTEBOOKS_NAMESPACE"] = config_data["NOTEBOOKS_NAMESPACE"]
     data["OPENSHIFT_PIPELINES_CHANNEL"] = config_data["OPENSHIFT_PIPELINES_CHANNEL"]
     data["RHODS_OSD_INSTALL_REPO"] = config_data["RHODS_OSD_INSTALL_REPO"]
+    data["ENABLE_NEW_OBSERVABILITY_STACK"] = config_data["ENABLE_NEW_OBSERVABILITY_STACK"]
     if config_data.get("NGC_API_KEY"):
         data["NGC_API_KEY"] = config_data["NGC_API_KEY"]
     if config_data.get("PIP_INDEX_URL"):


### PR DESCRIPTION
After [!1301 (merged)](https://github.com/ods/jenkins/-/merge_requests/1301), which added ENABLE_NEW_OBSERVABILITY_STACK to the step when RHOAI operator is being deployed, we need to add it also to the test execution step. Otherwise if a DSCI is created during the tests, it will contain new observability stack every time.