### PR TITLE
Add Feast OIDC test and Feast 3.5 EA1 Release version Info

### DIFF
--- a/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
+++ b/ods_ci/tests/Resources/Page/FeatureStore/FeatureStore.resource
@@ -6,11 +6,11 @@ Resource         ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 
 
 *** Variables ***
-${FEATURE-STORE-RELEASE-TAG}             release-3.4
+${FEATURE-STORE-RELEASE-TAG}             release-3.5-ea.1
 ${FEATURE-STORE_DIR}                     feature-store
 ${FEATURE-STORE_REPO_URL}                %{FEATURE-STORE_REPO_URL=https://github.com/opendatahub-io/feast.git}
-${NOTEBOOK_IMAGE}                        quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:aad51a27254dd57ae33fb4220af989f54b81c53c852a4e51c55d8a253a38a0e0
-${FEAST_VERSION}                         0.62.0
+${NOTEBOOK_IMAGE}                        quay.io/rhoai/odh-workbench-jupyter-datascience-cpu-py312-rhel9@sha256:0bcbcb167d1643009f3374464579bbbb4ff0f07111bf15f7e9e5d53d9d542555
+${FEAST_VERSION}                         0.63.0
 ${DSC_NAME}                              default-dsc
 
 
@@ -23,7 +23,7 @@ Prepare Feature Store Test Suite
         Enable Component    feastoperator
         Wait Component Ready    feastoperator
     END
-    
+
 Prepare Feast E2E Test Suite
     [Documentation]    Prepare Feast E2E Test Suite
     Log To Console    Preparing Feast E2E Test Suite
@@ -91,6 +91,16 @@ Run Feast Notebook Test
     [Documentation]    Run feast Notebook test
     [Arguments]   ${TEST_NAME}
     Log To Console    "Running feature-store Notebook test: ${TEST_NAME}"
+    ${cluster_auth_value}=    Get Variable Value    ${CLUSTER_AUTH}    ${EMPTY}
+    IF  "${cluster_auth_value}" == "oidc"
+        ${token}=    Get Oidc Token
+        ...      ${CLUSTER_OIDC_ISSUER}
+        ...      ${TEST_USER.USERNAME}
+        ...      ${TEST_USER.PASSWORD}
+        Should Not Be Empty    ${token}
+    ELSE
+        ${token}=    Set Variable    ${EMPTY}
+    END
     ${command}=    Set Variable    cd ${FEATURE-STORE_DIR}/infra/feast-operator && git fetch origin && git checkout ${FEATURE-STORE-RELEASE-TAG} && git branch && go test -timeout 10m ./test/e2e_rhoai/ -v -ginkgo.focus=${TEST_NAME}
     ${result}=    Run Process    ${command}
     ...    shell=true
@@ -103,6 +113,7 @@ Run Feast Notebook Test
     ...    env:OPENAI_API_KEY=${OPENAI_API_KEY}
     ...    env:PIP_INDEX_URL=${PIP_INDEX_URL}
     ...    env:PIP_TRUSTED_HOST=${PIP_TRUSTED_HOST}
+    ...    env:TOKEN=${token}
     Log To Console    ${result.stdout}
     IF    ${result.rc} != 0
         FAIL    Running test ${TEST_NAME} failed

--- a/ods_ci/tests/Tests/0700__feature_store/test-run-feast-notebook-tests.robot
+++ b/ods_ci/tests/Tests/0700__feature_store/test-run-feast-notebook-tests.robot
@@ -39,3 +39,14 @@ Run feastWorkbenchIntegrationWithoutAuth Test
     ...     FeatureStore
     ...     RHOAIENG-38921
     Run Feast Notebook Test    FeastWorkbenchIntegrationWithoutAuth
+
+Run feastWorkbenchOIDCAuth Test
+    [Documentation]    Run Feast Notebook test: TestFeastWorkbenchOIDCAuth
+    [Tags]  Tier1
+    ...     FeatureStore
+    ...     RHOAIENG-56206
+    ${cluster_auth_value}=    Get Variable Value    ${CLUSTER_AUTH}    ${EMPTY}
+    IF  "${cluster_auth_value}" != "oidc"
+        Skip  "Only applicable with BYOIDC"
+    END
+    Run Feast Notebook Test    OIDC


### PR DESCRIPTION
 Added Feast OIDC test for Feast OIDC authentication (Run feastWorkbenchOIDCAuth Test). The test validates that a Feast workbench notebook can authenticate against a Feast registry using OIDC token-based auth on a BYOIDC cluster.

- Adds OIDC-aware token resolution in Run Feast Notebook Test keyword — fetches an OIDC token via Get Oidc Token using the cluster issuer URL and test user credentials when CLUSTER_AUTH=oidc; passes it as TOKEN env var to the go test subprocess
- Falls back to empty token for non-OIDC clusters, preserving existing test behavior
- Updated 3.5.EA1 release version details
