### PR TITLE
Add modelCache configuration support to DSC setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,5 @@ robocop.log
 infrastructure_configuration.yaml
 log/
 text-generation-inference/
+.cursor/
+Agents.md

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -386,6 +386,10 @@ Verify RHODS Installation
   ${kserve} =    Is Component Enabled    kserve    ${DSC_NAME}
   IF    "${kserve}" == "true"
     Configure Gateway API
+    ${enable_model_cache} =    Is Model Cache Enabled
+    IF    ${enable_model_cache} and "${cluster_type}" == "managed"
+        Patch DSC With Model Cache Config
+    END
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=app=odh-model-controller    timeout=400s
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
@@ -855,6 +859,10 @@ Create DataScienceCluster CustomResource Using Test Variables
             IF    '${cmp}' == 'workbenches'
                 Run    sed -i'' -e 's/<workbenches_namespace>/${NOTEBOOKS_NAMESPACE}/' ${file_path}dsc_apply.yml
             END
+    END
+    ${enable_model_cache} =    Is Model Cache Enabled
+    IF    ${enable_model_cache}
+        Add Model Cache Config To DSC Yaml    ${file_path}dsc_apply.yml
     END
 
 
@@ -1538,6 +1546,50 @@ Configure Gateway API
     ...    bash tasks/Resources/Gateway/configure_gateway.sh
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for KServe
+
+Get Worker Node Names As JSON Array
+    [Documentation]    Dynamically fetch all worker node names and return them as a JSON array string
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | jq -R . | jq -sc .
+    Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
+    Should Not Be Empty    ${output}    msg=No worker nodes found in the cluster
+    Log To Console    Fetched worker node names: ${output}
+    RETURN    ${output}
+
+Add Model Cache Config To DSC Yaml
+    [Documentation]    Inject modelCache config into DSC YAML using yq before apply
+    [Arguments]    ${dsc_yaml_path}
+    ${rc}    ${node_names} =    Run And Return Rc And Output
+    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name"
+    Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
+    Should Not Be Empty    ${node_names}    msg=No worker nodes found in the cluster
+    Log To Console    Adding modelCache config with worker nodes: ${node_names}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    yq -i '.spec.components.kserve.modelCache.cacheSize = "20Gi" | .spec.components.kserve.modelCache.managementState = "Managed"' ${dsc_yaml_path}    #robocop:disable
+    Should Be Equal As Integers    ${rc}    0    msg=Failed to add modelCache config: ${output}
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    yq -i '.spec.components.kserve.modelCache.nodeNames = []' ${dsc_yaml_path}
+    Should Be Equal As Integers    ${rc}    0    msg=Failed to initialize nodeNames: ${output}
+    @{nodes} =    Split String    ${node_names}    \n
+    FOR    ${node}    IN    @{nodes}
+        ${node} =    Strip String    ${node}
+        IF    "${node}" != "${EMPTY}"
+            ${rc}    ${output} =    Run And Return Rc And Output
+            ...    yq -i '.spec.components.kserve.modelCache.nodeNames += ["${node}"]' ${dsc_yaml_path}
+            Should Be Equal As Integers    ${rc}    0    msg=Failed to add node ${node}: ${output}
+        END
+    END
+
+Patch DSC With Model Cache Config
+    [Documentation]    Patch the DataScienceCluster with modelCache config
+    ...    using dynamically fetched worker node names (used for managed clusters only)
+    [Arguments]    ${dsc_name}=${DSC_NAME}
+    ${node_names_json} =    Get Worker Node Names As JSON Array
+    Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json})
+    ${rc}    ${output} =    Run And Return Rc And Output
+    ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"20Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
+    Log To Console    ${output}
+    Should Be Equal As Integers    ${rc}    0    msg=Error patching DSC with modelCache config: ${output}
 
 Configure MaaS Gateway API
     [Documentation]    Configure Gateway API for MaaS traffic routing

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -387,7 +387,7 @@ Verify RHODS Installation
   IF    "${kserve}" == "true"
     Configure Gateway API
     ${enable_model_cache} =    Is Model Cache Enabled
-    IF    ${enable_model_cache} and "${cluster_type}" == "managed"
+    IF    ${enable_model_cache}
         Patch DSC With Model Cache Config
     END
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
@@ -859,10 +859,6 @@ Create DataScienceCluster CustomResource Using Test Variables
             IF    '${cmp}' == 'workbenches'
                 Run    sed -i'' -e 's/<workbenches_namespace>/${NOTEBOOKS_NAMESPACE}/' ${file_path}dsc_apply.yml
             END
-    END
-    ${enable_model_cache} =    Is Model Cache Enabled
-    IF    ${enable_model_cache}
-        Add Model Cache Config To DSC Yaml    ${file_path}dsc_apply.yml
     END
 
 
@@ -1547,50 +1543,14 @@ Configure Gateway API
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for KServe
 
-Get Worker Node Names As JSON Array
-    [Documentation]    Dynamically fetch all worker node names as a JSON array string
+Patch DSC With Model Cache Config
+    [Documentation]    Patch the DataScienceCluster with modelCache config using dynamically fetched worker node names
+    [Arguments]    ${dsc_name}=${DSC_NAME}
     ${cmd} =    Set Variable
     ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | jq -R . | jq -sc .    #robocop:disable
-    ${rc}    ${output} =    Run And Return Rc And Output    ${cmd}
+    ${rc}    ${node_names_json} =    Run And Return Rc And Output    ${cmd}
     Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
-    Should Not Be Empty    ${output}    msg=No worker nodes found in the cluster
-    Log To Console    Fetched worker node names: ${output}
-    RETURN    ${output}
-
-Add Model Cache Config To DSC Yaml
-    [Documentation]    Inject modelCache config into DSC YAML using yq before apply
-    [Arguments]    ${dsc_yaml_path}
-    ${rc}    ${node_names} =    Run And Return Rc And Output
-    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name"
-    Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
-    Should Not Be Empty    ${node_names}    msg=No worker nodes found in the cluster
-    Log To Console    Adding modelCache config with worker nodes: ${node_names}
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    yq -i '.spec.components.kserve.modelCache.cacheSize = "20Gi" | .spec.components.kserve.modelCache.managementState = "Managed"' ${dsc_yaml_path}    #robocop:disable
-    Should Be Equal As Integers    ${rc}    0    msg=Failed to add modelCache config: ${output}
-    Add Node Names To Model Cache Yaml    ${dsc_yaml_path}    ${node_names}
-
-Add Node Names To Model Cache Yaml
-    [Documentation]    Add worker node names to modelCache.nodeNames in DSC YAML
-    [Arguments]    ${dsc_yaml_path}    ${node_names}
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    yq -i '.spec.components.kserve.modelCache.nodeNames = []' ${dsc_yaml_path}
-    Should Be Equal As Integers    ${rc}    0    msg=Failed to initialize nodeNames: ${output}
-    @{nodes} =    Split String    ${node_names}    \n
-    FOR    ${node}    IN    @{nodes}
-        ${node} =    Strip String    ${node}
-        IF    "${node}" != "${EMPTY}"
-            ${rc}    ${output} =    Run And Return Rc And Output
-            ...    yq -i '.spec.components.kserve.modelCache.nodeNames += ["${node}"]' ${dsc_yaml_path}
-            Should Be Equal As Integers    ${rc}    0    msg=Failed to add node ${node}: ${output}
-        END
-    END
-
-Patch DSC With Model Cache Config
-    [Documentation]    Patch the DataScienceCluster with modelCache config
-    ...    using dynamically fetched worker node names (used for managed clusters only)
-    [Arguments]    ${dsc_name}=${DSC_NAME}
-    ${node_names_json} =    Get Worker Node Names As JSON Array
+    Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster
     Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json})
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"20Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1545,7 +1545,7 @@ Patch DSC With Model Cache Config
     [Documentation]    Patch the DataScienceCluster with modelCache config using dynamically fetched worker node names
     [Arguments]    ${dsc_name}=${DSC_NAME}
     ${cmd} =    Set Variable
-    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | jq -R . | jq -sc .    #robocop:disable
+    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | head -2 | jq -R . | jq -sc .    #robocop:disable
     ${rc}    ${node_names_json} =    Run And Return Rc And Output    ${cmd}
     Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
     Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1548,9 +1548,10 @@ Configure Gateway API
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for KServe
 
 Get Worker Node Names As JSON Array
-    [Documentation]    Dynamically fetch all worker node names and return them as a JSON array string
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | jq -R . | jq -sc .
+    [Documentation]    Dynamically fetch all worker node names as a JSON array string
+    ${cmd} =    Set Variable
+    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | jq -R . | jq -sc .    #robocop:disable
+    ${rc}    ${output} =    Run And Return Rc And Output    ${cmd}
     Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
     Should Not Be Empty    ${output}    msg=No worker nodes found in the cluster
     Log To Console    Fetched worker node names: ${output}
@@ -1567,6 +1568,11 @@ Add Model Cache Config To DSC Yaml
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    yq -i '.spec.components.kserve.modelCache.cacheSize = "20Gi" | .spec.components.kserve.modelCache.managementState = "Managed"' ${dsc_yaml_path}    #robocop:disable
     Should Be Equal As Integers    ${rc}    0    msg=Failed to add modelCache config: ${output}
+    Add Node Names To Model Cache Yaml    ${dsc_yaml_path}    ${node_names}
+
+Add Node Names To Model Cache Yaml
+    [Documentation]    Add worker node names to modelCache.nodeNames in DSC YAML
+    [Arguments]    ${dsc_yaml_path}    ${node_names}
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    yq -i '.spec.components.kserve.modelCache.nodeNames = []' ${dsc_yaml_path}
     Should Be Equal As Integers    ${rc}    0    msg=Failed to initialize nodeNames: ${output}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -387,9 +387,7 @@ Verify RHODS Installation
   IF    "${kserve}" == "true"
     Configure Gateway API
     ${enable_model_cache} =    Is Model Cache Enabled
-    IF    ${enable_model_cache}
-        Patch DSC With Model Cache Config
-    END
+    IF    ${enable_model_cache}    Patch DSC With Model Cache Config
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=app=odh-model-controller    timeout=400s
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
@@ -1551,9 +1549,10 @@ Patch DSC With Model Cache Config
     ${rc}    ${node_names_json} =    Run And Return Rc And Output    ${cmd}
     Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
     Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster
+    Should Not Be Equal    ${node_names_json}    []    msg=No worker nodes found in the cluster
     Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json})
     ${rc}    ${output} =    Run And Return Rc And Output
-    ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"20Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
+    ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"10Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error patching DSC with modelCache config: ${output}
 

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1541,14 +1541,14 @@ Configure Gateway API
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for KServe
 
-Patch DSC With Model Cache Config
+Patch DSC With Model Cache Config    #robocop:disable=TooManyKeywords
     [Documentation]    Patch the DataScienceCluster with modelCache config.
     ...    Uses MODEL_CACHE_NODE_COUNT (default 2) to decide how many worker nodes to include.
     ...    If 0, sets managementState to Removed. If >= 1, sets Managed with that many nodes.
     [Arguments]    ${dsc_name}=${DSC_NAME}
-    ${node_count}=    Get Variable Value    ${MODEL_CACHE_NODE_COUNT}    2
-    ${node_count}=    Convert To Integer    ${node_count}
-    IF    ${node_count} == 0
+    ${node_count} =    Get Variable Value    ${MODEL_CACHE_NODE_COUNT}    2
+    ${node_count} =    Convert To Integer    ${node_count}
+    IF    ${node_count} == ${0}
         Log To Console    MODEL_CACHE_NODE_COUNT is 0, setting modelCache managementState to Removed
         ${rc}    ${output} =    Run And Return Rc And Output
         ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"managementState":"Removed"}}}}}'    #robocop:disable
@@ -1559,7 +1559,7 @@ Patch DSC With Model Cache Config
         Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
         Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster
         Should Not Be Equal    ${node_names_json}    []    msg=No worker nodes found in the cluster
-        Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json}, count: ${node_count})
+        Log To Console    Patching DSC with modelCache (nodes: ${node_names_json}, count: ${node_count})
         ${rc}    ${output} =    Run And Return Rc And Output
         ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"10Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
     END

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1542,17 +1542,27 @@ Configure Gateway API
     Should Be Equal As Integers    ${rc}    0    msg=Error configuring Gateway for KServe
 
 Patch DSC With Model Cache Config
-    [Documentation]    Patch the DataScienceCluster with modelCache config using dynamically fetched worker node names
+    [Documentation]    Patch the DataScienceCluster with modelCache config.
+    ...    Uses MODEL_CACHE_NODE_COUNT (default 2) to decide how many worker nodes to include.
+    ...    If 0, sets managementState to Removed. If >= 1, sets Managed with that many nodes.
     [Arguments]    ${dsc_name}=${DSC_NAME}
-    ${cmd} =    Set Variable
-    ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | head -2 | jq -R . | jq -sc .    #robocop:disable
-    ${rc}    ${node_names_json} =    Run And Return Rc And Output    ${cmd}
-    Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
-    Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster
-    Should Not Be Equal    ${node_names_json}    []    msg=No worker nodes found in the cluster
-    Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json})
-    ${rc}    ${output} =    Run And Return Rc And Output
-    ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"10Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
+    ${node_count}=    Get Variable Value    ${MODEL_CACHE_NODE_COUNT}    2
+    ${node_count}=    Convert To Integer    ${node_count}
+    IF    ${node_count} == 0
+        Log To Console    MODEL_CACHE_NODE_COUNT is 0, setting modelCache managementState to Removed
+        ${rc}    ${output} =    Run And Return Rc And Output
+        ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"managementState":"Removed"}}}}}'    #robocop:disable
+    ELSE
+        ${cmd} =    Set Variable
+        ...    oc get nodes -l node-role.kubernetes.io/worker= --no-headers -o custom-columns=":metadata.name" | head -${node_count} | jq -R . | jq -sc .    #robocop:disable
+        ${rc}    ${node_names_json} =    Run And Return Rc And Output    ${cmd}
+        Should Be Equal As Integers    ${rc}    0    msg=Failed to fetch worker node names
+        Should Not Be Empty    ${node_names_json}    msg=No worker nodes found in the cluster
+        Should Not Be Equal    ${node_names_json}    []    msg=No worker nodes found in the cluster
+        Log To Console    Patching DSC ${dsc_name} with modelCache config (nodes: ${node_names_json}, count: ${node_count})
+        ${rc}    ${output} =    Run And Return Rc And Output
+        ...    oc patch DataScienceCluster/${dsc_name} --type merge -p '{"spec":{"components":{"kserve":{"modelCache":{"cacheSize":"10Gi","managementState":"Managed","nodeNames":${node_names_json}}}}}}'    #robocop:disable
+    END
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error patching DSC with modelCache config: ${output}
 

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -614,3 +614,11 @@ Skip If New Observability Stack Is Disabled
     [Documentation]    Skips test if new observability stack is disabled
     ${enabled}=    Is New Observability Stack Enabled
     Skip If    condition=${enabled}==False    msg=This test is skipped because new observability stack is disabled
+
+Is Model Cache Enabled
+    [Documentation]    Checks whether model cache is enabled, controlled by ENABLE_MODEL_CACHE test variable.
+    ...    Returns ${TRUE} if enabled (True|true|"True"|"true")
+    ...    Returns ${FALSE} otherwise, i.e. the variable is not defined or has a false value
+    ${enable_model_cache}=    Get Variable Value    ${ENABLE_MODEL_CACHE}    false
+    ${enable_model_cache}=    Convert To Boolean    ${enable_model_cache}
+    RETURN    ${enable_model_cache}


### PR DESCRIPTION
Configure modelCache in the kserve component of DataScienceCluster during RHOAI installation. Worker node names are dynamically fetched at runtime. The feature is controlled by ENABLE_MODEL_CACHE variable.

- Self-managed: inject modelCache via yq before oc apply
- Managed: patch DSC after operator creates it
- Add Is Model Cache Enabled keyword in Common.robot