### PR TITLE
Fail gpu_deploy script if deployment is unsuccessful

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -33,24 +33,29 @@ function wait_until_pod_ready_status() {
   local pod_label=$1
   local namespace=nvidia-gpu-operator
   local timeout=${2:-600}
-  start_time=$(date +%s)
+  local start_time=$(date +%s)
   while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
      pod_status="$(oc get pod -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
      daemon_status="$(oc get daemonset -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
      if [[ -n "$daemon_status" || -n "$pod_status" ]] ; then
         echo "Waiting until GPU Pods or Daemonset of '$pod_label' in namespace '$namespace' are in running state..."
         echo "Pods status: '$pod_status'"
-        echo "Daemonset status: '$daemon_status'"
-        oc wait --timeout=10s --for=condition=ready pod -n "$namespace" -l app="$pod_label" || \
-        if [ $? -ne 0 ]; then
+        echo "Daemonset status: '$daemon_status'"       
+        if [[ -n "$pod_status" ]] && \
+           ! oc wait --timeout=10s --for=condition=ready pod -n "$namespace" -l app="$pod_label"; then
           continue
         fi
-        oc rollout status --watch --timeout=3m daemonset -n "$namespace" -l app="$pod_label" || continue
-        break
+        if [[ -n "$daemon_status" ]] && \
+           ! oc rollout status --watch --timeout=3m daemonset -n "$namespace" -l app="$pod_label"; then
+          continue
+        fi
+        return 0
      fi
      echo "Waiting for Pods or Daemonset with label app='$pod_label' in namespace '$namespace' to be present..."
      sleep 5
   done
+  echo "ERROR: Timed out after ${timeout}s waiting for '$pod_label' in namespace '$namespace' to become ready" >&2
+  return 1
 }
 
 function create_gpu_profile() {

--- a/ods_ci/tasks/Resources/Provisioning/Hive/gpu-provision.robot
+++ b/ods_ci/tasks/Resources/Provisioning/Hive/gpu-provision.robot
@@ -22,5 +22,6 @@ Delete GPU Node In Self Managed AWS Cluster
 Install GPU Operator on Self Managed Cluster
    [Documentation]  Install GPU operator on Self Managed cluster
    ${gpu_install} =    Run Process    sh    tasks/Resources/Provisioning/GPU/gpu_deploy.sh   shell=yes
+   Should Be Equal As Integers    ${gpu_install.rc}    0
    Should Not Contain    ${gpu_install.stdout}    FAIL
    Wait For Pods Status   namespace=nvidia-gpu-operator   timeout=600


### PR DESCRIPTION
This PR ensures that the GPU Operator installation fails when GPU deployment is unsuccessful. Currently, when the gpu_deploy script fails, it does not return a non-zero exit code, allowing the pipeline to continue without reporting an error.

After this fix, the logs show:

Daemonset status: 'nvidia-device-plugin-daemonset 1 1 0 1 0 nvidia.com/gpu.deploy.device-plugin=true 22h'
error: timed out waiting for the condition on pods/nvidia-device-plugin-daemonset-m7d6b
Timed out after 600s waiting for 'nvidia-device-plugin-daemonset' in namespace 'nvidia-gpu-operator' to become ready

Jira: https://redhat.atlassian.net/issues?filter=-2&selectedIssue=[RHOAIENG-58185](https://redhat.atlassian.net/browse/RHOAIENG-58185)