### PR TITLE
fix(workbench start): waits until workbench app is truly available

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -381,7 +381,26 @@ Open Workbench
     SeleniumLibrary.Wait Until Page Contains Element    ${open_workbench_link}    timeout=30s
     SeleniumLibrary.Click Link    ${open_workbench_link}
     ${previous_handle}=    SeleniumLibrary.Switch Window    NEW
+
+    # Wait and retry if workbench is not ready yet
+    Wait Until Keyword Succeeds    2 min    5s    Verify Workbench Is Available
+
     RETURN    ${previous_handle}
+
+Verify Workbench Is Available
+    [Documentation]    Verifies that the workbench is available and ready to use.
+    ...                If "Application is not available" is detected, reload the page to retry.
+    ${app_not_available}=    Run Keyword And Return Status
+    ...    SeleniumLibrary.Page Should Contain    Application is not available
+    IF    ${app_not_available}
+        Log    msg=Application is not available, reloading page to retry...    level=INFO
+        SeleniumLibrary.Reload Page
+        # Give the page a moment to load after reload
+        Sleep    2s
+        Fail    msg=Application is not available - page reloaded for retry
+    END
+    # If we reach here, the application is available
+    Log    msg=Workbench application is available and ready    level=INFO
 
 Does Workbench Have A Description
     [Documentation]    Checks if a Workbench has a description in the list view of the project


### PR DESCRIPTION
Depsite the fact that the workbench pod is fully running, all the resources on cluster seem to be in place, there is still some delay between the RHOAI dashboard showing workbench as running ready and OpenShift app actually routing to the workbench. Let's give it some time and reload.

During the time OpenShift shows `Application is not available` text, I can see the following log lines in the oauth-proxy container of the workbench pod:

```
2025/08/29 14:25:04 server.go:3489: http: TLS handshake error from 10.128.2.2:46360: local error: tls: bad record MAC
2025/08/29 14:25:04 server.go:3489: http: TLS handshake error from 10.128.2.2:46370: local error: tls: bad record MAC
2025/08/29 14:25:05 server.go:3489: http: TLS handshake error from 10.128.2.2:54802: local error: tls: bad record MAC
2025/08/29 14:25:06 server.go:3489: http: TLS handshake error from 10.128.2.2:54812: local error: tls: bad record MAC
2025/08/29 14:25:07 server.go:3489: http: TLS handshake error from 10.128.2.2:54818: local error: tls: bad record MAC
```

Similar were seen in the past, I tend to think this is something to do with our environment preparation.

https://issues.redhat.com/browse/RHOAIENG-32365
