### PR TITLE
fix expected ODH name in the application listing box

### DIFF
--- a/ods_ci/test-variables-odh-overwrite.yml
+++ b/ods_ci/test-variables-odh-overwrite.yml
@@ -1,3 +1,2 @@
 # Overwrite here values for local variables defined in test suites
 # in order to make them compatible with ODH
-ODH_DASHBOARD_PROJECT_NAME: Open Data Hub


### PR DESCRIPTION
With the recent change to the konflux build of odh-nightly builds, we're using manifests that are closer/identical to what RHOAI uses. Part of these changes is also the text referrencing the ODH/RHOAI application in the OCP console on the top when redirecting to the application. So now in odh-nightlies we don't expect the `Open Data Hub` text anymore, but the standard `Red Hat OpenShift AI`.

---

I kept this in draft for now as I'm thinking whether we rather should remove this file from arguments in our Jenkins jobs and keep this file as is here for anyone running against true ODH build.