### PR TITLE
Fix bug in gpu_deploy.sh

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -9,7 +9,7 @@ CHANNEL="$(oc get packagemanifest gpu-operator-certified -n openshift-marketplac
 
 CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r '.status.channels[] | select(.name == "'$CHANNEL'") | .currentCSV')"
 
-sed -i'' -e "0,/v1.11/s//$CHANNEL/g" "$GPU_INSTALL_DIR/gpu_install.yaml"
+sed -i'' -e "s|channel: \".*\"|channel: \"$CHANNEL\"|" "$GPU_INSTALL_DIR/gpu_install.yaml"
 
 oc apply -f "$GPU_INSTALL_DIR/gpu_install.yaml"
 /bin/bash tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_install.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_install.yaml
@@ -22,7 +22,7 @@ metadata:
   name: gpu-operator-certified
   namespace: nvidia-gpu-operator
 spec:
-  channel: "v1.11"
+  channel: PLACEHOLDER
   installPlanApproval: Automatic
   name: gpu-operator-certified
   source: certified-operators


### PR DESCRIPTION
The sed command in gpu_deploy.sh replaces the literal string "v1.11" with the dynamically detected default channel from the cluster's packagemanifest. When the channel in gpu_install.yaml was updated to "v25.3", the sed became a no-op, causing the script to always install v25.3 regardless of the cluster's default channel.


Backport of https://github.com/red-hat-data-services/ods-ci/pull/2865