### PR TITLE
Fix NFS mount failures by forcing NFSv3 on StorageClass

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1177,3 +1177,7 @@ Deploy NFS Provisioner
     Log    ${output}    console=yes
     Wait For Pods To Be Ready    label_selector=nfsprovisioner_cr=${nfs_provisioner_name}
     ...    namespace=${NFS_OP_NS}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    oc patch storageclass nfs -p '{"mountOptions":["nfsvers=3"]}'
+    Should Be Equal As Integers    ${rc}    0
+    Log    ${output}    console=yes


### PR DESCRIPTION
## Summary
- Cherry-picks the NFS fix from master (`dacf1308`) to the release-2.25 branch
- Adds `nfsvers=3` mountOption to the NFS StorageClass to work around NFSv4 failures with the containerized NFS Ganesha provisioner on RHCOS

## Test plan
- [ ] Verify NFS PV mounts succeed on a fresh cluster install using the 2.25 branch
- [ ] Confirm `oc get storageclass nfs -o yaml` shows `mountOptions: ["nfsvers=3"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)