### PR TITLE
[2.21] chore(guidedTour): disable guided tour via CLI if possible

### DIFF
--- a/ods_ci/tests/Resources/Page/LoginPage.robot
+++ b/ods_ci/tests/Resources/Page/LoginPage.robot
@@ -58,7 +58,7 @@ Login To Openshift
     Input Text  id=inputPassword  ${ocp_user_pw}
     Click Button   //*[@type="submit"]
     Wait Until Page Does Not Contain    Log in to your account    timeout=30s
-    Maybe Skip Tour
+    Maybe Skip Tour    ${ocp_user_name}
 
 Log In Should Be Requested
     [Documentation]    Passes if the login page appears and fails otherwise

--- a/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
+++ b/ods_ci/tests/Resources/Page/OCPDashboard/OCPMenu.robot
@@ -46,17 +46,66 @@ Switch To Developer Perspective
       Wait Until Page Contains Element     ${PERSPECTIVE_SWITCHER_TEXT_ELEMENT}  timeout=30
   END
 
+Disable Guided Tour Via CLI
+    [Documentation]    Disables the OpenShift Console guided tour for the current user using oc commands.
+    ...                This is more reliable than UI-based modal detection and clicking.
+    ...                Only updates existing user settings configmap, does not create new ones.
+    [Arguments]    ${username}
+
+    # Get the current user's UID
+    ${rc}    ${user_uid}=    Run And Return Rc And Output    oc get user ${username} -o jsonpath='{.metadata.uid}'
+    IF    ${rc} != 0
+        Log    Failed to get user UID for ${username}, guided tour may still appear: ${user_uid}    level=WARN
+        RETURN
+    END
+
+    Log    Found user UID for ${username}: ${user_uid}
+
+    # Check if the user settings configmap exists
+    ${rc}    ${output}=    Run And Return Rc And Output    oc get cm user-settings-${user_uid} -n openshift-console-user-settings -o name
+
+    IF    ${rc} != 0
+        Log    User settings configmap does not exist yet, skipping CLI method    level=INFO
+        RETURN
+    ELSE
+        Log    User settings configmap exists, updating guided tour settings...
+        # Patch the existing configmap to disable guided tour
+        ${rc}    ${output}=    Run And Return Rc And Output    oc patch configmap user-settings-${user_uid} -n openshift-console-user-settings --patch='{"data":{"console.guidedTour":"{\\"admin\\":{\\"completed\\":true},\\"developer\\":{\\"completed\\":true}}"}}'
+        IF    ${rc} != 0
+            Log    Failed to patch user settings configmap: ${output}    level=WARN
+            RETURN
+        END
+        Log    Successfully updated user settings configmap to disable guided tour
+    END
+
 Maybe Skip Tour
     [Documentation]    If we are in the openshift web console, maybe skip the first time
     ...    tour popup given to users, otherwise RETURN.
+    ...    This function now uses CLI commands to disable the tour proactively if username is provided.
+    [Arguments]    ${username}=${EMPTY}
+
     ${should_cont} =    Does Current Sub Domain Start With    https://console-openshift-console
     IF  ${should_cont}==False
         RETURN
     END
-    ${MODAL_GUIDED_TOUR_XPATH} =  Set Variable  xpath=//div[@id='guided-tour-modal']
 
+    # Try to disable the tour via CLI first (more reliable) if username is provided
+    IF    "${username}" != "${EMPTY}"
+        Log    Attempting to disable guided tour via CLI for user: ${username}
+        Disable Guided Tour Via CLI    ${username}
+        # Give the console a moment to pick up the configuration change and reload page
+        Sleep    3s
+        Reload Page
+        Wait Until OpenShift Console Is Loaded
+    ELSE
+        Log    No username provided, skipping CLI method and using UI fallback only
+    END
+
+    # Fallback: still check for modal in case CLI approach didn't work or username not provided
+    ${MODAL_GUIDED_TOUR_XPATH} =  Set Variable  xpath=//div[@id='guided-tour-modal']
     ${tour_modal} =  Run Keyword And Return Status  Wait Until Page Contains Element  ${MODAL_GUIDED_TOUR_XPATH}  timeout=5s
     IF  ${tour_modal}
+        Log    Guided tour modal still appeared, attempting to close via UI
         # This xpath is for OCP 4.18 and older
         ${MODAL_BUTTON_OLDER_XPATH} =  Set Variable  ${MODAL_GUIDED_TOUR_XPATH}/button
         # This xpath is for OCP 4.19+
@@ -69,8 +118,11 @@ Maybe Skip Tour
         ELSE IF  ${modal_newer}
             Click Element  ${MODAL_BUTTON_NEWER_XPATH}
         ELSE
+            Capture Page Screenshot
             Fail  Unexpected Guided tour modal window, please check and update the implementation.
         END
+    ELSE
+        Log    No guided tour modal detected, CLI disabling was successful or not needed
     END
 
 Get OpenShift Version

--- a/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0102__alerts/0102__alerts.robot
+++ b/ods_ci/tests/Tests/0100__platform/0102__monitor_and_manage/0102__alerts/0102__alerts.robot
@@ -584,7 +584,7 @@ Check Particular Text Is Present In Rhods-operator's Log
     [Arguments]         ${text_to_check}
     Open OCP Console
     Login To Openshift    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}    ${OCP_ADMIN_USER.AUTH_TYPE}
-    Maybe Skip Tour
+    Maybe Skip Tour    ${OCP_ADMIN_USER.USERNAME}
     ${val_result}=  Get Pod Logs From UI  namespace=${OPERATOR_NAMESPACE}
     ...                                   pod_search_term=rhods-operator
     ...                                   container_button_id=rhods-deployer-link


### PR DESCRIPTION
This is yet another attempt to make the guided tour modal window disablement working reliably on the OCP 4.19+. Let's try the CLI method first now (if appropriate username is given).

This is a followup of the previous attempts introduced via:
* 2e4975dad3c225ad3b6651a3e50a17938f501486
* 7b5f6bfe41e69aa2b51cfc7426c677a94f8c97a3

(cherry picked from commit 03d2e0d7adfdef2f7ee0af93d3a3e23ba82a89b8) #2604