### PR TITLE
refactor(gpu): use Install And Import Package In JupyterLab

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
@@ -1,6 +1,7 @@
 *** Settings ***
 Documentation  Set of Keywords for GPU support
 Resource    ../../../OCP.resource
+Resource    JupyterLabLauncher.robot
 Library     OperatingSystem
 
 
@@ -19,8 +20,7 @@ Verify Pytorch Can See GPU
     [Documentation]    Verifies that PyTorch can see a GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
-        # TODO: use Install And Import Package In JupyterLab after #202 is merged
-        Run Cell And Check For Errors    !pip install torch numpy    timeout=300s
+        Install And Import Package In JupyterLab    torch    timeout=300s
     END
     Run Cell And Check Output
     ...    import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")
@@ -30,7 +30,7 @@ Verify Tensorflow Can See GPU
     [Documentation]    Verifies that Tensorflow can see a GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
-        Run Cell And Check For Errors    !pip install tensorflow    timeout=300s
+        Install And Import Package In JupyterLab    tensorflow    timeout=300s
     END
     # Need to wrap output in double quotes
     ${out} =    Run Cell And Get Output    import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; tf.config.list_physical_devices('GPU')  # robocop: disable

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/GPU.resource
@@ -20,7 +20,7 @@ Verify Pytorch Can See GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
         # TODO: use Install And Import Package In JupyterLab after #202 is merged
-        Run Cell And Check For Errors    !pip install torch==2.4.1 numpy==2.1.3    timeout=300s
+        Run Cell And Check For Errors    !pip install torch numpy    timeout=300s
     END
     Run Cell And Check Output
     ...    import torch; device = "cuda" if torch.cuda.is_available() else "cpu"; print(f"Using {device} device")
@@ -30,8 +30,7 @@ Verify Tensorflow Can See GPU
     [Documentation]    Verifies that Tensorflow can see a GPU
     [Arguments]    ${install}=False
     IF  ${install}==True
-        # This installs the latest .z stream available for 2.7 to avoid the protobuf bug
-        Run Cell And Check For Errors    !pip install tensorflow~=2.7    timeout=300s
+        Run Cell And Check For Errors    !pip install tensorflow    timeout=300s
     END
     # Need to wrap output in double quotes
     ${out} =    Run Cell And Get Output    import tensorflow as tf; import os; os.environ['TF_CPP_MIN_LOG_LEVEL'] = '3'; tf.config.list_physical_devices('GPU')  # robocop: disable

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -547,10 +547,11 @@ Check Versions In JupyterLab
 
 Install And Import Package In JupyterLab
     [Documentation]  Install any Package and import it
-    [Arguments]  ${package}
+    [Arguments]  ${package}    ${timeout}=120seconds
     Add And Run JupyterLab Code Cell In Active Notebook  !pip install ${package}
+    Wait Until JupyterLab Code Cell Is Not Active    ${timeout}
     Add And Run JupyterLab Code Cell In Active Notebook  import ${package}
-    Wait Until JupyterLab Code Cell Is Not Active
+    Wait Until JupyterLab Code Cell Is Not Active    ${timeout}
     JupyterLab Code Cell Error Output Should Not Be Visible
     Capture Page Screenshot
 


### PR DESCRIPTION
## Summary

Follow-up to #2953. Resolves the stale TODO in `GPU.resource` (ods-ci PR #202 merged in 2022).

- Replace direct `Run Cell And Check For Errors` pip installs with `Install And Import Package In JupyterLab`
- Extend that keyword with optional `${timeout}` and wait after pip install before running import

This branch also includes the pip pin removal from #2953 (2 commits). **Merge #2953 first**, then rebase this onto `master` so only the refactor commit remains — or merge both together.

## Test plan

- [ ] GPU minimal-cuda / pytorch / tensorflow install paths pass on RHOAI 3.5

Made with [Cursor](https://cursor.com)