### PR TITLE
fix(platform): add a teardown in case test fails

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
@@ -300,6 +300,7 @@ Verify RHODS Notebooks Network Policies
     Should Be Equal As Strings    ${policy_oauth}    ${expected_policy_oauth}
     Log    ${policy_oauth}
     Log    ${expected_policy_oauth}
+    [Teardown]    Delete User Notebook CR    ${TEST_USER.USERNAME}
 
 Verify All The Pods Are Using Image Digest Instead Of Tags
     [Documentation]    Verifies that the all the rhods pods are using image digest


### PR DESCRIPTION
With the notebook network policy test, the workbench may stay running in case something failed during the test itself.

https://issues.redhat.com/browse/RHOAIENG-32365