### PR TITLE
GCP GPU MachineSet: retry provisioning in alternate zones on timeout

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/provision-gpu.sh
@@ -49,6 +49,76 @@ KUSTOMIZE_PATH="$PWD/tasks/Resources/Provisioning/Hive/GPU"
 MACHINESET_PATH="$KUSTOMIZE_PATH/base/source-machineset.yaml"
 PROVIDER_OVERLAY_DIR=$KUSTOMIZE_PATH/overlays/$PROVIDER
 MACHINE_WAIT_TIMEOUT=10m
+
+# On GCP, if the first zone has no GPU capacity, try other zones in the same region (from
+# worker MachineSets, or common zone suffixes). Copies matching worker networkInterfaces.
+retry_gpu_machineset_other_gcp_zones() {
+  local ms=$1
+  local replicas=$2
+  local wait_timeout=$3
+  local current_zone
+  current_zone=$(oc get machinesets.machine.openshift.io -n openshift-machine-api "$ms" -o jsonpath='{.spec.template.spec.providerSpec.value.zone}')
+  local region="${current_zone%-*}"
+
+  ZONE_CANDIDATES=()
+  while IFS= read -r line; do
+    [[ -n "$line" ]] && ZONE_CANDIDATES+=("$line")
+  done < <(oc get machinesets.machine.openshift.io -n openshift-machine-api -o json | jq -r --arg ms "$ms" --arg cz "$current_zone" --arg reg "$region" '
+    [.items[] | select(.metadata.name != $ms)
+     | select((.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-type"] // "") == "worker")
+     | .spec.template.spec.providerSpec.value.zone // empty | select(. != "")
+     | select(startswith($reg + "-"))
+     | select(. != $cz)]
+    | unique | .[]')
+
+  if [[ ${#ZONE_CANDIDATES[@]} -eq 0 ]]; then
+    local suf z
+    for suf in b c f d a; do
+      z="${region}-${suf}"
+      [[ "$z" == "$current_zone" ]] && continue
+      ZONE_CANDIDATES+=("$z")
+    done
+  fi
+
+  local z worker_ms patchfile
+  for z in "${ZONE_CANDIDATES[@]}"; do
+    echo "GPU wait failed in $current_zone; retrying zone $z"
+    oc scale machinesets.machine.openshift.io "$ms" -n openshift-machine-api --replicas=0
+    if ! oc wait --timeout="$wait_timeout" --for=jsonpath='{.status.replicas}'=0 machinesets.machine.openshift.io "$ms" -n openshift-machine-api; then
+      echo "GPU MachineSet $ms did not scale down to 0 replicas within $wait_timeout; aborting zone retries to avoid patching while Machines are still terminating"
+      return 1
+    fi
+
+    worker_ms=$(oc get machinesets.machine.openshift.io -n openshift-machine-api -o json | jq -r --arg z "$z" --arg gpu "$ms" '
+      [.items[] | select(.metadata.name != $gpu)
+       | select((.spec.template.spec.providerSpec.value.zone // "") == $z)
+       | select((.spec.template.metadata.labels["machine.openshift.io/cluster-api-machine-type"] // "") == "worker")]
+      | if length > 0 then .[0].metadata.name else empty end')
+
+    if [[ -n "$worker_ms" ]]; then
+      patchfile=$(mktemp)
+      oc get machinesets.machine.openshift.io -n openshift-machine-api "$worker_ms" -o json | jq --arg z "$z" '
+        [
+          {"op": "replace", "path": "/spec/template/spec/providerSpec/value/zone", "value": $z},
+          {"op": "replace", "path": "/spec/template/spec/providerSpec/value/networkInterfaces",
+           "value": .spec.template.spec.providerSpec.value.networkInterfaces}
+        ]' > "$patchfile"
+      oc patch machinesets.machine.openshift.io "$ms" -n openshift-machine-api --type=json -p "$(cat "$patchfile")"
+      rm -f "$patchfile"
+    else
+      oc patch machinesets.machine.openshift.io "$ms" -n openshift-machine-api --type=merge -p "{\"spec\":{\"template\":{\"spec\":{\"providerSpec\":{\"value\":{\"zone\":\"$z\"}}}}}}"
+    fi
+
+    oc scale machinesets.machine.openshift.io "$ms" -n openshift-machine-api --replicas="$replicas"
+    if oc wait --timeout="$wait_timeout" --for jsonpath='{.status.readyReplicas}'="$replicas" machinesets.machine.openshift.io "$ms" -n openshift-machine-api; then
+      echo "GPU nodes became ready in zone $z"
+      return 0
+    fi
+    current_zone="$z"
+  done
+  return 1
+}
+
 # Check if existing machineset GPU already exists
 EXISTING_GPU_MACHINESET="$(oc get machinesets.machine.openshift.io -n openshift-machine-api -o jsonpath="{.items[?(@.metadata.annotations['machine\.openshift\.io/GPU']>'0')].metadata.name}")"
 if [[ -n "$EXISTING_GPU_MACHINESET" ]] ; then
@@ -83,8 +153,10 @@ oc apply --kustomize $PROVIDER_OVERLAY_DIR
 oc patch machinesets.machine.openshift.io -n openshift-machine-api "$NEW_MACHINESET_NAME" -p '{"metadata":{"labels":{"gpu-machineset":"true"}}}' --type=merge
 # wait for the machine to be Ready
 echo "Waiting for GPU Node to be Ready"
-oc wait --timeout=$MACHINE_WAIT_TIMEOUT --for jsonpath='{.status.readyReplicas}'=$GPU_NODE_COUNT machinesets.machine.openshift.io $NEW_MACHINESET_NAME -n openshift-machine-api
- if [ $? -ne 0 ]; then
+if ! oc wait --timeout=$MACHINE_WAIT_TIMEOUT --for jsonpath='{.status.readyReplicas}'=$GPU_NODE_COUNT machinesets.machine.openshift.io $NEW_MACHINESET_NAME -n openshift-machine-api; then
+  if [[ "$PROVIDER" == "GCP" ]] && retry_gpu_machineset_other_gcp_zones "$NEW_MACHINESET_NAME" "$GPU_NODE_COUNT" "$MACHINE_WAIT_TIMEOUT"; then
+    exit 0
+  fi
   echo "Machine Set $NEW_MACHINESET_NAME does not have its Machines in Running status after $MACHINE_WAIT_TIMEOUT timeout"
   echo "Please check the cluster"
   exit 1

--- a/ods_ci/tasks/Resources/Provisioning/Hive/gpu-provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/gpu-provision.robot
@@ -1,25 +1,128 @@
 *** Settings ***
+Library           Collections
 Library           OperatingSystem
+Library           Process
+Library           String
+
+
+*** Variables ***
+${GPU_INSTANCE_TYPE}    g4dn.xlarge
+${GPU_PROVIDER}    AWS
+${GPU_NODE_COUNT}    1
+${GPU_COUNT_NVIDIA}    1
+${GPU_GCP_INSTANCE_TYPE}    a2-ultragpu-1g
+
 
 *** Keywords ***
-Create GPU Node In Self Managed AWS Cluster
-    [Documentation]    Create GPU node in self-managed AWS cluster using script defaults.
+Create GPU Node In Self Managed Cluster
+    [Documentation]    Runs ``tasks/Resources/Provisioning/GPU/provision-gpu.sh`` from the
+    ...                ``ods_ci`` working directory.
+    ...
+    ...    On GCP, other zones in the same region are tried automatically if the first has no GPU capacity.
+    ...
+    ...    Override ``${GPU_INSTANCE_TYPE}``, ``${GPU_PROVIDER}``, ``${GPU_NODE_COUNT}``,
+    ...    ``${GPU_COUNT_NVIDIA}`` (suite/task) or pass arguments.
+    [Arguments]    ${instance_type}=${GPU_INSTANCE_TYPE}
+    ...    ${provider}=${GPU_PROVIDER}
+    ...    ${node_count}=${GPU_NODE_COUNT}
+    ...    ${gpu_count}=${GPU_COUNT_NVIDIA}
     Set Log Level    Info
-    ${gpu_node} =    Run Process    sh    tasks/Resources/Provisioning/GPU/provision-gpu.sh
+    VAR    @{cmd}    sh
+    ...    tasks/Resources/Provisioning/GPU/provision-gpu.sh
+    ...    ${instance_type}
+    ...    ${provider}
+    ...    ${node_count}
+    ${nvidia}=    Run Keyword And Return Status    Should Start With    ${instance_type}    nvidia-
+    IF    '${provider}' == 'GCP' and ${nvidia}
+        Append To List    ${cmd}    ${gpu_count}
+    END
+    ${gpu_node}=    Run Process    @{cmd}
     Should Be Equal As Integers    ${gpu_node.rc}    0
-    ...    msg=AWS GPU node provisioning failed: ${gpu_node.stdout} ${gpu_node.stderr}
-    Log    AWS GPU node provisioning completed: ${gpu_node.stdout}    console=True
+    ...    msg=GPU node provisioning failed: ${gpu_node.stdout} ${gpu_node.stderr}
+    Log    GPU node provisioning completed: ${gpu_node.stdout}    console=True
 
-Delete GPU Node In Self Managed AWS Cluster
-    ${gpu_nodes} =    Oc Get    kind=Machine    label_selector=machine.openshift.io/instance-type=g4dn.xlarge
-    Log    ${gpu_nodes[0]['metadata']['name']}    console=True
-    Run And Return Rc    oc annotate machine/${gpu_nodes[0]['metadata']['name']} -n openshift-machine-api machine.openshift.io/cluster-api-delete-machine="true"
-    Run And Return Rc    oc adm cordon ${gpu_nodes[0]['metadata']['name']}
-    Run And Return Rc    oc adm drain ${gpu_nodes[0]['metadata']['name']} --ignore-daemonsets --delete-local-data
-    ${gpu_machineset} =    Oc Get    kind=MachineSet    label_selector=gpu-machineset=true
-    Run And Return Rc    oc scale --replicas=0 machineset/${gpu_machineset[0]['metadata']['name']} -n openshift-machine-api
+Create GPU Node In Self Managed AWS Cluster
+    [Documentation]    Create GPU node on AWS using ``${GPU_INSTANCE_TYPE}`` (default ``g4dn.xlarge``). Same as
+    ...                ``Create GPU Node In Self Managed Cluster`` with AWS defaults.
+    Create GPU Node In Self Managed Cluster    ${GPU_INSTANCE_TYPE}    AWS    ${GPU_NODE_COUNT}
 
-Install GPU Operator on Self Managed Cluster
+Create GPU Node In Self Managed GCP Cluster
+    [Documentation]    Create GPU node on GCP using ``${GPU_GCP_INSTANCE_TYPE}`` (default
+    ...                ``a2-ultragpu-1g``). Other zones in the region are tried if the first has no GPU capacity.
+    Create GPU Node In Self Managed Cluster    ${GPU_GCP_INSTANCE_TYPE}    GCP
+    ...    ${GPU_NODE_COUNT}
+    ...    ${GPU_COUNT_NVIDIA}
+
+Delete Provisioned GPU Node
+    [Documentation]    Delete a GPU ``Machine`` created by ``provision-gpu.sh`` and scale the GPU
+    ...                ``MachineSet`` (``gpu-machineset=true``) to zero. ``oc annotate`` uses the
+    ...                ``Machine`` name; ``oc adm cordon``/``drain`` use the linked Node
+    ...                (``status.nodeRef.name``). Resolves candidates from that
+    ...                ``MachineSet`` via ``machine.openshift.io/cluster-api-machineset``. If
+    ...                ``${instance_type}`` is non-empty, prefers Machines whose label
+    ...                ``machine.openshift.io/instance-type`` matches (e.g. ``${GPU_INSTANCE_TYPE}`` on AWS);
+    ...                if none match, uses any Machine in the set (needed for GCP ``nvidia-*`` flavors where
+    ...                the API machine type is the base shape, not the flavor string).
+    [Arguments]    ${instance_type}=${EMPTY}
+    ${effective_type}=    Strip String    ${instance_type}
+    ${want_filter}=    Evaluate    len(r'''${effective_type}''') > 0
+    ${gpu_machineset}=    Oc Get    kind=MachineSet    label_selector=gpu-machineset=true
+    ${ms_name}=    Set Variable    ${gpu_machineset[0]['metadata']['name']}
+    ${gpu_machines}=    Oc Get    kind=Machine
+    ...    label_selector=machine.openshift.io/cluster-api-machineset=${ms_name}
+    ${count}=    Get Length    ${gpu_machines}
+    Should Be True    ${count} > ${0}    msg=No Machines found for GPU MachineSet ${ms_name}
+    ${candidates}=    Copy List    ${gpu_machines}
+    IF    ${want_filter}
+        VAR    @{matching}    @{EMPTY}
+        FOR    ${m}    IN    @{gpu_machines}
+            ${labels}=    Get Variable Value    ${m}[metadata][labels]    ${NONE}
+            IF    '${labels}' == '${NONE}'    CONTINUE
+            ${status}    ${inst_lbl}=    Run Keyword And Ignore Error    Get From Dictionary    ${labels}
+            ...    machine.openshift.io/instance-type
+            ${is_eq}=    Run Keyword And Return Status    Should Be Equal As Strings    ${inst_lbl}
+            ...    ${effective_type}
+            IF    '${status}' == 'PASS' and ${is_eq}
+                Append To List    ${matching}    ${m}
+            END
+        END
+        ${match_len}=    Get Length    ${matching}
+        IF    ${match_len} > ${0}
+            ${candidates}=    Copy List    ${matching}
+        END
+    END
+    ${gpu_machine}=    Set Variable    ${candidates}[0]
+    ${gpu_machine_name}=    Set Variable    ${gpu_machine}[metadata][name]
+    ${gpu_node_name}=    Get Variable Value    ${gpu_machine}[status][nodeRef][name]    ${EMPTY}
+    Should Not Be Empty    ${gpu_node_name}
+    ...    msg=Machine ${gpu_machine_name} has no status.nodeRef.name; cannot cordon/drain
+    Log    ${gpu_machine_name}    console=True
+    ${annotate_cmd}=    Catenate    SEPARATOR=${SPACE}    oc annotate machine/${gpu_machine_name}
+    ...    -n openshift-machine-api
+    ...    machine.openshift.io/cluster-api-delete-machine="true"
+    ${annotate_rc}=    Run And Return Rc    ${annotate_cmd}
+    Should Be Equal As Integers    ${annotate_rc}    ${0}    msg=oc annotate machine failed for ${gpu_machine_name}
+    ${cordon_rc}=    Run And Return Rc    oc adm cordon ${gpu_node_name}
+    Should Be Equal As Integers    ${cordon_rc}    ${0}    msg=oc adm cordon failed for node ${gpu_node_name}
+    ${drain_rc}=    Run And Return Rc    oc adm drain ${gpu_node_name}    --ignore-daemonsets
+    ...    --delete-emptydir-data
+    Should Be Equal As Integers    ${drain_rc}    ${0}    msg=oc adm drain failed for node ${gpu_node_name}
+    ${scale_cmd}=    Catenate    SEPARATOR=${SPACE}    oc scale --replicas=0 machineset/${ms_name}
+    ...    -n openshift-machine-api
+    ${scale_rc}=    Run And Return Rc    ${scale_cmd}
+    Should Be Equal As Integers    ${scale_rc}    ${0}    msg=oc scale machineset failed for ${ms_name}
+
+Delete GPU Node Self Managed AWS Cluster
+    [Documentation]    Delete AWS GPU node. Prefers ``${GPU_INSTANCE_TYPE}`` (default ``g4dn.xlarge``) when
+    ...                it matches ``Machine`` labels; otherwise any Machine from the GPU ``MachineSet``.
+    Delete Provisioned GPU Node    ${GPU_INSTANCE_TYPE}
+
+Delete GPU Node Self Managed GCP Cluster
+    [Documentation]    Delete GCP GPU node. Prefers ``${GPU_GCP_INSTANCE_TYPE}`` when it matches ``Machine``
+    ...                labels; otherwise any Machine from the GPU ``MachineSet`` (e.g. ``nvidia-*`` on n1).
+    Delete Provisioned GPU Node    ${GPU_GCP_INSTANCE_TYPE}
+
+Install GPU Operator On Self Managed Cluster
    [Documentation]  Install GPU operator on Self Managed cluster
    ${gpu_install} =    Run Process    sh    tasks/Resources/Provisioning/GPU/gpu_deploy.sh   shell=yes
    Should Be Equal As Integers    ${gpu_install.rc}    0

--- a/ods_ci/tasks/Tasks/provision_self_managed_cluster.robot
+++ b/ods_ci/tasks/Tasks/provision_self_managed_cluster.robot
@@ -42,13 +42,27 @@ Add GPU Node To Self-Managed AWS Cluster
     [Tags]    gpu_node_aws_self_managed_provision
     Login To Cluster
     Create GPU Node In Self Managed AWS Cluster
-    Install GPU Operator on Self Managed Cluster
+    Install GPU Operator On Self Managed Cluster
+
+Add GPU Node To Self-Managed GCP Cluster
+    [Documentation]    Add GPU node to self-managed GCP cluster. ``provision-gpu.sh`` tries other
+    ...                zones in the region if the first has no GPU capacity.
+    [Tags]    gpu_node_gcp_self_managed_provision
+    Login To Cluster
+    Create GPU Node In Self Managed GCP Cluster
+    Install GPU Operator On Self Managed Cluster
 
 Delete GPU Node From Self-Managed AWS Cluster
     [Documentation]    Delete GPU node from self-managed cluster
     [Tags]    gpu_node_aws_self_managed_deprovision
     Login To Cluster
-    Delete GPU Node In Self Managed AWS Cluster
+    Delete GPU Node Self Managed AWS Cluster
+
+Delete GPU Node From Self-Managed GCP Cluster
+    [Documentation]    Delete GPU node from self-managed GCP cluster
+    [Tags]    gpu_node_gcp_self_managed_deprovision
+    Login To Cluster
+    Delete GPU Node Self Managed GCP Cluster
 
 Disconnect Self-Managed Cluster
     [Documentation]    Disconnect a self-managed cluster


### PR DESCRIPTION
Jira: https://redhat.atlassian.net/issues?filter=-1&selectedIssue=[RHOAIENG-21063](https://redhat.atlassian.net/browse/RHOAIENG-21063)

What was going wrong
GPU nodes are created from the first worker MachineSet (head -n1 in provision-gpu.sh), so the GPU MachineSet keeps that worker’s single GCP zone. GPU capacity on GCP is per zone; if that zone is out of stock, provisioning fails. The cluster autoscaler only changes how many nodes a MachineSet has; it does not move machines to another zone.

What we changed
provision-gpu.sh now has GCP-only zone retry after the initial oc wait fails:
1. Scale the GPU MachineSet to 0 and wait for machines to go away.
2. Candidate zones: all zones used by other worker MachineSets (excluding the GPU one), excluding the zone that already failed. If there is only one worker zone in the cluster, it falls back to the same region with common suffixes b, c, f, d, a (covers regions like us-central1 that use -f instead of -d).
3. For each candidate zone, if there is a worker MachineSet in that zone, it patches both zone and networkInterfaces from that worker so subnets stay correct for multi-subnet installs. If not, it only patches zone.
4. Scales back to the desired replica count and waits again.