### PR TITLE
fix: Revert RHODS User Groups test as Auth CR is not available on 2.16

### DIFF
--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -117,10 +117,8 @@ Assign Vars According To Product
         Set Suite Variable    ${APPLICATIONS_NAMESPACE}    redhat-ods-applications
         IF  "${CLUSTER_TYPE}" == "managed"
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     addon-managed-odh
-            Set Suite Variable    ${ADMIN_GROUPS}       dedicated-admins
         ELSE
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
-            Set Suite Variable    ${ADMIN_GROUPS}       rhods-admins', 'rhods-users
             IF  "${INSTALL_TYPE}" == "OperatorHub"
                 Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhods-operator
             END
@@ -137,7 +135,6 @@ Assign Vars According To Product
         Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
         Set Suite Variable    ${APPLICATIONS_NAMESPACE}    opendatahub
         Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
-        Set Suite Variable    ${ADMIN_GROUPS}       odh-admins
         Set Suite Variable   ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
     END
 

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -36,7 +36,6 @@ ${S_SIZE}                   25
 ${DW_PROJECT_CREATED}       False
 ${UPGRADE_NS}    upgrade
 ${UPGRADE_CONFIG_MAP}    upgrade-config-map
-${ALLOWED_GROUPS}       system:authenticated
 
 
 *** Test Cases ***
@@ -56,12 +55,11 @@ Verify Pod Toleration
 
 Verify RHODS User Groups
     [Documentation]    Verify User Configuration after the upgrade
-    [Tags]      Upgrade     Platform        RHOAIENG-19806
-    Get Auth Cr Config Data
-    ${admin}        Set Variable        ${AUTH_PAYLOAD[0]['spec']['adminGroups']}
-    ${user}     Set Variable        ${AUTH_PAYLOAD[0]['spec']['allowedGroups']}
-    Should Be Equal As Strings      '${admin}'      '['${ADMIN_GROUPS}']'
-    Should Be Equal As Strings      '${user}'       '['${ALLOWED_GROUPS}']'
+    [Tags]      Upgrade
+    ${admin}        Set Variable        ${payload[0]['spec']['groupsConfig']['adminGroups']}
+    ${user}     Set Variable        ${payload[0]['spec']['groupsConfig']['allowedGroups']}
+    Should Be Equal As Strings      '${admin}'      'rhods-admins,rhods-users'
+    Should Be Equal As Strings      '${user}'       'system:authenticated'
     [Teardown]      Set Default Users
 
 Verify Culler is Enabled
@@ -322,12 +320,6 @@ Get Dashboard Config Data
     ${payload}    Oc Get    kind=OdhDashboardConfig    namespace=${APPLICATIONS_NAMESPACE}
     ...    field_selector=metadata.name==odh-dashboard-config
     Set Suite Variable    ${payload}    # robocop:disable
-
-Get Auth Cr Config Data
-    [Documentation]    Get payload from Auth CR
-    ${AUTH_PAYLOAD}    Oc Get    kind=Auth    namespace=${APPLICATIONS_NAMESPACE}
-    ...    field_selector=metadata.name==auth
-    Set Suite Variable    ${AUTH_PAYLOAD}
 
 Set Default Users
     [Documentation]    Set Default user settings


### PR DESCRIPTION
Revert of https://github.com/red-hat-data-services/ods-ci/pull/2332 as there is no Auth CR on 2.16.

FYI @asanzgom 