### PR TITLE
task(RHOAIENG-34228): Update ray cuda image sha for multi-arch

### DIFF
--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -11,7 +11,7 @@ ${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/latest/download
 # Corresponds to quay.io/modh/ray:2.47.1-py312-cu128
-${RAY_CUDA_IMAGE_3.12}                   quay.io/modh/ray@sha256:9c72e890f5c66bb2a0f0d940120539ffc875fb6fed83380cbe2eba938e8789b1
+${RAY_CUDA_IMAGE_3.12}                   quay.io/modh/ray@sha256:fb6f207de63e442c67bb48955cf0584f3704281faf17b90419cfa274fdec63c5
 # Corresponds to quay.io/modh/ray:2.47.1-py311-cu121
 ${RAY_CUDA_IMAGE_3.11}                   quay.io/modh/ray@sha256:6d076aeb38ab3c34a6a2ef0f58dc667089aa15826fa08a73273c629333e12f1e
 # Corresponds to quay.io/rhoai/ray:2.35.0-py311-cu121-torch24-fa26


### PR DESCRIPTION
Updated Ray Python 3.12 CUDA 12.8 image sha after multi-arch update.