### PR TITLE
enhancement: add new observability parameters to the DSCI payload when the new stack is enabled

### DIFF
--- a/ods_ci/tasks/Resources/Files/monitoring-patch-payload.json
+++ b/ods_ci/tasks/Resources/Files/monitoring-patch-payload.json
@@ -2,6 +2,8 @@
     "spec": {
         "monitoring": {
             "managementState": "Managed",
+            "collectorReplicas": 2,
+            "alerting": {},
             "metrics": {
                 "storage": {
                     "size": "5Gi",
@@ -12,10 +14,10 @@
                     "memorylimit": "512Mi",
                     "cpurequest": "100m",
                     "memoryrequest": "256Mi"
-                },
-                "replicas": 2
+                }
             },
             "traces": {
+                "exporters": {},
                 "sampleRatio": "0.1",
                 "storage": {
                     "backend": "pv",


### PR DESCRIPTION
Adding new observability parameters for 2.24 in the DSCI payload.

collectorReplicas parameter as 2 (the default value)
alerting section
traces.exporters section

removed the metrics.replicas to use the default values (1 for SNO, 2 for multinode)