### PR TITLE
RHOAIENG-59911: fix failing ray smoke on odh nightly

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-smoke.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0602__training/test-smoke.robot
@@ -29,5 +29,7 @@ Ray smoke test
         FAIL    Can not find kuberay-operator service in ${APPLICATIONS_NAMESPACE}
     END
     Log To Console    kuberay-operator service exists
-    Verify container images    kuberay-operator    kuberay-operator    odh-kuberay-operator-controller
+    IF    "${PRODUCT}" == "RHODS"
+        Verify container images    kuberay-operator    kuberay-operator    odh-kuberay-operator-controller
+    END
 


### PR DESCRIPTION
## WHAT
[RHOAIENG-59911](https://redhat.atlassian.net/browse/RHOAIENG-59911): fix failing ray smoke on odh nightly

## HOW
skip image check when not installing RHOAI (ODH operator is installed instead)

## WHY
nightly smoke tests are failing:

```
Unexpected container image url: '"quay.io/opendatahub/kuberay-operator@sha256:b6f9ce810eb5917f55c4be7f38a076e6e3efb4e4cd11847f7149a804e7887000"' does not contain 'registry.redhat.io/rhoai/odh-kuberay-operator-controller'
```

This only happens on ODH-operator installations. I verified that the test passes on RHOAI installations:

```
Product:RHODS Version:3.4.0-ea.1
[ WARN ] No Prometheus found
Ray smoke test :: Check that Kuberay deployment and service are up... Waiting for kuberay-operator to be available
..deployment.apps/kuberay-operator condition met
..kuberay-operator deployment is available
..NAME               TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
kuberay-operator   ClusterIP   172.30.11.166   <none>        8080/TCP   11d
..kuberay-operator service exists
Ray smoke test :: Check that Kuberay deployment and service are up... .Verifying kuberay-operator's container image is referred from registry.redhat.io
kuberay-operator's container image is verified
Ray smoke test :: Check that Kuberay deployment and service are up... | PASS |
------------------------------------------------------------------------------
Tests.Distributed Workloads.Training.Test-Smoke :: Smoke tests for... | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Distributed Workloads.Training                                  | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests.Distributed Workloads                                           | PASS |
1 test, 1 passed, 0 failed
==============================================================================
Tests                                                                 | PASS |
1 test, 1 passed, 0 failed
```