### PR TITLE
Make RDMA enablement in ClusterPolicy configurable via ENABLE_RDMA en…

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/cluster-policy.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/cluster-policy.yaml
@@ -1,13 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-    name: kernel-module-params
-    namespace: nvidia-gpu-operator
-data:
-    nvidia.conf: |-
-        NVreg_RegistryDwords="PeerMappingOverride=1;"
-        NVreg_EnableStreamMemOPs=1
----
 apiVersion: nvidia.com/v1
 kind: ClusterPolicy
 metadata:
@@ -37,13 +27,13 @@ spec:
             name: ""
         enabled: true
         kernelModuleConfig:
-            name: kernel-module-params
+            name: <kernel_module_config>
         kernelModuleType: auto
         licensingConfig:
             configMapName: ""
             nlsEnabled: false
         rdma:
-            enabled: true
+            enabled: <rdma_enabled>
             useHostMofed: false
         repoConfig:
             configMapName: ""
@@ -66,7 +56,7 @@ spec:
         virtualTopology:
             config: ""
     gdrcopy:
-        enabled: true
+        enabled: <gdrcopy_enabled>
     gds:
         enabled: false
     gfd:

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -185,7 +185,20 @@ if [ "$gpu_nodes_found" = false ]; then
 fi
 
 echo "Applying NVIDIA GPU ClusterPolicy"
-oc apply -f "${GPU_INSTALL_DIR}/cluster-policy.yaml"
+if [ "${ENABLE_RDMA:-false}" = "true" ]; then
+  echo "RDMA enabled - applying kernel module params and enabling RDMA in ClusterPolicy"
+  oc apply -f "${GPU_INSTALL_DIR}/rdma-kernel-module-params.yaml"
+  sed -e 's/<rdma_enabled>/true/g' \
+      -e 's/<gdrcopy_enabled>/true/g' \
+      -e 's/<kernel_module_config>/kernel-module-params/g' \
+      "${GPU_INSTALL_DIR}/cluster-policy.yaml" | oc apply -f -
+else
+  echo "RDMA disabled (set ENABLE_RDMA=true to enable)"
+  sed -e 's/<rdma_enabled>/false/g' \
+      -e 's/<gdrcopy_enabled>/false/g' \
+      -e 's/<kernel_module_config>/""/g' \
+      "${GPU_INSTALL_DIR}/cluster-policy.yaml" | oc apply -f -
+fi
 wait_until_pod_ready_status "nvidia-device-plugin-daemonset" 600
 wait_until_pod_ready_status "nvidia-container-toolkit-daemonset"
 wait_until_pod_ready_status "nvidia-dcgm-exporter"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/rdma-kernel-module-params.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/rdma-kernel-module-params.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: kernel-module-params
+    namespace: nvidia-gpu-operator
+data:
+    nvidia.conf: |-
+        NVreg_RegistryDwords="PeerMappingOverride=1;"
+        NVreg_EnableStreamMemOPs=1


### PR DESCRIPTION
…v var

Extract RDMA-specific kernel module params ConfigMap to a separate file and use placeholders in cluster-policy.yaml for rdma, gdrcopy, and kernelModuleConfig settings. The gpu_deploy.sh script substitutes these based on the ENABLE_RDMA environment variable (defaults to false).