### PR TITLE
add OCP 4.20 and 4.21 image to install_nfd.sh

### DIFF
--- a/.github/workflows/code_quality.yaml
+++ b/.github/workflows/code_quality.yaml
@@ -38,22 +38,24 @@ jobs:
     name: python linters
     runs-on: ubuntu-latest
     env:
-      python_version: '3.11'
+      # Must stay within pyproject.toml requires-python: >=3.11.5, <3.12.0
+      python_version: '3.11.9'
       poetry_version: '2.1.1'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Install poetry
-        run: pipx install poetry==${{ env.poetry_version }}
-
+      # Install Python before pipx: otherwise Poetry is bound to the runner default (3.12) and poetry sync fails.
+      # No cache: 'poetry' here — setup-python runs poetry for cache keys; Poetry is installed in the next step.
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '${{ env.python_version }}'
-          cache: 'poetry'
+
+      - name: Install poetry
+        run: pipx install poetry==${{ env.poetry_version }} --python "${{ steps.setup-python.outputs.python-path }}"
 
       - name: Configure poetry
         run: |
@@ -78,20 +80,19 @@ jobs:
     name: selftests
     runs-on: ubuntu-latest
     env:
-      python_version: '3.11'
+      python_version: '3.11.9'
       poetry_version: '2.1.1'
     steps:
       - uses: actions/checkout@v4
-
-      - name: Install poetry
-        run: pipx install poetry==${{ env.poetry_version }}
 
       - name: Set up Python
         id: setup-python
         uses: actions/setup-python@v5
         with:
           python-version: '${{ env.python_version }}'
-          cache: 'poetry'
+
+      - name: Install poetry
+        run: pipx install poetry==${{ env.poetry_version }} --python "${{ steps.setup-python.outputs.python-path }}"
 
       - name: Configure poetry
         run: poetry env use "${{ steps.setup-python.outputs.python-path }}"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
@@ -18,7 +18,9 @@ declare -A images=(
     # 4.18 is a pre-release image. We need to update it later
     ["4.18"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:510cb4351253492455664b6c323f54dc2f6f2f8791c5e92ba6b7e60b8adb357c"
     ["4.19"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:d23fe6bcb36bdbe0e61a30f8ab7cb90e6dea25a399d87c3ba3d94415a61735b8"
-)
+    ["4.20"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:fbd8db340dd4e4cda793b1f0453d42988bb8102d1061388827777bb848b067f2"
+    ["4.21"]="registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:76a161a255a255eafcef4dc036adb8c0c8aadab2f0c57c3d3e19d5eea0ac5961"
+    )
 if [ "${images[$xyVersion]}" ]; then
     imageUrl="${images[$xyVersion]}"
     echo "Using image SHA for $xyVersion: $imageUrl"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
@@ -19,7 +19,7 @@ declare -A images=(
     ["4.18"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:510cb4351253492455664b6c323f54dc2f6f2f8791c5e92ba6b7e60b8adb357c"
     ["4.19"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:d23fe6bcb36bdbe0e61a30f8ab7cb90e6dea25a399d87c3ba3d94415a61735b8"
     ["4.20"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:fbd8db340dd4e4cda793b1f0453d42988bb8102d1061388827777bb848b067f2"
-    ["4.21"]="registry.redhat.io/openshift4/ose-node-feature-discovery-rhel9@sha256:76a161a255a255eafcef4dc036adb8c0c8aadab2f0c57c3d3e19d5eea0ac5961"
+    ["4.21"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:76a161a255a255eafcef4dc036adb8c0c8aadab2f0c57c3d3e19d5eea0ac5961"
     )
 if [ "${images[$xyVersion]}" ]; then
     imageUrl="${images[$xyVersion]}"


### PR DESCRIPTION
This PR updates the NFD installation script to support OCP 4.20,4.21 by adding the corresponding image entry 