### PR TITLE
fix: remove service mesh condition check from the logs because of message over the limit

### DIFF
--- a/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
+++ b/ods_ci/tests/Tests/2001__disruptive_tests/2002__dsc_negative_dependant_operators_not_installed.robot
@@ -251,11 +251,6 @@ DataScienceCluster Should Fail Because Service Mesh Operator Is Not Installed
     Should Be Equal As Integers  ${return_code}   0   msg=Error retrieved DSC conditions
     Should Contain    ${output}    ServiceMesh operator must be installed for this component's configuration    #robocop:disable
 
-    ${rc}    ${logs}=    Run And Return Rc And Output
-    ...    oc logs -l ${OPERATOR_LABEL_SELECTOR} -c ${OPERATOR_POD_CONTAINER_NAME} -n ${OPERATOR_NS} --ignore-errors
-
-    Should Contain    ${logs}    failed to find the pre-requisite Service Mesh Operator subscription, please ensure Service Mesh Operator is installed.    #robocop:disable
-
 DataScienceCluster Should Fail Because Serverless Operator Is Not Installed
     [Documentation]   Keyword to check the DSC conditions when serverless operator is not installed.
     ...           One condition should appear saying this operator is needed to enable kserve component.


### PR DESCRIPTION
With the Service Mesh controller for rhoai 2.25, the rhods-operator logs are to heavy, and some content is not shown. This is making the condition to check the logs to fail. Removing that part to just rely on the dsc/dsci conditions