### PR TITLE
Fix ODH nightly (rhods-operator) support for Operator tests

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -173,7 +173,12 @@ Get RHODS Version
     ...    Will fetch version only if $RHODS_VERSION was not already set, or $force_fetch is True.
     [Arguments]    ${force_fetch}=False
     IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}"=="True"
-        IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
+        # Use OPERATOR_NAME when set (e.g. ODH nightly uses rhods-operator CSV)
+        IF  "${OPERATOR_NAME}" != "${None}" and "${OPERATOR_NAME}" == "rhods-operator"
+            ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
+        ELSE IF  "${OPERATOR_NAME}" != "${None}" and "${OPERATOR_NAME}" == "opendatahub-operator"
+            ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
+        ELSE IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
         ELSE
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -174,9 +174,9 @@ Get RHODS Version
     [Arguments]    ${force_fetch}=False
     IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}"=="True"
         # Use OPERATOR_NAME when set (e.g. ODH nightly uses rhods-operator CSV)
-        IF  "${OPERATOR_NAME}" != "${None}" and "${OPERATOR_NAME}" == "rhods-operator"
+        IF  "${OPERATOR_NAME}" == "rhods-operator"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
-        ELSE IF  "${OPERATOR_NAME}" != "${None}" and "${OPERATOR_NAME}" == "opendatahub-operator"
+        ELSE IF  "${OPERATOR_NAME}" == "opendatahub-operator"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
         ELSE IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -172,13 +172,10 @@ Get RHODS Version
     [Documentation]    Return RHODS/ODH operator version number.
     ...    Will fetch version only if $RHODS_VERSION was not already set, or $force_fetch is True.
     [Arguments]    ${force_fetch}=False
-    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}"=="True"
+    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}" == "True"
         # Use OPERATOR_NAME when set (e.g. ODH nightly uses rhods-operator CSV)
-        IF  "${OPERATOR_NAME}" == "rhods-operator"
+        IF  "${OPERATOR_NAME}" == "rhods-operator" or "${UPDATE_CHANNEL}" == "odh-stable"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
-        ELSE IF  "${OPERATOR_NAME}" == "opendatahub-operator"
-            ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
-        IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS" or "${UPDATE_CHANNEL}" == "odh-stable"
         ELSE
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
         END

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -172,9 +172,7 @@ Get RHODS Version
     [Documentation]    Return RHODS/ODH operator version number.
     ...    Will fetch version only if $RHODS_VERSION was not already set, or $force_fetch is True.
     [Arguments]    ${force_fetch}=False
-    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}" == "True"
-        # Use OPERATOR_NAME when set (e.g. ODH nightly uses rhods-operator CSV)
-        IF  "${OPERATOR_NAME}" == "rhods-operator" or "${UPDATE_CHANNEL}" == "odh-stable"
+    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}" == "True" or "${UPDATE_CHANNEL}" == "odh-stable"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
         ELSE
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -178,8 +178,7 @@ Get RHODS Version
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
         ELSE IF  "${OPERATOR_NAME}" == "opendatahub-operator"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
-        ELSE IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS"
-            ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
+        IF  "${PRODUCT}" == "${None}" or "${PRODUCT}" == "RHODS" or "${UPDATE_CHANNEL}" == "odh-stable"
         ELSE
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'
         END

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -172,7 +172,8 @@ Get RHODS Version
     [Documentation]    Return RHODS/ODH operator version number.
     ...    Will fetch version only if $RHODS_VERSION was not already set, or $force_fetch is True.
     [Arguments]    ${force_fetch}=False
-    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}" == "True" or "${UPDATE_CHANNEL}" == "odh-stable"
+    IF  "${RHODS_VERSION}" == "${None}" or "${force_fetch}" == "True"
+        IF  "${OPERATOR_NAME}" == "rhods-operator" or "${UPDATE_CHANNEL}" == "odh-stable"
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "rhods-operator" | awk -F ' {2,}' '{print $3}'
         ELSE
             ${RHODS_VERSION}=  Run  oc get csv -n ${OPERATOR_NAMESPACE} | grep "opendatahub" | awk -F ' {2,}' '{print $3}'

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -133,19 +133,19 @@ Assign Vars According To Product
         ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.     ${RHODS_VERSION}
         Set Suite Variable      ${CSV_NAME}
     ELSE IF    "${PRODUCT}" == "ODH" AND "${OPERATOR_NAME}" == "opendatahub-operator"
-            Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/opendatahub-operator.${OPERATOR_NAMESPACE}
-            Set Suite Variable    ${IMAGE_PULL_PATH}        quay.io
-            Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        registry.k8s.io
-            Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.k8s.io
-            ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.v   ${RHODS_VERSION}
-            Set Suite Variable      ${CSV_NAME}
-            Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
-            Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  manager
-            Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
-            Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
-            Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
-            Set Suite Variable    ${OPERATOR_YAML_LABEL}  opendatahub-operator
-            Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
+        Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/opendatahub-operator.${OPERATOR_NAMESPACE}
+        Set Suite Variable    ${IMAGE_PULL_PATH}        quay.io
+        Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        registry.k8s.io
+        Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.k8s.io
+        ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.v   ${RHODS_VERSION}
+        Set Suite Variable      ${CSV_NAME}
+        Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
+        Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  manager
+        Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
+        Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
+        Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
+        Set Suite Variable    ${OPERATOR_YAML_LABEL}  opendatahub-operator
+        Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
         Set Suite Variable    ${OPERATOR_APPNAME}  "Open Data Hub Operator"
         Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
         Set Suite Variable    ${ADMIN_GROUPS}       odh-admins

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -149,6 +149,8 @@ Assign Vars According To Product
         Set Suite Variable    ${OPERATOR_APPNAME}  "Open Data Hub Operator"
         Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
         Set Suite Variable    ${ADMIN_GROUPS}       odh-admins
+    ELSE
+        Log    PRODUCT=${PRODUCT} OPERATOR_NAME=${OPERATOR_NAME} - no matching branch in Assign Vars According To Product    console=yes
     END
 
 Gather Release Attributes From DSC And DSCI
@@ -182,7 +184,6 @@ Set Expected Value For Release Name
         END
     ELSE IF    "${PRODUCT}" == "ODH"
         ${expected_release_name}=    Set Variable     ${ODH_RELEASE_NAME}
-
     END
 
     Set Suite Variable    ${expected_release_name}

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -146,11 +146,9 @@ Assign Vars According To Product
             Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
             Set Suite Variable    ${OPERATOR_YAML_LABEL}  opendatahub-operator
             Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
-        END
         Set Suite Variable    ${OPERATOR_APPNAME}  "Open Data Hub Operator"
         Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
         Set Suite Variable    ${ADMIN_GROUPS}       odh-admins
-
     END
 
 Gather Release Attributes From DSC And DSCI

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -132,24 +132,7 @@ Assign Vars According To Product
         Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.redhat.io
         ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.     ${RHODS_VERSION}
         Set Suite Variable      ${CSV_NAME}
-    ELSE IF    "${PRODUCT}" == "ODH"
-        # ODH-nightlies (rhods-operator same as RHODS deployment/pod names)
-        IF      "${OPERATOR_NAME}" == "rhods-operator"
-            Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/rhods-operator.${OPERATOR_NAMESPACE}
-            Set Suite Variable    ${IMAGE_PULL_PATH}        registry.redhat.io
-            Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        quay.io
-            Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.redhat.io
-            ${CSV_NAME} =   Catenate    SEPARATOR=   rhods-operator.  ${RHODS_VERSION}
-            Set Suite Variable      ${CSV_NAME}
-            Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
-            Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  rhods-operator
-            Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
-            Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
-            Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=rhods-dashboard
-            Set Suite Variable    ${OPERATOR_YAML_LABEL}  rhods-operator
-            Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    rhoai-model-registries
-        # ODH COMMUNITY (opendatahub-operator)
-        ELSE IF     "${OPERATOR_NAME}" == "opendatahub-operator"
+    ELSE IF    "${PRODUCT}" == "ODH" AND "${OPERATOR_NAME}" == "opendatahub-operator"
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/opendatahub-operator.${OPERATOR_NAMESPACE}
             Set Suite Variable    ${IMAGE_PULL_PATH}        quay.io
             Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        registry.k8s.io

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -176,7 +176,7 @@ Set Expected Value For Release Name
     ...                RHOAI managed: OpenShift AI Cloud Service
     ...                RHOAI selfmanaged: OpenShift AI Self-Managed
 
-    IF    "${PRODUCT}" == "RHODS"
+    IF    "${PRODUCT}" == "RHODS" or "${UPDATE_CHANNEL}" == "odh-stable"
         IF     ${IS_SELF_MANAGED}
              ${expected_release_name}=    Set Variable     ${RHOAI_SELFMANAGED_RELEASE_NAME}
         ELSE

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -183,12 +183,8 @@ Set Expected Value For Release Name
              ${expected_release_name}=    Set Variable     ${RHOAI_MANAGED_RELEASE_NAME}
         END
     ELSE IF    "${PRODUCT}" == "ODH"
-        # ODH nightly uses rhods-operator which reports OpenShift AI Self-Managed
-        IF    "${OPERATOR_NAME}" == "rhods-operator"
-            ${expected_release_name}=    Set Variable     ${RHOAI_SELFMANAGED_RELEASE_NAME}
-        ELSE
-            ${expected_release_name}=    Set Variable     ${ODH_RELEASE_NAME}
-        END
+        ${expected_release_name}=    Set Variable     ${ODH_RELEASE_NAME}
+
     END
 
     Set Suite Variable    ${expected_release_name}

--- a/ods_ci/tests/Resources/RHOSi.resource
+++ b/ods_ci/tests/Resources/RHOSi.resource
@@ -133,15 +133,22 @@ Assign Vars According To Product
         ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.     ${RHODS_VERSION}
         Set Suite Variable      ${CSV_NAME}
     ELSE IF    "${PRODUCT}" == "ODH"
-        # ODH-nightlies
+        # ODH-nightlies (rhods-operator same as RHODS deployment/pod names)
         IF      "${OPERATOR_NAME}" == "rhods-operator"
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/rhods-operator.${OPERATOR_NAMESPACE}
             Set Suite Variable    ${IMAGE_PULL_PATH}        registry.redhat.io
             Set Suite Variable    ${KSERVE_IMAGE_PULL_PATH}        quay.io
             Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.redhat.io
-            ${CSV_NAME} =   Catenate    SEPARATOR=   opendatahub-operator.  ${RHODS_VERSION}
+            ${CSV_NAME} =   Catenate    SEPARATOR=   rhods-operator.  ${RHODS_VERSION}
             Set Suite Variable      ${CSV_NAME}
-            # ODH COMMUNITY
+            Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    rhods-operator
+            Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  rhods-operator
+            Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    name=rhods-operator
+            Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    rhods-dashboard
+            Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=rhods-dashboard
+            Set Suite Variable    ${OPERATOR_YAML_LABEL}  rhods-operator
+            Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    rhoai-model-registries
+        # ODH COMMUNITY (opendatahub-operator)
         ELSE IF     "${OPERATOR_NAME}" == "opendatahub-operator"
             Set Suite Variable    ${OPERATOR_SUBSCRIPTION_LABEL}     operators.coreos.com/opendatahub-operator.${OPERATOR_NAMESPACE}
             Set Suite Variable    ${IMAGE_PULL_PATH}        quay.io
@@ -149,18 +156,17 @@ Assign Vars According To Product
             Set Suite Variable    ${KUEUE_IMAGE_PULL_PATH}        registry.k8s.io
             ${CSV_NAME} =   Catenate    SEPARATOR=   ${OPERATOR_NAME}.v   ${RHODS_VERSION}
             Set Suite Variable      ${CSV_NAME}
-
+            Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
+            Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  manager
+            Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
+            Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
+            Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
+            Set Suite Variable    ${OPERATOR_YAML_LABEL}  opendatahub-operator
+            Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
         END
         Set Suite Variable    ${OPERATOR_APPNAME}  "Open Data Hub Operator"
-        Set Suite Variable    ${OPERATOR_YAML_LABEL}  opendatahub-operator
-        Set Suite Variable    ${OPERATOR_DEPLOYMENT_NAME}    opendatahub-operator-controller-manager
-        Set Suite Variable    ${OPERATOR_POD_CONTAINER_NAME}  manager
-        Set Suite Variable    ${OPERATOR_LABEL_SELECTOR}    control-plane=controller-manager
-        Set Suite Variable    ${DASHBOARD_DEPLOYMENT_NAME}    odh-dashboard
-        Set Suite Variable    ${DASHBOARD_LABEL_SELECTOR}     app.kubernetes.io/part-of=dashboard
         Set Suite Variable    ${OPERATOR_SUBSCRIPTION_NAME}     rhoai-operator-dev
         Set Suite Variable    ${ADMIN_GROUPS}       odh-admins
-        Set Suite Variable    ${MODEL_REGISTRY_NAMESPACE}    odh-model-registries
 
     END
 
@@ -182,7 +188,8 @@ Gather Release Attributes From DSC And DSCI
 
 Set Expected Value For Release Name
     [Documentation]    Sets the expected value for release.name attribute from the DSC and DSCI.
-    ...                ODH: Open Data Hub
+    ...                ODH community: Open Data Hub
+    ...                ODH nightly (rhods-operator): OpenShift AI Self-Managed
     ...                RHOAI managed: OpenShift AI Cloud Service
     ...                RHOAI selfmanaged: OpenShift AI Self-Managed
 
@@ -193,7 +200,12 @@ Set Expected Value For Release Name
              ${expected_release_name}=    Set Variable     ${RHOAI_MANAGED_RELEASE_NAME}
         END
     ELSE IF    "${PRODUCT}" == "ODH"
-        ${expected_release_name}=    Set Variable     ${ODH_RELEASE_NAME}
+        # ODH nightly uses rhods-operator which reports OpenShift AI Self-Managed
+        IF    "${OPERATOR_NAME}" == "rhods-operator"
+            ${expected_release_name}=    Set Variable     ${RHOAI_SELFMANAGED_RELEASE_NAME}
+        ELSE
+            ${expected_release_name}=    Set Variable     ${ODH_RELEASE_NAME}
+        END
     END
 
     Set Suite Variable    ${expected_release_name}


### PR DESCRIPTION
## Summary
Makes Operator-tagged tests work when running against ODH nightly (Open Data Hub using the `rhods-operator`), where the cluster uses RHODS-style resources (deployment name, CSV, release name, model registry namespace) instead of ODH community (`opendatahub-operator`).

## Problem
With `PRODUCT=ODH` and `OPERATOR_NAME=rhods-operator` (test-variables-odh-nightly.yml), several Operator tests failed because:
- The suite assumed deployment `opendatahub-operator-controller-manager`; ODH nightly uses `rhods-operator`.
- Version detection used the `opendatahub` CSV; ODH nightly only has the `rhods-operator` CSV, so `RHODS_VERSION` was empty and `CSV_NAME` became `rhods-operator.` (invalid).
- Expected release name was "Open Data Hub" while the operator reports "OpenShift AI Self-Managed".
- Expected model registry namespace was `odh-model-registries` while the cluster uses `rhoai-model-registries`.

## Solution
- **RHOSi.resource:** When `PRODUCT=ODH` and `OPERATOR_NAME=rhods-operator`, set operator/dashboard and related vars to the same values as RHODS (`rhods-operator`, `rhods-dashboard`, `name=rhods-operator`, etc.). Set `MODEL_REGISTRY_NAMESPACE` per variant: `rhoai-model-registries` for rhods-operator, `odh-model-registries` for opendatahub-operator. For ODH nightly, set expected release name to "OpenShift AI Self-Managed".
- **Common.robot:** In `Get RHODS Version`, use `OPERATOR_NAME` when set: grep `rhods-operator` CSV for `rhods-operator`, and `opendatahub` for `opendatahub-operator`, so ODH nightly gets the correct version and `CSV_NAME`.

## Testing
- Run with `--include Operator --test-variables-file test-variables-odh-nightly.yml` (and e.g. `--skip-oclogin --skip-install --no-output-subfolder`). Operator installation tests and related suites (e.g. Trusted CA Bundles, DSC components that depend on CSV/deployment name, release name, model registry namespace) should pass or fail only on remaining environment-specific issues (e.g. image digest, image pull path).