### PR TITLE
Add MaaS PostgreSQL prerequisites for maas-api pod

### DIFF
--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+
+APPS_NS="${APPLICATIONS_NAMESPACE:-redhat-ods-applications}"
+POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15:latest"
+
+# Generate random credentials
+PG_USER="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
+PG_PASS="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
+PG_DB="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
+
+# Skip if already provisioned
+if oc get secret maas-db-config -n "${APPS_NS}" &>/dev/null; then
+    echo "maas-db-config already exists in ${APPS_NS}, skipping."
+    exit 0
+fi
+
+# 1. postgres-creds secret
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: postgres-creds
+  namespace: ${APPS_NS}
+  labels:
+    app: postgres
+    purpose: poc
+type: Opaque
+stringData:
+  POSTGRES_USER: "${PG_USER}"
+  POSTGRES_PASSWORD: "${PG_PASS}"
+  POSTGRES_DB: "${PG_DB}"
+EOF
+
+# 2. maas-db-config secret (DB_CONNECTION_URL key)
+DB_URL="postgresql://${PG_USER}:${PG_PASS}@postgres:5432/${PG_DB}?sslmode=disable"
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Secret
+metadata:
+  name: maas-db-config
+  namespace: ${APPS_NS}
+  labels:
+    app: maas-api
+    purpose: poc
+type: Opaque
+stringData:
+  DB_CONNECTION_URL: "${DB_URL}"
+EOF
+
+# 3. postgres Service
+oc apply -f - <<EOF
+apiVersion: v1
+kind: Service
+metadata:
+  name: postgres
+  namespace: ${APPS_NS}
+  labels:
+    app: postgres
+    purpose: poc
+spec:
+  selector:
+    app: postgres
+  ports:
+    - name: postgres
+      port: 5432
+      protocol: TCP
+      targetPort: 5432
+EOF
+
+# 4. postgres Deployment
+oc apply -f - <<EOF
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: postgres
+  namespace: ${APPS_NS}
+  labels:
+    app: postgres
+    purpose: poc
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: postgres
+  template:
+    metadata:
+      labels:
+        app: postgres
+        purpose: poc
+    spec:
+      containers:
+        - name: postgres
+          image: ${POSTGRES_IMAGE}
+          env:
+            - name: POSTGRESQL_USER
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: POSTGRES_USER
+            - name: POSTGRESQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: POSTGRES_PASSWORD
+            - name: POSTGRESQL_DATABASE
+              valueFrom:
+                secretKeyRef:
+                  name: postgres-creds
+                  key: POSTGRES_DB
+          ports:
+            - containerPort: 5432
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/pgsql/data
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "512Mi"
+              cpu: "500m"
+          readinessProbe:
+            exec:
+              command: ["/usr/libexec/check-container"]
+            initialDelaySeconds: 5
+            periodSeconds: 5
+      volumes:
+        - name: data
+          emptyDir: {}
+EOF
+
+# Wait for postgres to be ready
+oc wait deployment/postgres -n "${APPS_NS}" \
+  --for=condition=Available --timeout=5m || \
+echo "PostgreSQL deployment may not be ready; check with: oc get deployment postgres -n ${APPS_NS}"
+
+echo "MaaS PostgreSQL prerequisites provisioned in ${APPS_NS}"

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -18,6 +18,9 @@ done
 APPS_NS="${APPS_NS:-redhat-ods-applications}"
 POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15:latest"
 
+# Ensure namespace exists
+oc create namespace "${APPS_NS}" --dry-run=client -o yaml | oc apply -f -
+
 # Skip if all resources already exist and deployment is ready
 if oc get secret maas-db-config -n "${APPS_NS}" &>/dev/null \
    && oc get secret postgres-creds -n "${APPS_NS}" &>/dev/null \

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -16,7 +16,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 APPS_NS="${APPS_NS:-redhat-ods-applications}"
-POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15:latest"
+POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15@sha256:90ec347a35ab8a5d530c8d09f5347b13cc71df04f3b994bfa8b1a409b1171d59"
 
 # Ensure namespace exists
 oc create namespace "${APPS_NS}" --dry-run=client -o yaml | oc apply -f -
@@ -36,11 +36,15 @@ if oc get secret postgres-creds -n "${APPS_NS}" &>/dev/null; then
     PG_USER="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_USER}' | base64 -d)"
     PG_PASS="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
     PG_DB="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_DB}' | base64 -d)"
+    if [[ -z "${PG_USER}" || -z "${PG_PASS}" || -z "${PG_DB}" ]]; then
+        echo "postgres-creds in ${APPS_NS} is missing required keys/values" >&2
+        exit 1
+    fi
     echo "Reusing existing postgres-creds in ${APPS_NS}"
 else
-    PG_USER="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
-    PG_PASS="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
-    PG_DB="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
+    PG_USER="maas-$(tr -dc a-z0-9 </dev/urandom | head -c 8)"
+    PG_PASS="$(tr -dc A-Za-z0-9 </dev/urandom | head -c 32)"
+    PG_DB="maas-$(tr -dc a-z0-9 </dev/urandom | head -c 8)"
 fi
 
 # 1. postgres-creds secret

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -1,7 +1,21 @@
 #!/bin/bash
 set -euo pipefail
 
-APPS_NS="${APPLICATIONS_NAMESPACE:-redhat-ods-applications}"
+while [ "$#" -gt 0 ]; do
+    case $1 in
+        --namespace)
+            shift
+            APPS_NS=$1
+            shift
+            ;;
+        *)
+            echo "Unknown command line switch: $1"
+            exit 1
+            ;;
+    esac
+done
+
+APPS_NS="${APPS_NS:-redhat-ods-applications}"
 POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15:latest"
 
 # Skip if all resources already exist and deployment is ready

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -1,17 +1,29 @@
 #!/bin/bash
+set -euo pipefail
 
 APPS_NS="${APPLICATIONS_NAMESPACE:-redhat-ods-applications}"
 POSTGRES_IMAGE="registry.redhat.io/rhel9/postgresql-15:latest"
 
-# Generate random credentials
-PG_USER="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
-PG_PASS="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
-PG_DB="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
-
-# Skip if already provisioned
-if oc get secret maas-db-config -n "${APPS_NS}" &>/dev/null; then
-    echo "maas-db-config already exists in ${APPS_NS}, skipping."
+# Skip if all resources already exist and deployment is ready
+if oc get secret maas-db-config -n "${APPS_NS}" &>/dev/null \
+   && oc get secret postgres-creds -n "${APPS_NS}" &>/dev/null \
+   && oc get service postgres -n "${APPS_NS}" &>/dev/null \
+   && oc get deployment postgres -n "${APPS_NS}" &>/dev/null; then
+    oc wait deployment/postgres -n "${APPS_NS}" --for=condition=Available --timeout=5m
+    echo "MaaS PostgreSQL prerequisites already exist in ${APPS_NS}, skipping."
     exit 0
+fi
+
+# Reuse existing credentials if postgres-creds secret is present, otherwise generate new ones
+if oc get secret postgres-creds -n "${APPS_NS}" &>/dev/null; then
+    PG_USER="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_USER}' | base64 -d)"
+    PG_PASS="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_PASSWORD}' | base64 -d)"
+    PG_DB="$(oc get secret postgres-creds -n "${APPS_NS}" -o jsonpath='{.data.POSTGRES_DB}' | base64 -d)"
+    echo "Reusing existing postgres-creds in ${APPS_NS}"
+else
+    PG_USER="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
+    PG_PASS="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
+    PG_DB="maas-$(head /dev/urandom | tr -dc a-z0-9 | head -c 8)"
 fi
 
 # 1. postgres-creds secret
@@ -130,8 +142,9 @@ spec:
 EOF
 
 # Wait for postgres to be ready
-oc wait deployment/postgres -n "${APPS_NS}" \
-  --for=condition=Available --timeout=5m || \
-echo "PostgreSQL deployment may not be ready; check with: oc get deployment postgres -n ${APPS_NS}"
+if ! oc wait deployment/postgres -n "${APPS_NS}" --for=condition=Available --timeout=5m; then
+    echo "PostgreSQL deployment is not ready in ${APPS_NS}" >&2
+    exit 1
+fi
 
 echo "MaaS PostgreSQL prerequisites provisioned in ${APPS_NS}"

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1441,6 +1441,6 @@ Configure MaaS Database
     [Documentation]    Provision PostgreSQL and maas-db-config secret required by maas-api
     Log To Console    Provisioning MaaS PostgreSQL prerequisites
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    bash tasks/Resources/Database/configure_maas_postgres.sh
+    ...    bash tasks/Resources/Database/configure_maas_postgres.sh --namespace ${APPLICATIONS_NAMESPACE}
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error provisioning MaaS PostgreSQL prerequisites

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1194,6 +1194,7 @@ Install RHOAI Dependencies With CLI
     Install Leader Worker Set Operator Via Cli
     Install Connectivity Link Operator Via Cli
     Install JobSet Dependencies
+    Configure MaaS Database
     Configure MaaS Gateway API
 
 Install Observability Dependencies
@@ -1435,3 +1436,11 @@ Configure MaaS Gateway API
     ...    bash tasks/Resources/Gateway/configure_maas_gateway.sh
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for MaaS
+
+Configure MaaS Database
+    [Documentation]    Provision PostgreSQL and maas-db-config secret required by maas-api
+    Log To Console    Provisioning MaaS PostgreSQL prerequisites
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    bash tasks/Resources/Database/configure_maas_postgres.sh
+    Log To Console    ${output}
+    Should Be Equal As Integers    ${rc}    0    msg=Error provisioning MaaS PostgreSQL prerequisites


### PR DESCRIPTION
The Models As A Service component needs a postgres instance and db secret to run. Adds a `Database/` directory within resources similar to `Gateway/` and adds a configuration based on the provided scripts in opendatahub tests. Calls the script in the same manner and place as MaaS Gateway Setup.

- [maas_postgres_prereqs](https://github.com/opendatahub-io/opendatahub-tests/blob/e81fb1f563c40af2a78c9cab726f5d7b0d3bf66e/tests/model_serving/maas_billing/maas_subscription/conftest.py#L341)
- [maas_postgres_credentials](https://github.com/opendatahub-io/opendatahub-tests/blob/e81fb1f563c40af2a78c9cab726f5d7b0d3bf66e/tests/model_serving/maas_billing/maas_subscription/conftest.py#L321)

Related to: [RHOAIENG-53410](https://redhat.atlassian.net/browse/RHOAIENG-53410) 