### PR TITLE
Update Feature Store Release version tag for 2.24 Release

### DIFF
--- a/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
+++ b/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
@@ -6,11 +6,11 @@ Resource         ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 
 
 *** Variables ***
-${FEATURE-STORE-RELEASE-TAG}             v0.50.0
+${FEATURE-STORE-RELEASE-TAG}             v0.52.0
 ${FEATURE-STORE_DIR}                     feature-store
 ${FEATURE-STORE_REPO_URL}                %{FEATURE-STORE_REPO_URL=https://github.com/feast-dev/feast.git}
-${NOTEBOOK_IMAGE}                        quay.io/modh/odh-workbench-jupyter-pytorch-cuda-py311-ubi9@sha256:891ca3cf61bbdd256e9ed996b10d76bc460eb0fab41d1cb48d5994a8b3bd7c70
-${FEAST_VERSION}                         0.50.0
+${NOTEBOOK_IMAGE}                        quay.io/modh/odh-workbench-jupyter-datascience-cpu-py311-ubi9@sha256:dd89151814ab05939f03ce8022b64e7ebad26628f65eb7cf2a047eb92d41c9ae
+${FEAST_VERSION}                         0.52.0
 
 
 *** Keywords ***


### PR DESCRIPTION
- Added Feature store release version for rhoai 2.24 release 
- Updated image to use `jupyter-datascience-cpu` as pytorch image size is bigger and sometimes tests filing because of Timeout