### PR TITLE
Fix NFS mount failures by forcing NFSv3 on StorageClass

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1420,6 +1420,10 @@ Deploy NFS Provisioner
     Log    ${output}    console=yes
     Wait For Pods To Be Ready    label_selector=nfsprovisioner_cr=${nfs_provisioner_name}
     ...    namespace=${NFS_OP_NS}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    oc patch storageclass nfs -p '{"mountOptions":["nfsvers=3"]}'
+    Should Be Equal As Integers    ${rc}    0
+    Log    ${output}    console=yes
 
 Configure Gateway API
     [Documentation]    Configure Gateway API for KServe inference traffic routing


### PR DESCRIPTION
## Summary
- The containerized NFS Ganesha provisioner cannot serve NFSv4 because overlayfs doesn't support NFS file handles (`name_to_handle_at()`) needed for the pseudo-root export
- RHCOS defaults to NFSv4 for `mount -t nfs`, causing all NFS PV mounts to fail with `mount.nfs: mount system call failed`
- Adds `mountOptions: ["nfsvers=3"]` to the `nfs` StorageClass after deploying the NFS provisioner, ensuring all dynamically provisioned PVs use NFSv3

## Test plan
- [x] Deploy cluster with NFS provisioner and verify the `nfs` StorageClass has `mountOptions: [nfsvers=3]`
- [x] Create a PVC using the `nfs` StorageClass and verify the resulting PV has `nfsvers=3` in mountOptions
- [x] Create a workbench backed by an NFS PVC and verify it starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)