### PR TITLE
fix(upgrade ide): clean eventual existing Jupyter workbench before test

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -350,7 +350,7 @@ Spawn Notebook With Arguments  # robocop: disable
                 END
             END
             Spawn Notebook    ${spawner_timeout}    ${same_tab}
-            Run Keyword And Warn On Failure    Wait Until Page Contains    Log in with OpenShift    timeout=15s
+            Run Keyword And Warn On Failure    Wait Until Page Contains    Log in with    timeout=15s
             ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
             IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
             Run Keyword And Warn On Failure   Login To Openshift  ${username}  ${password}  ${auth_type}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -9,6 +9,7 @@ Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboardResources.
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHModelServing.resource
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/DataConnections.resource
 Resource            ../../Resources/Page/ODH/JupyterHub/HighAvailability.robot
+Resource            ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Projects.resource
 Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/ModelServer.resource
 Resource            ../../Resources/Page/ODH/AiApps/Anaconda.resource
@@ -263,6 +264,7 @@ Launch Notebook
     ...    ${username}=${TEST_USER2.USERNAME}
     ...    ${password}=${TEST_USER2.PASSWORD}
     ...    ${auth_type}=${TEST_USER2.AUTH_TYPE}
+    Clean All Standalone Notebooks
     Begin Web Test    username=${username}    password=${password}    auth_type=${auth_type}
     Launch Jupyter From RHODS Dashboard Link
     Spawn Notebook With Arguments


### PR DESCRIPTION
This assures that there is no Notebook CR for the Jupyter app tile running in the RHOAI instance before we do our test.

Also fixes a small string check with the current OpenShift UI appearance