### PR TITLE
[ide] fix intermittent special-user-testing failure

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/special-user-testing.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/special-user-testing.robot
@@ -36,8 +36,18 @@ Special User Testing Suite Setup
 
 Login Verify Logout
     [Arguments]  ${username}  ${password}  ${auth}
-    Logout From RHODS Dashboard
+    # Clear session cookies while still on the dashboard domain, then navigate
+    # to about:blank to kill all active WebSocket/AJAX connections. Without this,
+    # stale background requests trigger competing OAuth flows that overwrite the
+    # CSRF cookie, causing intermittent login failures (CSRF token mismatch).
+    Delete All Cookies
+    Go To  about:blank
+    Go To  ${ODH_DASHBOARD_URL}
     Login To RHODS Dashboard  ${username}  ${password}  ${auth}
+    # Wait for dashboard framework to load (title + logo) before navigating.
+    # We only check page-agnostic elements since the post-login redirect target varies.
+    Wait For Condition    return document.title == "${ODH_DASHBOARD_PROJECT_NAME}"    timeout=30
+    Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=30
     # We need to Launch Jupyter app again, because there is a redirect to the `enabled` page in the
     # Login To RHODS Dashboard keyword now as a workaround.
     Launch Jupyter From RHODS Dashboard Link


### PR DESCRIPTION
There was a problem in timing and also as there may be some in-flight requests that would be affecting the logout and login cycles that are done quite fast after each other.

Tested with:
```
./run_robot_test.sh --extra-robot-args '-i IDEORJupyterHub -e AutomationBug -e ProductBug -e Upgrade -e Sanity -e Tier1 -e Tier2 -e Resources* -e NVIDIA-GPUs -e ODS-2125 -e ODS-936 -e ODS-1808' --open-report true --skip-oclogin
```
<img width="846" height="382" alt="image" src="https://github.com/user-attachments/assets/8819b8aa-5f1a-4a98-a05f-f1a7d5b89c16" />
