### PR TITLE
fix(ide): bump the expected versions of JupyterLab and git plugin

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
@@ -18,8 +18,8 @@ Test Tags          JupyterHub
 *** Variables ***
 @{status_list}      # robocop: disable
 &{package_versions}      # robocop: disable
-${JupyterLab_Version}         v4.2
-${JupyterLab-git_Version}     v0.50
+${JupyterLab_Version}         v4.4
+${JupyterLab-git_Version}     v0.51
 
 
 *** Test Cases ***


### PR DESCRIPTION
Updated in RHOAI 2.24

Found during the https://issues.redhat.com/browse/RHOAIENG-32365