### PR TITLE
fix: pre/post upgrade dw message (2.23)

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -201,7 +201,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     Click Button    ${WORKLOAD_STATUS_TAB_XP}
     Check Distributed Workload Resource Metrics Status      ${JOB_NAME}     Running
     Check Distributed Worklaod Status Overview      ${JOB_NAME}     Running
-    ...     All pods were ready or succeeded since the workload admission
+    ...     All pods reached readiness and the workload is running
 
     Click Button    ${PROJECT_METRICS_TAB_XP}
     Check Distributed Workload Resource Metrics Chart       ${PRJ_UPGRADE}      ${cpu_requested}

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -250,7 +250,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     Click Button    ${WORKLOAD_STATUS_TAB_XP}
     Check Distributed Workload Resource Metrics Status      ${JOB_NAME}     Running
     Check Distributed Worklaod Status Overview      ${JOB_NAME}     Running
-    ...     All pods were ready or succeeded since the workload admission
+    ...     All pods reached readiness and the workload is running
 
     Click Button    ${PROJECT_METRICS_TAB_XP}
     Check Distributed Workload Resource Metrics Chart       ${PRJ_UPGRADE}      ${cpu_requested}

--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-distributed-workloads-metrics-ui.robot
@@ -108,7 +108,7 @@ Verify The Workload Metrics By Submitting Kueue Batch Workload
 
 
     Check Distributed Workload Resource Metrics Status    ${JOB_NAME_QUEUE}    Running
-    Check Distributed Worklaod Status Overview    ${JOB_NAME_QUEUE}    Running    All pods were ready or succeeded since the workload admission
+    Check Distributed Worklaod Status Overview    ${JOB_NAME_QUEUE}    Running    All pods reached readiness and the workload is running
 
     Click Button    ${PROJECT_METRICS_TAB_XP}
 


### PR DESCRIPTION
## WHAT
fix: pre/post upgrade dw message

## WHY
Currently pre/post upgrade tests fail with the following error (on RHOAI 2.22+):

```
'All pods reached readiness and the workload is running' does not match 'All pods were ready or succeeded since the workload admission'
```