### PR TITLE
[2.16] Add deprecatedTests tags to Model Serving tests

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -82,19 +82,19 @@ Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
 
 Verify Custom Image Can Be Added
     [Documentation]    Create Custome notebook using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade      deprecatedTest
     Oc Apply        kind=ImageStream        src=tests/Tests/0200__rhoai_upgrade/custome_image.yaml
 
 Verify User Can Disable The Runtime
     [Documentation]    Disable the Serving runtime using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade      deprecatedTest
     Disable Model Serving Runtime Using CLI     namespace=redhat-ods-applications
 
 Verify Model Can Be Deployed For Upgrade
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    Verify Model Can Be Deployed Via cli For Upgrade
-    [Tags]                  Upgrade    ModelServing    ModelServer
+    [Tags]                  Upgrade    ModelServing    ModelServer      deprecatedTest
     ${test_namespace}=         Set Variable    ovmsmodel-upgrade
     ${inference_input}=        Set Variable    @tests/Resources/Files/modelmesh-mnist-input.json
     ${exp_inference_output}=   Set Variable    {"model_name":"ovms-model","model_version":"1","outputs":[{"name":"Plus214_Output_0","datatype":"FP32","shape":[1,10],"data":[-8.233053,-7.7497034,-3.4236815,12.3630295,-12.079103,17.266596,-10.570976,0.7130762,3.321715,1.3621228]}]}    # robocop: off=line-too-long
@@ -138,7 +138,7 @@ Verify Model Can Be Deployed For Upgrade
 
 Verify User Can Deploy Custom Runtime For Upgrade
     [Documentation]     Verify User Can Deploy Custom Runtime For Upgrade
-    [Tags]      Upgrade
+    [Tags]      Upgrade      deprecatedTest
     Create Custom Serving Runtime Using Template By CLI
     ...    tests/Resources/Files/caikit_runtime_template.yaml
     Begin Web Test

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -107,7 +107,7 @@ Verify Custom Image Is Present
 
 Verify Disable Runtime Is Present
     [Documentation]    Disable the Serving runtime using Cli
-    [Tags]      Upgrade
+    [Tags]      Upgrade      deprecatedTest
     ${rn}       Set Variable        ${payload[0]['spec']['templateDisablement']}
     List Should Contain Value       ${rn}       ovms-gpu
     [Teardown]      Enable Model Serving Runtime Using CLI      namespace=redhat-ods-applications
@@ -155,7 +155,7 @@ Test Inference Post RHODS Upgrade
     # robocop: off=too-many-calls-in-test-case
     # robocop: off=too-long-test-case
     [Documentation]    Test the inference result after having deployed a model
-    [Tags]                  Upgrade    ModelServing    ModelServer
+    [Tags]                  Upgrade    ModelServing    ModelServer    deprecatedTest
     Set Suite Variable    ${TEST_NS}    ovmsmodel-upgrade
     Set Suite Variable    ${KSERVE_MODE}    Serverless    # RawDeployment   # Serverless
     Set Suite Variable    ${INFERENCE_INPUT}    @tests/Resources/Files/modelmesh-mnist-input.json
@@ -179,7 +179,7 @@ Test Inference Post RHODS Upgrade
 
 Verify Custom Runtime Exists After Upgrade
     [Documentation]    Test the inference result after having deployed a model that requires Token Authentication
-    [Tags]      Upgrade
+    [Tags]      Upgrade      deprecatedTest
     [Setup]     Begin Web Test
     Menu.Navigate To Page       Settings        Serving runtimes
     Wait Until Page Contains        Add serving runtime     timeout=15s


### PR DESCRIPTION
## Description

Deprecate 6 tests for pre-upgrade and post-upgrade for Model Serving 