### PR TITLE
Remove llamastackoperator wait for deployment replica

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -438,12 +438,6 @@ Verify RHODS Installation
     ...    label_selector=app.kubernetes.io/part-of=feastoperator
   END
 
-  ${llamastackoperator} =    Is Component Enabled    llamastackoperator    ${DSC_NAME}
-  IF    "${llamastackoperator}" == "true"
-    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
-    ...    label_selector=app.kubernetes.io/part-of=llamastackoperator
-  END
-
   ${ogx} =     Is Component Enabled    ogx    ${DSC_NAME}
   IF    "${ogx}" == "true"
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}


### PR DESCRIPTION
I think we should remove this so if lls is ever set to Managed it fails on ogx, if ogx is activated as well (ogx will report error). If lls is Managed but ogx Removed, the test shouldn't hang on waiting for non-existent deployment.