### PR TITLE
fix JupyterLab popup button XPath selector

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -341,7 +341,7 @@ Maybe Close Popup
       # Check if a popup exists
       ${accept} =    Get WebElements    xpath://div[contains(concat(' ',normalize-space(@class),' '),' jp-Dialog-footer ')]
       # Click the right most button of the popup
-      IF    ${accept}    Click Element    xpath://div[contains(concat(' ',normalize-space(@class),' '),' jp-Dialog-footer ')]/button[last()]
+      IF    ${accept}    Click Element    xpath://div[contains(concat(' ',normalize-space(@class),' '),' jp-Dialog-footer ')]//button[last()]
       Capture Page Screenshot
     END
 


### PR DESCRIPTION
<img width="1332" height="532" alt="Screenshot 2025-08-25 at 8 18 06 AM" src="https://github.com/user-attachments/assets/9bc6adec-be31-450c-8d81-7aa1b8375e36" />

<img width="1468" height="669" alt="Screenshot 2025-08-25 at 8 18 23 AM" src="https://github.com/user-attachments/assets/af724af9-c06c-4a1d-8cf2-0c4147a1b0c0" />
