### PR TITLE
Backport upgrade fixes from PR #2900 to release-3.4. Do not merge 

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -517,15 +517,85 @@ Install RHODS In Self Managed Cluster Using CLI
   Should Be Equal As Integers   ${return_code}   0   msg=Error detected while installing RHODS
 
 Upgrade RHODS In Self Managed Cluster Using CLI
-  [Documentation]   Upgrade RHODS on self managed cluster using CLI by applying new catalog source
+  [Documentation]   Upgrade RHODS on self managed cluster using CLI by updating catalog source and subscription.
+  ...              Uses OPERATOR_NAME as the subscription name since setup.sh creates the subscription
+  ...              with that name (not OPERATOR_SUBSCRIPTION_NAME which differs for Cli installs).
+  ...              When a catalog source image is provided, creates/updates the catalog and points
+  ...              the subscription to it. Approves any intermediate install plans before the target.
   [Arguments]     ${image_url}     ${rhoai_version}
   Log    Starting RHODS upgrade with image: ${image_url}    console=yes
   Log    Update channel: ${UPDATE_CHANNEL}    console=yes
+  Log    Using subscription name: ${OPERATOR_NAME} (from setup.sh -n flag)    console=yes
+  Set Subscription Install Plan Approval    ${OPERATOR_NAMESPACE}    Manual    ${OPERATOR_NAME}
+  Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${OPERATOR_NAME}
+  IF    "${image_url}" != "${EMPTY}"
+      Set Catalog Source Image    ${image_url}    cs_name=${CATALOG_SOURCE}
+      Update Subscription Source    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${CATALOG_SOURCE}
+  END
+  Approve Intermediate Installplans    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${rhoai_version}
+  Wait For Target CSV    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${rhoai_version}
 
-  Set Subscription Install Plan Approval    ${OPERATOR_NAMESPACE}    Manual    ${OPERATOR_SUBSCRIPTION_NAME}
-  Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${OPERATOR_SUBSCRIPTION_NAME}
-  Set Catalog Source Image    ${image_url}    cs_name=${CATALOG_SOURCE}
-  Wait For Installplan And Approve It    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${OPERATOR_SUBSCRIPTION_NAME}    ${rhoai_version}    #robocop:disable
+Update Subscription Source
+  [Documentation]   Updates the source catalog of a subscription.
+  [Arguments]    ${namespace}    ${sub_name}    ${catalog_source}
+  Log    Updating subscription source to ${catalog_source}    console=yes
+  ${rc} =    Run And Return Rc
+  ...    oc patch subscription ${sub_name} -n ${namespace} --type merge --patch '{"spec": {"source": "${catalog_source}"}}'    #robocop:disable
+  IF    ${rc} != 0
+      Log    Failed to update subscription source, continuing    console=yes    level=WARN
+  END
+
+Approve Intermediate Installplans
+  [Documentation]   Approves pending install plans until the target version's plan appears.
+  ...              OLM may require intermediate upgrades (e.g. 2.25.0 -> 2.25.2 -> 2.25.3).
+  [Arguments]    ${namespace}    ${sub_name}    ${target_version}
+  ${target_csv} =    Set Variable    ${sub_name}.${target_version}
+  Log    Waiting for target CSV ${target_csv}, approving intermediate install plans    console=yes
+  FOR    ${_}    IN RANGE    20
+      ${ip_csv}    ${ip_name}    ${ip_approved} =    Get Current Installplan Info
+      ...    ${namespace}    ${sub_name}
+      IF    "${ip_name}" == ""
+          Sleep    30s
+          CONTINUE
+      END
+      Log    Install plan ${ip_name}: csv=${ip_csv}, approved=${ip_approved}    console=yes
+      IF    "${ip_approved}" == "false"
+          Log    Approving install plan ${ip_name} for ${ip_csv}    console=yes
+          Run And Return Rc
+          ...    oc patch installplan ${ip_name} -n ${namespace} -p '{"spec":{"approved": true}}' --type=merge    #robocop:disable
+      END
+      IF    "${ip_csv}" == "${target_csv}"
+          Log    Target install plan found and approved: ${ip_name}    console=yes
+          BREAK
+      END
+      Sleep    30s
+  END
+
+Get Current Installplan Info
+  [Documentation]   Returns the CSV name, installplan name, and approval status for the current installplan.
+  [Arguments]    ${namespace}    ${sub_name}
+  ${rc}    ${ip_name} =    Run And Return Rc And Output
+  ...    oc get subscription ${sub_name} -n ${namespace} -o jsonpath='{.status.installplan.name}'
+  IF    ${rc} != 0 or "${ip_name}" == "" or "${ip_name}" == "null"
+      RETURN    ${EMPTY}    ${EMPTY}    ${EMPTY}
+  END
+  ${rc}    ${ip_csv} =    Run And Return Rc And Output
+  ...    oc get installplan ${ip_name} -n ${namespace} -o jsonpath='{.spec.clusterServiceVersionNames[0]}'
+  ${rc}    ${ip_approved} =    Run And Return Rc And Output
+  ...    oc get installplan ${ip_name} -n ${namespace} -o jsonpath='{.spec.approved}'
+  RETURN    ${ip_csv}    ${ip_name}    ${ip_approved}
+
+Wait For Target CSV
+  [Documentation]   Waits for the target CSV to reach Succeeded state.
+  [Arguments]    ${namespace}    ${operator_name}    ${target_version}
+  ${target_csv} =    Set Variable    ${operator_name}.${target_version}
+  Log    Waiting for target CSV ${target_csv} to succeed    console=yes
+  ${rc} =    Run And Return Rc
+  ...    oc wait --timeout=600s --for jsonpath='{.status.phase}'=Succeeded csv -n ${namespace} ${target_csv}
+  IF    ${rc} != 0
+      FAIL    Target CSV ${target_csv} did not reach Succeeded state
+  END
+  Log    Upgrade to ${target_csv} completed successfully    console=yes
 
 Install RHODS In Managed Cluster Using CLI
   [Documentation]   Install rhods on managed managed cluster using cli

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -486,37 +486,38 @@ Set Subscription Update Channel
     END
 
 Set Catalog Source Image
-    [Documentation]    Updates the image endpoint of a catalog source.
+    [Documentation]    Creates or updates a catalog source with the given image.
+    ...                If the catalog source doesn't exist, it is created. If it exists, the image is patched.
     ...                Example: Set Catalog Source Image    quay.io/rhoai/rhoai-fbc-fragment:latest    openshift-marketplace    rhoai-catalog-dev
     [Arguments]    ${new_image_url}    ${namespace}=openshift-marketplace    ${cs_name}=rhoai-catalog-dev
     Log    Setting catalog source image to ${new_image_url} in namespace ${namespace}    console=yes
-    ${old_image}=    Get Resource Attribute    ${namespace}    CatalogSource    ${cs_name}    .spec.image
-    Log    Current catalog source image: ${old_image}    console=yes
-    Log    Patching catalog source ${cs_name} in namespace ${namespace} to set image=${new_image_url}    console=yes
-    ${patch_status}=    Run And Return Rc
-    ...    oc patch catalogsource ${cs_name} -n ${namespace} --type merge --patch '{"spec": {"image": "${new_image_url}"}}'
-    IF    ${patch_status} == 0
-        Log    Successfully updated catalog source image for ${cs_name}    console=yes
-        ${current_image}=    Get Resource Attribute    ${namespace}    CatalogSource    ${cs_name}    .spec.image
-        Log    Verified: Current catalog source image is ${current_image}    console=yes
-        Should Be Equal As Strings    ${current_image}    ${new_image_url}    msg=Catalog source image verification failed
-        Log    Waiting for catalog source pod to restart and become ready    console=yes
-        ${rc}=    Run And Return Rc
-        ...    oc wait pod -n ${namespace} -l olm.catalogSource=${cs_name} --for=delete --timeout=120s
-        IF    ${rc} == 0
-            Log    Old catalog source pod deleted    console=yes
-        ELSE
-            Log    Old catalog source pod may already be deleted or timeout reached    console=yes    level=WARN
-        END
-        ${rc}=    Run And Return Rc
-        ...    oc wait pod -n ${namespace} -l olm.catalogSource=${cs_name} --for=condition=Ready --timeout=300s
-        IF    ${rc} == 0
-            Log    New catalog source pod is ready    console=yes
-        ELSE
-            Log    Catalog source pod did not become ready within timeout, but continuing    console=yes    level=WARN
+    ${exists_rc}=    Run And Return Rc    oc get catalogsource ${cs_name} -n ${namespace}
+    IF    ${exists_rc} != 0
+        Log    Catalog source ${cs_name} does not exist, creating it    console=yes
+        ${apply_rc}    ${apply_out}=    Run And Return Rc And Output
+        ...    oc apply -f - <<< '{"apiVersion":"operators.coreos.com/v1alpha1","kind":"CatalogSource","metadata":{"name":"${cs_name}","namespace":"${namespace}"},"spec":{"displayName":"RHOAI Catalog Dev","image":"${new_image_url}","publisher":"Red Hat","sourceType":"grpc","updateStrategy":{"registryPoll":{"interval":"15m"}}}}'    #robocop:disable
+        Log    ${apply_out}    console=yes
+        IF    ${apply_rc} != 0
+            FAIL    Failed to create catalog source ${cs_name}: ${apply_out}
         END
     ELSE
-        FAIL    Failed to update catalog source image for ${cs_name} in namespace ${namespace}
+        Log    Catalog source ${cs_name} exists, updating image    console=yes
+        ${patch_status}=    Run And Return Rc
+        ...    oc patch catalogsource ${cs_name} -n ${namespace} --type merge --patch '{"spec": {"image": "${new_image_url}"}}'
+        IF    ${patch_status} != 0
+            FAIL    Failed to update catalog source image for ${cs_name} in namespace ${namespace}
+        END
+    END
+    ${current_image}=    Get Resource Attribute    ${namespace}    CatalogSource    ${cs_name}    .spec.image
+    Log    Verified: Current catalog source image is ${current_image}    console=yes
+    Should Be Equal As Strings    ${current_image}    ${new_image_url}    msg=Catalog source image verification failed
+    Log    Waiting for catalog source pod to become ready    console=yes
+    ${rc}=    Run And Return Rc
+    ...    oc wait pod -n ${namespace} -l olm.catalogSource=${cs_name} --for=condition=Ready --timeout=300s
+    IF    ${rc} == 0
+        Log    Catalog source pod is ready    console=yes
+    ELSE
+        Log    Catalog source pod did not become ready within timeout, but continuing    console=yes    level=WARN
     END
 
 Wait For Namespace To Be Active

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
@@ -14,6 +14,7 @@ Library             JupyterLibrary
 Test Tags           DuringUpgrade
 
 *** Variables ***
+${UPGRADE_TO_IIB}=    ${EMPTY}
 ${UPGRADE_ODS_BUILD_URL}=    ${EMPTY}
 
 
@@ -24,7 +25,9 @@ Upgrade RHODS
     ${initial_version} =    Get RHODS Version
     ${initial_creation_date} =      Get Operator Pod Creation Date
     Set Suite Variable    ${UPDATE_CHANNEL}    ${UPGRADE_TO_UPDATE_CHANNEL}
-    Install RHODS   ${CLUSTER_TYPE}    ${UPGRADE_ODS_BUILD_URL}    Manual    ${UPGRADE_TO_VERSION}    True
+    ${upgrade_image} =    Set Variable If    "${UPGRADE_ODS_BUILD_URL}" != "${EMPTY}"
+    ...    ${UPGRADE_ODS_BUILD_URL}    ${UPGRADE_TO_IIB}
+    Install RHODS   ${CLUSTER_TYPE}    ${upgrade_image}    Manual    ${UPGRADE_TO_VERSION}    True
     RHODS Version Should Be Greater Than        ${initial_version}
     Operator Pod Creation Date Should Be Updated        ${initial_creation_date}
     OpenShiftLibrary.Wait For Pods Status       namespace=${OPERATOR_NAMESPACE}     timeout=300

--- a/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
+++ b/ods_ci/utils/scripts/testconfig/generateTestConfigFile.py
@@ -306,6 +306,8 @@ def generate_test_config_file(
         data["UPGRADE_TO_VERSION"] = config_data["UPGRADE_TO_VERSION"]
     if config_data.get("UPGRADE_ODS_BUILD_URL"):
         data["UPGRADE_ODS_BUILD_URL"] = config_data["UPGRADE_ODS_BUILD_URL"]
+    if config_data.get("UPGRADE_TO_IIB"):
+        data["UPGRADE_TO_IIB"] = config_data["UPGRADE_TO_IIB"]
     data["RHODS_OSD_INSTALL_REPO"] = config_data["RHODS_OSD_INSTALL_REPO"]
     data["ENABLE_NEW_OBSERVABILITY_STACK"] = config_data["ENABLE_NEW_OBSERVABILITY_STACK"]
     if config_data.get("NGC_API_KEY"):


### PR DESCRIPTION
## Summary

Backport of upgrade-flow fixes from master (PR #2900 / #2884) to `release-3.4`, matching the same changes already applied on `release-3.3` in commit `73c4fb5e`.

Fixes CLI and OperatorHub upgrade paths that caused CSV wait failures during RHOAI upgrade Jenkins jobs (e.g. `rhoai/3.4/selfmanaged/.../rhoai-upgrade`).

## Problem

Three bugs in the upgrade flow caused failures during during-upgrade test runs:

1. **CLI upgrade used wrong subscription name** — `Upgrade RHODS In Self Managed Cluster Using CLI` patched `${OPERATOR_SUBSCRIPTION_NAME}` (e.g. `rhoai-operator-dev`) instead of `${OPERATOR_NAME}` (e.g. `rhods-operator`), which is what `setup.sh -n` creates on CLI installs.
2. **Catalog source patch-only logic** — `Set Catalog Source Image` failed when the catalog did not already exist.
3. **Missing intermediate install plan handling** — multi-step OLM upgrades (e.g. z-stream hops) were not approved correctly before waiting for the target CSV.

Additionally, older Jenkins configs passing `UPGRADE_TO_IIB` instead of `UPGRADE_ODS_BUILD_URL` had no fallback.

## Changes

| File | Change |
|---|---|
| `oc_install.robot` | Rewrite `Upgrade RHODS In Self Managed Cluster Using CLI` to use `${OPERATOR_NAME}`; add `Update Subscription Source`, `Approve Intermediate Installplans`, `Get Current Installplan Info`, and `Wait For Target CSV` |
| `OCP.resource` | `Set Catalog Source Image` — create catalog if missing, patch if exists |
| `0202__during_upgrade.robot` | Add `${UPGRADE_TO_IIB}` with fallback: prefer `UPGRADE_ODS_BUILD_URL`, else `UPGRADE_TO_IIB` |
| `generateTestConfigFile.py` | Pass through `UPGRADE_TO_IIB` into test-variables |

## Reference

- Original fix: PR #2900 (from #2884 on master)
- 3.3 backport: `73c4fb5e` on `release-3.3`
- 3.4 backport: `426da777` on `backport-upgrade-fix-3.4`

## Test plan

- [ ] Re-run `rhoai/3.4/selfmanaged/cli/aws/rhoai-upgrade` during-upgrade stage (3.4.0 → 3.4.1)
- [ ] Confirm upgrade log shows: `Using subscription name: rhods-operator (from setup.sh -n flag)`
- [ ] Confirm subscription channel/catalog updates succeed (no `Failed to set installPlanApproval for subscription rhoai-operator-dev`)
- [ ] Confirm target CSV reaches `Succeeded` and during-upgrade RF tests proceed past `Upgrade RHODS`
- [ ] (Optional) Validate OperatorHub upgrade path still uses `Set Subscription Update Channel`

---

