### PR TITLE
fix: backport GPU installation fixes from 2.25 to 3.3

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh
@@ -24,6 +24,7 @@ declare -A images=(
     ["4.18"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:510cb4351253492455664b6c323f54dc2f6f2f8791c5e92ba6b7e60b8adb357c"
     ["4.19"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:d23fe6bcb36bdbe0e61a30f8ab7cb90e6dea25a399d87c3ba3d94415a61735b8"
     ["4.20"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:fbd8db340dd4e4cda793b1f0453d42988bb8102d1061388827777bb848b067f2"
+    ["4.21"]="registry.redhat.io\/openshift4\/ose-node-feature-discovery-rhel9@sha256:76a161a255a255eafcef4dc036adb8c0c8aadab2f0c57c3d3e19d5eea0ac5961"
 )
 if [ "${images[$xyVersion]}" ]; then
     imageUrl="${images[$xyVersion]}"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -7,9 +7,30 @@ GPU_INSTALL_DIR="$(dirname "$0")"
 
 CHANNEL="$(oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')"
 
-CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r '.status.channels[] | select(.name == "'$CHANNEL'") | .currentCSV')"
+if [[ -z "${CHANNEL}" ]]; then
+  echo "ERROR: Could not determine defaultChannel from gpu-operator-certified packagemanifest." >&2
+  echo "Falling back to 'stable' channel." >&2
+  CHANNEL="stable"
+fi
+echo "Using GPU Operator channel: $CHANNEL"
 
-sed -i'' -e "0,/v1.11/s//$CHANNEL/g" "$GPU_INSTALL_DIR/gpu_install.yaml"
+CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r ".status.channels[] | select(.name == \"${CHANNEL}\") | .currentCSV")"
+
+if [[ -z "${CSVNAME}" ]]; then
+  echo "ERROR: Could not determine CSV name for channel '$CHANNEL'." >&2
+  echo "Available channels:" >&2
+  oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.channels[*].name}' >&2
+  echo "" >&2
+  exit 1
+fi
+echo "Using GPU Operator CSV: $CSVNAME"
+
+sed -i'' -E "s|^([[:space:]]*)channel:.*|\1channel: \"${CHANNEL}\"|" "$GPU_INSTALL_DIR/gpu_install.yaml"
+
+if grep -qE '^[[:space:]]*channel:[[:space:]]*"?PLACEHOLDER"?' "$GPU_INSTALL_DIR/gpu_install.yaml"; then
+  echo "ERROR: GPU Operator subscription channel was not substituted (still PLACEHOLDER). Check gpu_install.yaml and sed." >&2
+  exit 1
+fi
 
 oc apply -f "$GPU_INSTALL_DIR/gpu_install.yaml"
 /bin/bash tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh


### PR DESCRIPTION
## Summary
- Backports GPU installation fixes from `release-2.25` (PRs #2907 and #2929) to `release-3.3`
- **Add OCP 4.21 NFD image** to `install_nfd.sh` — without it, 4.21 clusters fall back to the 4.17 NFD image which fails to discover GPU features
- **Fix GPU operator channel sed pattern** in `gpu_deploy.sh` — the old sed matched literal `v1.11` but the template now uses `v25.3`, so the channel was never substituted. Adds channel validation, `stable` fallback, and CSV verification

## Root Cause
GPU installation fails on OCP 4.21 clusters running RHOAI 3.3 due to:
1. Missing NFD image for 4.21 → NFD can't label GPU nodes → GPU operator daemonsets never deploy
2. Broken sed pattern → GPU operator subscription created with wrong channel

Observed in [dashboard-e2e-tests #759](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/components/job/dashboard/job/dashboard-e2e-tests/759/)

## Test plan
- [ ] Verify GPU installation succeeds on OCP 4.21 cluster with RHOAI 3.3
- [ ] Verify NFD correctly labels GPU nodes with `feature.node.kubernetes.io/pci-10de.present=true`
- [ ] Verify GPU operator subscription uses correct channel from packagemanifest

Closes: https://redhat.atlassian.net/browse/RHOAIENG-62642