### PR TITLE
RHAIENG-4797: update CUDA version expectations in GPU tests for RHOAI 3.5

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-cuda-test.robot
@@ -13,8 +13,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         minimal-gpu
-${EXPECTED_CUDA_VERSION} =  12.9
-${EXPECTED_CUDA_VERSION_N_1} =  12.6
+${EXPECTED_CUDA_VERSION} =  13.0
+${EXPECTED_CUDA_VERSION_N_1} =  13.0
 
 
 *** Test Cases ***

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-pytorch-test.robot
@@ -15,8 +15,8 @@ Test Tags       JupyterHub
 
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         pytorch
-${EXPECTED_CUDA_VERSION} =  12.9
-${EXPECTED_CUDA_VERSION_N_1} =  12.6
+${EXPECTED_CUDA_VERSION} =  13.0
+${EXPECTED_CUDA_VERSION_N_1} =  12.9
 ${TENSORBOARD_FRAME_XPATH} =  //iframe[contains(@id, "tensorboard-frame")]
 
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/minimal-tensorflow-test.robot
@@ -17,7 +17,7 @@ Test Tags       JupyterHub
 *** Variables ***
 ${NOTEBOOK_IMAGE} =         tensorflow
 ${EXPECTED_CUDA_VERSION} =  12.9
-${EXPECTED_CUDA_VERSION_N_1} =  12.6
+${EXPECTED_CUDA_VERSION_N_1} =  12.9
 ${TENSORBOARD_FRAME_XPATH} =  //iframe[contains(@id, "tensorboard-frame")]
 
 


### PR DESCRIPTION
## Summary

Update hardcoded CUDA version expectations in GPU test files to match the actual CUDA versions in 3.5 images (from `build-args/konflux.*.conf` on `opendatahub-io/notebooks` main).

### Changes

| Test file | Variable | Old | New | Reason |
|---|---|---|---|---|
| minimal-cuda-test.robot | EXPECTED_CUDA_VERSION | 12.9 | **13.0** | Minimal CUDA base is cuda-13.0 |
| minimal-cuda-test.robot | EXPECTED_CUDA_VERSION_N_1 | 12.6 | **13.0** | N-1 (3.4) Minimal CUDA is also 13.0 |
| minimal-pytorch-test.robot | EXPECTED_CUDA_VERSION | 12.9 | **13.0** | PyTorch CUDA base is cuda-13.0 |
| minimal-pytorch-test.robot | EXPECTED_CUDA_VERSION_N_1 | 12.6 | **12.9** | N-1 (3.4) PyTorch uses cuda-12.9 |
| minimal-tensorflow-test.robot | EXPECTED_CUDA_VERSION_N_1 | 12.6 | **12.9** | N-1 (3.4) TF uses cuda-12.9 |

Related manifest fix: https://github.com/opendatahub-io/notebooks/pull/3600
Fixes https://redhat.atlassian.net/browse/RHAIENG-4797