### PR TITLE
[rhoai-3.4.0-ea.2] [ide] revert fixes supposed to be for 3.4.0-ga only

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -274,7 +274,7 @@ Spawn Notebook
         Wait Until Page Contains    TriggeredScaleUp    timeout=120s
     END
     Wait Until Page Contains Element
-    ...    //*[@data-testid="notebook-status-text"]//*[text() = "Ready"]
+    ...    //*[@data-testid="notebook-status-text"]//*[text() = "Running"]
     ...    ${spawner_timeout}
     IF  ${same_tab}
         Click Button    Open in current tab

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataSciencePipelines.resource
@@ -203,7 +203,7 @@ Verify Pipeline Run Is Completed
     [Documentation]    Open the Pipeline detail and wait for the Completed Status
     [Arguments]    ${pipeline_run_name}    ${timeout}=10m   ${experiment_name}=Default
     Open Pipeline Run    ${pipeline_run_name}    ${experiment_name}
-    Wait Until Page Contains Element    //span[@class='pf-v6-c-label__text' and text()='Complete']    timeout=${timeout}
+    Wait Until Page Contains Element    //span[@class='pf-v6-c-label__text' and text()='Succeeded']    timeout=${timeout}
     Capture Page Screenshot
 
 # robocop: disable:line-too-long

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -10,7 +10,7 @@ Resource       Projects.resource
 *** Variables ***
 ${PV_MOUNT_PATH}=    ods-ci-test-path
 ${WORKBENCH_SECTION_XP}=             xpath=//div[@data-testid="section-workbenches"]
-${WORKBENCH_CREATE_BTN_XP}=           xpath=//*[@data-testid="create-workbench-button"]
+${WORKBENCH_CREATE_BTN_XP}=           xpath=//button[@data-testid="create-workbench-button"]
 ${WORKBENCH_CREATE_BTN_2_XP}=         xpath=//button[@id="create-button"]
 ${WORKBENCH_CANCEL_BTN_XP}=         xpath=//button[@id="cancel-button"]
 ${WORKBENCH_NAME_INPUT_XP}=               xpath=//input[@name="workbench-name"]
@@ -30,7 +30,7 @@ ${WORKBENCH_ADD_VAR_BTN_XP}=           xpath=//button[@data-testid="add-variable
 ${WORKBENCH_USE_CONNECTION_CHK_XP}=           xpath=//input[@name="enable-data-connection-checkbox"]
 ${WORKBENCH_EXISTING_CONNECTION_RAD_XP}=      xpath=//button[@data-testid="attach-existing-connection-button"]
 ${WORKBENCH_STATUS_STOPPED}=                  Stopped
-${WORKBENCH_STATUS_RUNNING}=                  Ready
+${WORKBENCH_STATUS_RUNNING}=                  Running
 ${WORKBENCH_STATUS_STARTING}=                 Starting
 ${WORKBENCH_STATUS_FAILED}=                   Failed
 ${WORKBENCH_IMAGE_VER_LABEL}=        //label[@for="workbench-image-version-selection"]


### PR DESCRIPTION
This reverts the #2910 and #2916 changes from the RHOAI 3.4.0-ea2 branch as they are supposed to be part of the RHOAI 3.4.0-ga release only.