### PR TITLE
fix: add rolebinding setup/ teardown for distributed workloads tests

### DIFF
--- a/ods_ci/tests/Resources/Files/kueue-batch-user-rolebinding.yaml
+++ b/ods_ci/tests/Resources/Files/kueue-batch-user-rolebinding.yaml
@@ -1,0 +1,12 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: kueue-batch-user-rolebinding
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: 'system:authenticated'
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kueue-batch-user-role

--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -207,6 +207,7 @@ Prepare DistributedWorkloads Integration Test Suite
     Log To Console    "Log back as cluster admin"
     Login To OCP Using API    ${OCP_ADMIN_USER.USERNAME}    ${OCP_ADMIN_USER.PASSWORD}
     RHOSi Setup
+    Setup Kueue Batch User RoleBinding
 
 Teardown DistributedWorkloads Integration Test Suite
     [Documentation]    Teardown DistributedWorkloads Integration Test Suite
@@ -215,6 +216,7 @@ Teardown DistributedWorkloads Integration Test Suite
     Log To Console    "Removing test binaries"
     Remove File        ${ODH_BINARY_NAME}
     RHOSi Teardown
+    Teardown Kueue Batch User RoleBinding
 
 Generate User Token
     [Documentation]    Authenticate as a user and return user token.
@@ -257,3 +259,25 @@ Check missing Go test
     [Documentation]    Check that upstream Go test is not missing
     [Arguments]    ${test_run_output}
     Should Not Contain    ${test_run_output}    testing: warning: no tests to run    No Go tests were run
+
+Setup Kueue Batch User RoleBinding
+    [Documentation]    Apply the kueue-batch-user-rolebinding ClusterRoleBinding as admin
+    Log To Console    "Applying kueue-batch-user-rolebinding ClusterRoleBinding"
+    ${result} =    Run Process    oc apply -f tests/Resources/Files/kueue-batch-user-rolebinding.yaml
+    ...    shell=true
+    ...    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        FAIL    Unable to apply kueue-batch-user-rolebinding ClusterRoleBinding
+    END
+
+Teardown Kueue Batch User RoleBinding
+    [Documentation]    Remove the kueue-batch-user-rolebinding ClusterRoleBinding as admin
+    Log To Console    "Removing kueue-batch-user-rolebinding ClusterRoleBinding"
+    ${result} =    Run Process    oc delete -f tests/Resources/Files/kueue-batch-user-rolebinding.yaml
+    ...    shell=true
+    ...    stderr=STDOUT
+    Log To Console    ${result.stdout}
+    IF    ${result.rc} != 0
+        Log To Console    "Warning: Unable to delete kueue-batch-user-rolebinding ClusterRoleBinding (may not exist)"
+    END


### PR DESCRIPTION
## WHAT
fix: add rolebinding setup/ teardown for distributed workloads tests