### PR TITLE
[ide] migrate test tags from sanity to Tier1, Tier2 and Tier3 levels

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
@@ -30,14 +30,14 @@ ${IMAGESTREAM_NAME}=
 Verify Admin User Can Access Custom Notebook Settings
     [Documentation]    Verifies an admin user can reach the custom notebook
     ...    settings page.
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-1366
     Pass Execution    Passing tests, as suite setup ensures page can be reached
 
 Verify Custom Image Can Be Added
     [Documentation]    Imports the custom image via UI
     ...                Then loads the spawner and tries using the custom img
-    [Tags]    Tier1    ExcludeOnDisconnected
+    [Tags]    Tier2    ExcludeOnDisconnected
     ...       ODS-1208    ODS-1365
     ${CLEANUP}=  Set Variable  False
     Create Custom Image
@@ -63,7 +63,7 @@ Verify Custom Image Can Be Added
 Test Duplicate Image
     [Documentation]  Test adding two images with the same name (should fail)
     ...       There was a bug related https://issues.redhat.com/browse/RHOAIENG-1192
-    [Tags]    Tier1    ExcludeOnDisconnected
+    [Tags]    Tier3    ExcludeOnDisconnected
     ...       ODS-1368
     Sleep  1
     Create Custom Image
@@ -80,7 +80,7 @@ Test Duplicate Image
 
 Test Bad Image URL
     [Documentation]  Test adding an image with a bad repo URL (should fail)
-    [Tags]    Tier1
+    [Tags]    Tier3
     ...       ODS-1367
     ${OG_URL}=  Set Variable  ${IMG_URL}
     ${IMG_URL}=  Set Variable  quay.io/RandomName/RandomImage:v1.2.3
@@ -93,7 +93,7 @@ Test Bad Image URL
 
 Test Image From Local registry
     [Documentation]  Try creating a custom image using a local registry URL (i.e. OOTB image)
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-2470
     ...       ExcludeOnDisconnected    # Since we don't have internal image registry enabled there usually
     ...       InternalImageRegistry    # Requires internal image registry enabled

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/image-iteration.robot
@@ -20,12 +20,12 @@ ${python_dict}  {'classifiers':[${generic-1}, ${minimal-1}], 'clustering':[${gen
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Tier1
+  [Tags]  Tier2
   Login To RHODS Dashboard  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Wait For RHODS Dashboard To Load
 
 Iterative Testing Classifiers
-  [Tags]  Tier1
+  [Tags]  Tier2
   ...     Execution-Time-Over-15m
   &{DICTIONARY} =  Evaluate  ${python_dict}
   FOR  ${sublist}  IN  @{DICTIONARY}[classifiers]

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/jupyterhub-user-access.robot
@@ -31,7 +31,7 @@ Verify User Can Set Custom RHODS Groups
     ...                via ODH Dashboard UI in `Settings -> User management` section, see:
     ...                `Verify Unauthorized User Is Not Able To Spawn Jupyter Notebook` in
     ...                tests/Tests/400__ods_dashboard/405__ods_dashboard_user_mgmt.robot
-    [Tags]  Tier1
+    [Tags]  Tier3
     ...     ODS-293    ODS-503
     [Setup]      Set Standard RHODS Groups Variables
     Create Custom Groups

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
@@ -21,35 +21,35 @@ ${EXPECTED_CUDA_VERSION_N_1} =  12.6
 Verify CUDA Image Can Be Spawned With GPU
     [Documentation]    Spawns CUDA image with 1 GPU and verifies that the GPU is
     ...    not available for other users.
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1141    ODS-346    ODS-1359
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 Verify CUDA Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1142
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify PyTorch Library Can See GPUs In Minimal CUDA
     [Documentation]    Installs PyTorch and verifies it can see the GPU
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1144
     Verify Pytorch Can See GPU    install=True
 
 Verify Tensorflow Library Can See GPUs In Minimal CUDA
     [Documentation]    Installs Tensorflow and verifies it can see the GPU
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1143
     Verify Tensorflow Can See GPU    install=True
 
 Verify Cuda Image Has NVCC Installed
     [Documentation]     Verifies NVCC Version in Minimal CUDA Image
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-483
     ${nvcc_version} =  Run Cell And Get Output    input=!nvcc --version

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
@@ -23,13 +23,13 @@ ${TENSORBOARD_FRAME_XPATH} =  //iframe[contains(@id, "tensorboard-frame")]
 *** Test Cases ***
 Verify PyTorch Image Can Be Spawned
     [Documentation]    Spawns pytorch image
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1149
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 PyTorch Image Workload Test
     [Documentation]    Runs a pytorch workload
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1150
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
     Capture Page Screenshot
@@ -37,7 +37,7 @@ PyTorch Image Workload Test
 
 Verify Tensorboard Is Accessible
     [Documentation]  Verifies that tensorboard is accessible
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1414
     Close Previous Server
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  hardware_profile=default-profile
@@ -50,7 +50,7 @@ Verify Tensorboard Is Accessible
 
 Verify PyTorch Image Can Be Spawned With GPU
     [Documentation]    Spawns PyTorch image with 1 GPU
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1145
     Clean Up Server
@@ -62,21 +62,21 @@ Verify PyTorch Image Can Be Spawned With GPU
 
 Verify PyTorch Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1146
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify PyTorch Library Can See GPUs In PyTorch Image
     [Documentation]    Verifies PyTorch can see the GPU
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1147
     Verify Pytorch Can See GPU
 
 Verify PyTorch Image GPU Workload
     [Documentation]  Runs a workload on GPUs in PyTorch image
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1148
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/pytorch/fgsm_tutorial.ipynb

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
@@ -24,13 +24,13 @@ ${TENSORBOARD_FRAME_XPATH} =  //iframe[contains(@id, "tensorboard-frame")]
 *** Test Cases ***
 Verify Tensorflow Image Can Be Spawned
     [Documentation]    Spawns tensorflow image
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1155
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 Tensorflow Workload Test
     [Documentation]    Runs tensorflow workload
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1156
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb
     Capture Page Screenshot
@@ -38,7 +38,7 @@ Tensorflow Workload Test
 
 Verify Tensorboard Is Accessible
     [Documentation]  Verifies that tensorboard is accessible
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     ODS-1413
     Close Previous Server
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  hardware_profile=default-profile
@@ -51,7 +51,7 @@ Verify Tensorboard Is Accessible
 
 Verify Tensorflow Image Can Be Spawned With GPU
     [Documentation]    Spawns PyTorch image with 1 GPU
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1151
     Close Previous Server
@@ -60,21 +60,21 @@ Verify Tensorflow Image Can Be Spawned With GPU
 
 Verify Tensorflow Image Includes Expected CUDA Version
     [Documentation]    Checks CUDA version
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1152
     Verify Installed CUDA Version    ${EXPECTED_CUDA_VERSION}
 
 Verify Tensorflow Library Can See GPUs In Tensorflow Image
     [Documentation]    Verifies Tensorlow can see the GPU
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1153
     Verify Tensorflow Can See GPU
 
 Verify Tensorflow Image GPU Workload
     [Documentation]  Runs a workload on GPUs in Tensorflow image
-    [Tags]  Tier1
+    [Tags]  Tier2
     ...     Resources-GPU    NVIDIA-GPUs
     ...     ODS-1154
     Run Repo And Clean  https://github.com/lugi0/notebook-benchmarks  notebook-benchmarks/tensorflow/GPU-no-warnings.ipynb

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-vscode-test.robot
@@ -20,7 +20,7 @@ ${NOTEBOOK_IMAGE} =         code-server
 *** Test Cases ***
 Verify VSCode Image Can Be Spawned
     [Documentation]    Spawns vscode image
-    [Tags]  Tier1
+    [Tags]  Tier2
     Pass Execution    Passing tests, as suite setup ensures that image can be spawned
 
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-gpus.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/multiple-gpus.robot
@@ -22,7 +22,7 @@ Verify Number Of Available GPUs Is Correct
     [Documentation]  Verifies that the number of available GPUs in the
     ...    Spawner dropdown is correct; i.e., it should show the maximum
     ...    Number of GPUs available in a single node.
-    [Tags]    Sanity  Resources-2GPUS    NVIDIA-GPUs
+    [Tags]    Tier2  Resources-2GPUS    NVIDIA-GPUs
     ...       ODS-1256
     ${maxNo} =    Find Max Number Of GPUs In One Node
     ${maxSpawner} =    Fetch Max Number Of GPUs In Spawner Page
@@ -31,7 +31,7 @@ Verify Number Of Available GPUs Is Correct
 Verify Two Servers Can Be Spawned
     [Documentation]    Spawns two servers requesting 1 gpu each, and checks
     ...    that both can schedule and are scheduled on different nodes.
-    [Tags]    Sanity  Resources-2GPUS    NVIDIA-GPUs
+    [Tags]    Tier2  Resources-2GPUS    NVIDIA-GPUs
     ...       ODS-1257
     # TODOjstourac = we need to define our custom profile with a gpu
     Spawn Notebook With Arguments  image=${NOTEBOOK_IMAGE}  hardware_profile=default-profile

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/networkpolicy-test.robot
@@ -15,7 +15,7 @@ Test Tags       JupyterHub
 Test Network Policy Effect
     [Documentation]    Spawns two Notebooks with two different users and verifies
     ...    That the new network policies prevent user2 from accessing user1's workspace
-    [Tags]  Tier1
+    [Tags]  Tier3
     ...     ODS-2046
     Open Browser And Start Notebook As First User
     Open Browser And Start Notebook As Second User With Env Vars

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/plugin-verification.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/plugin-verification.robot
@@ -22,7 +22,7 @@ Test Tags       JupyterHub
 
 *** Test Cases ***
 Test User Notebook Plugin in JupyterLab
-    [Tags]  Sanity
+    [Tags]  Tier2
     ...     ODS-486
     ...     ProductBug
     Gather Notebook data

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-filling-pvc.robot
@@ -26,7 +26,7 @@ ${FILE_NAME}            fill-notebook-pvc-to-complete-100.ipynb
 Verify Users Get Notifications If Storage Capacity Limits Get Exceeded
     [Documentation]    Runs a jupyter notebook to fill the user PVC to 100% and verifies that
     ...    a "No space left on device" OSError and a "File Save Error" dialog are shown
-    [Tags]    Tier1
+    [Tags]    Tier3
     ...       ODS-539
 
     ${error} =    Run Git Repo And Return Last Cell Error Text    ${LINK_OF_GITHUB}    ${PATH_TO_FILE}

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git-notebook.robot
@@ -13,27 +13,27 @@ Test Tags       JupyterHub
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Tier1
+  [Tags]  Tier2
   Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
-  [Tags]  Tier1
+  [Tags]  Tier2
   Launch Jupyter From RHODS Dashboard Link
 
 Can Login to Jupyterhub
-  [Tags]  Tier1
+  [Tags]  Tier2
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a basic workbench
 
 Can Spawn Notebook
-  [Tags]  Tier1
+  [Tags]  Tier2
   Fix Spawner Status
   Spawn Notebook With Arguments  image=science-notebook
 
 Can Launch Python3 Smoke Test Notebook
-  [Tags]  Tier1
+  [Tags]  Tier2
   ##################################################
   # Manual Notebook Input
   ##################################################

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-git.robot
@@ -21,7 +21,7 @@ ${COMMIT_MSG}       commit msg2
 Verify Pushing Project Changes Remote Repository
     [Documentation]    Verifies that changes has been pushed successfully to remote repository
     [Tags]    ODS-326
-    ...       Tier1
+    ...       Tier2
     Set Simple Staging Status    status=OFF
     ${randnum}=    Generate Random String    9    [NUMBERS]
     ${commit_message}=    Catenate    ${COMMIT_MSG}    ${randnum}
@@ -36,7 +36,7 @@ Verify Pushing Project Changes Remote Repository
 Verify Updating Project With Changes From Git Repository
     [Documentation]    Verifies that changes has been pulled successfully to local repository
     [Tags]    ODS-324
-    ...       Tier1
+    ...       Tier2
     Set Simple Staging Status    status=OFF
     Clone Git Repository And Open    ${REPO_URL}    ${FILE_PATH}
     Sleep    1s

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-jupyterlab-notebook.robot
@@ -16,27 +16,27 @@ Test Tags       JupyterHub
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Sanity
+  [Tags]  Tier1
   Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
-  [Tags]  Sanity
+  [Tags]  Tier1
   Launch Jupyter From RHODS Dashboard Link
 
 Can Login to Jupyterhub
-  [Tags]  Sanity
+  [Tags]  Tier1
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a basic workbench
 
 Can Spawn Notebook
-  [Tags]  Sanity
+  [Tags]  Tier1
   Fix Spawner Status
   Spawn Notebook With Arguments  image=science-notebook
 
 Can Launch Python3 Smoke Test Notebook
-  [Tags]  Sanity  ODS-906
+  [Tags]  Tier1  ODS-906
   Add And Run JupyterLab Code Cell In Active Notebook  import os
   Add And Run JupyterLab Code Cell In Active Notebook  print("Hello World!")
   Capture Page Screenshot
@@ -54,7 +54,7 @@ Can Launch Python3 Smoke Test Notebook
 Verify A Default Image Is Provided And Starts Successfully
     [Documentation]    Verify that, if a user doesn't explicitly select any jupyter image
     ...    a default one is selected and it can be spawned successfully
-    [Tags]    Sanity
+    [Tags]    Tier1
     ...       ODS-469
     Clean Up Server
     Stop JupyterLab Notebook Server

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-minimal-image.robot
@@ -10,7 +10,7 @@ Library             ../../../../libs/Helpers.py
 Suite Setup         Begin Web Test
 Suite Teardown      End Web Test
 
-Test Tags          Sanity    JupyterHub      OpenDataHub
+Test Tags          Tier1    JupyterHub      OpenDataHub
 
 
 *** Variables ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-pipChanges-not-permanent.robot
@@ -15,7 +15,7 @@ Verify pip Changes not permanent
     ...   Verify if installed pip changes are permanent
     ...   after stopping and starting notebook
 
-    [Tags]  Sanity
+    [Tags]  Tier1
     ...     ODS-909
     Install And Import Package In JupyterLab  paramiko
     Stop JupyterLab Notebook Server

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-s3-cc-fraud.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-s3-cc-fraud.robot
@@ -13,27 +13,27 @@ Test Tags       JupyterHub
 
 *** Test Cases ***
 Open RHODS Dashboard
-  [Tags]  Sanity
+  [Tags]  Tier1
   Wait For RHODS Dashboard To Load
 
 Can Launch Jupyterhub
-  [Tags]  Sanity
+  [Tags]  Tier1
   Launch Jupyter From RHODS Dashboard Link
 
 Can Login to Jupyterhub
-  [Tags]  Sanity
+  [Tags]  Tier1
   Login To Jupyterhub  ${TEST_USER.USERNAME}  ${TEST_USER.PASSWORD}  ${TEST_USER.AUTH_TYPE}
   Verify Service Account Authorization Not Required
   #Wait Until Page Contains Element  xpath://span[@id='jupyterhub-logo']
   Wait Until Page Contains  Start a basic workbench
 
 Can Spawn Notebook
-  [Tags]  Sanity  ODS-902  ODS-904
+  [Tags]  Tier1  ODS-902  ODS-904
   Fix Spawner Status
   Spawn Notebooks And Set S3 Credentials    image=science-notebook
 
 Can Launch Python3 Smoke Test Notebook
-  [Tags]  Sanity  ODS-910  ODS-911  ODS-921  ODS-924  ODS-929  ODS-931  ODS-333
+  [Tags]  Tier1  ODS-910  ODS-911  ODS-921  ODS-924  ODS-929  ODS-931  ODS-333
   Navigate Home (Root folder) In JupyterLab Sidebar File Browser
   Open With JupyterLab Menu  Git  Clone a Repository
   Input Text  //div[.="Clone a repo"]/../div[contains(@class, "jp-Dialog-body")]//input  https://github.com/lugi0/clustering-notebook

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/test-versions.robot
@@ -25,49 +25,49 @@ ${JupyterLab-git_Version}     v0.51
 *** Test Cases ***
 Open JupyterHub Spawner Page
     [Documentation]    Verifies that Spawner page can be loaded
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-695
     Pass Execution    Passing tests, as suite setup ensures that spawner can be loaded
 
 Verify Libraries in Minimal Image
     [Documentation]    Verifies libraries in Minimal Python image
-    [Tags]    Tier1
+    [Tags]    Tier2
     Verify List Of Libraries In Image    minimal-notebook    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Cuda Image
     [Documentation]    Verifies libraries in Cuda image
-    [Tags]    Tier1
+    [Tags]    Tier2
     Verify List Of Libraries In Image    minimal-gpu    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in SDS Image
     [Documentation]    Verifies libraries in Standard Data Science image
-    [Tags]    Tier1
+    [Tags]    Tier2
     Verify List Of Libraries In Image    science-notebook    JupyterLab ${JupyterLab_Version}
     ...    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in PyTorch Image
     [Documentation]    Verifies libraries in PyTorch image
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-215    ODS-216    ODS-217    ODS-218    ODS-466
     Verify List Of Libraries In Image
     ...    pytorch    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in Tensorflow Image
     [Documentation]    Verifies libraries in Tensorflow image
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-204    ODS-205    ODS-206    ODS-207  ODS-474
     Verify List Of Libraries In Image
     ...    tensorflow    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify Libraries in TrustyAI Image
     [Documentation]    Verifies libraries in TrustyAI image
-    [Tags]    Tier1
+    [Tags]    Tier2
     Verify List Of Libraries In Image
     ...    odh-trustyai-notebook    JupyterLab ${JupyterLab_Version}    JupyterLab-git ${JupyterLab-git_Version}
 
 Verify All Images And Spawner
     [Documentation]    Verifies that all images have the correct libraries with same versions
-    [Tags]    Tier1
+    [Tags]    Tier2
     ...       ODS-340    ODS-452    ODS-468
     List Should Not Contain Value    ${status_list}    FAIL
     ${length} =    Get Length    ${status_list}

--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -53,7 +53,7 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Based I
     ...    Note: this a templated test case
     ...    (more info at https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#test-templates)
     [Template]    Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
-    [Tags]        Sanity    ODS-2271
+    [Tags]        Tier1    ODS-2271
     [Timeout]     40m
     Jupyter | PyTorch | CUDA | Python 3.12       Runtime | Datascience | CPU | Python 3.12    pytorch-pipeline      600s
     Jupyter | TensorFlow | CUDA | Python 3.12    Runtime | Datascience | CPU | Python 3.12    tensorflow-pipeline   600s


### PR DESCRIPTION
https://redhat.atlassian.net/browse/RHOAIENG-56181

#### Step 1 -- Tier1 -> Tier2 (8 files, ~38 tag changes):

* custom-image.robot -- 3 positive tests: Tier1 -> Tier2
* image-iteration.robot -- 2 tests: Tier1 -> Tier2
* minimal-pytorch-test.robot -- 7 tests: Tier1 -> Tier2
* minimal-tensorflow-test.robot -- 7 tests: Tier1 -> Tier2
* minimal-vscode-test.robot -- 1 test: Tier1 -> Tier2
* test-jupyterlab-git-notebook.robot -- 5 tests: Tier1 -> Tier2
* test-jupyterlab-git.robot -- 2 tests: Tier1 -> Tier2
* test-versions.robot -- 8 tests: Tier1 -> Tier2

#### Step 1 -- Tier1 -> Tier3 (3 files + 2 cases in custom-image, 5 tag changes):

* networkpolicy-test.robot -- 1 test: Tier1 -> Tier3
* test-filling-pvc.robot -- 1 test: Tier1 -> Tier3
* jupyterhub-user-access.robot -- 1 test: Tier1 -> Tier3
* custom-image.robot -- "Test Duplicate Image" and "Test Bad Image URL": Tier1 -> Tier3

#### Step 2 -- Sanity retired (8 files, ~21 tag changes):

* test-jupyterlab-notebook.robot -- 6 tests: Sanity -> Tier1
* test-minimal-image.robot -- suite-level: Sanity -> Tier1
* test-s3-cc-fraud.robot -- 5 tests: Sanity -> Tier1
* test-pipChanges-not-permanent.robot -- 1 test: Sanity -> Tier1
* 0502__ide_elyra.robot -- 1 test: Sanity -> Tier1
* minimal-cuda-test.robot -- 5 tests: Sanity -> Tier2
* multiple-gpus.robot -- 2 tests: Sanity -> Tier2
* plugin-verification.robot -- 1 test: Sanity -> Tier2

---

Backports:
* 3.3: #2960
* 2.25: #2961