### PR TITLE
Backport PR #2920: make RDMA enablement in ClusterPolicy configurable via ENABLE_RDMA env var

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/cluster-policy.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/cluster-policy.yaml
@@ -1,13 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-    name: kernel-module-params
-    namespace: nvidia-gpu-operator
-data:
-    nvidia.conf: |-
-        NVreg_RegistryDwords="PeerMappingOverride=1;"
-        NVreg_EnableStreamMemOPs=1
----
 apiVersion: nvidia.com/v1
 kind: ClusterPolicy
 metadata:
@@ -37,13 +27,13 @@ spec:
             name: ""
         enabled: true
         kernelModuleConfig:
-            name: kernel-module-params
+            name: <kernel_module_config>
         kernelModuleType: auto
         licensingConfig:
             configMapName: ""
             nlsEnabled: false
         rdma:
-            enabled: true
+            enabled: <rdma_enabled>
             useHostMofed: false
         repoConfig:
             configMapName: ""
@@ -66,7 +56,7 @@ spec:
         virtualTopology:
             config: ""
     gdrcopy:
-        enabled: true
+        enabled: <gdrcopy_enabled>
     gds:
         enabled: false
     gfd:

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -208,7 +208,20 @@ if [ "$gpu_nodes_found" = false ]; then
 fi
 
 echo "Applying NVIDIA GPU ClusterPolicy"
-oc apply -f "${GPU_INSTALL_DIR}/cluster-policy.yaml"
+if [ "${ENABLE_RDMA:-false}" = "true" ]; then
+  echo "RDMA enabled - applying kernel module params and enabling RDMA in ClusterPolicy"
+  oc apply -f "${GPU_INSTALL_DIR}/rdma-kernel-module-params.yaml"
+  sed -e 's/<rdma_enabled>/true/g' \
+      -e 's/<gdrcopy_enabled>/true/g' \
+      -e 's/<kernel_module_config>/kernel-module-params/g' \
+      "${GPU_INSTALL_DIR}/cluster-policy.yaml" | oc apply -f -
+else
+  echo "RDMA disabled (set ENABLE_RDMA=true to enable)"
+  sed -e 's/<rdma_enabled>/false/g' \
+      -e 's/<gdrcopy_enabled>/false/g' \
+      -e 's/<kernel_module_config>/""/g' \
+      "${GPU_INSTALL_DIR}/cluster-policy.yaml" | oc apply -f -
+fi
 wait_until_pod_ready_status "nvidia-device-plugin-daemonset" 600
 wait_until_pod_ready_status "nvidia-container-toolkit-daemonset"
 wait_until_pod_ready_status "nvidia-dcgm-exporter"

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/rdma-kernel-module-params.yaml
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/rdma-kernel-module-params.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: kernel-module-params
+    namespace: nvidia-gpu-operator
+data:
+    nvidia.conf: |-
+        NVreg_RegistryDwords="PeerMappingOverride=1;"
+        NVreg_EnableStreamMemOPs=1


### PR DESCRIPTION
Backports [PR #2920](https://github.com/red-hat-data-services/ods-ci/pull/2920) from master to release-3.3.

The cluster-policy.yaml on release-3.3 hardcodes rdma.enabled: true, gdrcopy.enabled: true, and a kernel-module-params ConfigMap. This causes the nvidia-driver-daemonset to fail loading the kernel module on OCP 4.21 with certain GPU instance types (e.g. p4d.24xlarge), as the RDMA/GDRCopy driver compilation is incompatible with the 4.21 kernel. The failure cascades to nvidia-device-plugin-daemonset and all downstream GPU pods.

This change makes RDMA opt-in via the ENABLE_RDMA environment variable (defaults to false), so standard GPU workloads work out of the box without requiring RDMA-capable hardware and drivers.