### PR TITLE
[ide] fix the expected status text for a started workbench

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -274,7 +274,7 @@ Spawn Notebook
         Wait Until Page Contains    TriggeredScaleUp    timeout=120s
     END
     Wait Until Page Contains Element
-    ...    //*[@data-testid="notebook-status-text"]//*[text() = "Running"]
+    ...    //*[@data-testid="notebook-status-text"]//*[text() = "Ready"]
     ...    ${spawner_timeout}
     IF  ${same_tab}
         Click Button    Open in current tab


### PR DESCRIPTION
This change was introduced in RHOAI 3.4.0.

CI:
```
./run_robot_test.sh --test-case ./tests/Tests/0500__ide/0501__ide_jupyterhub/test.robot --open-report true --skip-oclogin true --test-variables-file test-variables.yml
```
<img width="842" height="316" alt="image" src="https://github.com/user-attachments/assets/a87bfeb0-ed0c-4142-a7fd-b4b025279fad" />
