### PR TITLE
Backport GPU operator channel fix from release-2.25/3.3 to release-3.4 [DNM]

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -7,12 +7,30 @@ GPU_INSTALL_DIR="$(dirname "$0")"
 
 CHANNEL="$(oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.defaultChannel}')"
 
-CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r ".status.channels[] | select(.name == \"$CHANNEL\") | .currentCSV")"
+if [[ -z "${CHANNEL}" ]]; then
+  echo "ERROR: Could not determine defaultChannel from gpu-operator-certified packagemanifest." >&2
+  echo "Falling back to 'stable' channel." >&2
+  CHANNEL="stable"
+fi
+echo "Using GPU Operator channel: $CHANNEL"
 
-# For mac OS
-# sed -i'' -e "s|channel: \".*\"|channel: \"$CHANNEL\"|" "$GPU_INSTALL_DIR/gpu_install.yaml"
-# Since CI uses Linux machines use the below command
-sed -i -e "s|channel:.*|channel: \"$CHANNEL\"|" "$GPU_INSTALL_DIR/gpu_install.yaml"
+CSVNAME="$(oc get packagemanifests/gpu-operator-certified -n openshift-marketplace -o json | jq -r ".status.channels[] | select(.name == \"${CHANNEL}\") | .currentCSV")"
+
+if [[ -z "${CSVNAME}" ]]; then
+  echo "ERROR: Could not determine CSV name for channel '$CHANNEL'." >&2
+  echo "Available channels:" >&2
+  oc get packagemanifest gpu-operator-certified -n openshift-marketplace -o jsonpath='{.status.channels[*].name}' >&2
+  echo "" >&2
+  exit 1
+fi
+echo "Using GPU Operator CSV: $CSVNAME"
+
+sed -i'' -E "s|^([[:space:]]*)channel:.*|\1channel: \"${CHANNEL}\"|" "$GPU_INSTALL_DIR/gpu_install.yaml"
+
+if grep -qE '^[[:space:]]*channel:[[:space:]]*"?PLACEHOLDER"?' "$GPU_INSTALL_DIR/gpu_install.yaml"; then
+  echo "ERROR: GPU Operator subscription channel was not substituted (still PLACEHOLDER). Check gpu_install.yaml and sed." >&2
+  exit 1
+fi
 
 oc apply -f "$GPU_INSTALL_DIR/gpu_install.yaml"
 /bin/bash tasks/Resources/Provisioning/GPU/NFD/install_nfd.sh


### PR DESCRIPTION
## Summary

Backport GPU operator installation fix from `release-2.25` (#2929 / `af9ba142`) and `release-3.3` (#2948 / `f6bfbbf2`) to `release-3.4`.

Fixes `gpu_deploy.sh` so the GPU Operator subscription channel is correctly substituted when `gpu_install.yaml` uses unquoted `channel: PLACEHOLDER`.

## Changes

- **`gpu_deploy.sh`**: Fix sed to match any channel value (quoted or unquoted)
- Add fallback to `stable` if `defaultChannel` lookup returns empty
- Add CSV name validation with available channels on failure
- Add post-sed verification to catch `PLACEHOLDER` left behind
- Add logging for channel and CSV selection

## Not included (already on release-3.4)

- **NFD OCP 4.21 image** in `install_nfd.sh` — already present on `release-3.4`
- **RDMA ClusterPolicy logic** — kept as-is on 3.4

## Reference

| Branch | Commit / PR | Author |
|--------|-------------|--------|
| release-2.25 | `af9ba142` / #2929 | Sanket Jagtap |
| release-3.3 | `f6bfbbf2` / #2948 | Backport of 2.25 fixes |

## Test plan

- [ ] Run GPU provisioning job on OCP 4.21+ cluster
- [ ] Confirm `Using GPU Operator channel:` and `Using GPU Operator CSV:` in console
- [ ] Confirm subscription is not created with `PLACEHOLDER` channel
- [ ] Confirm GPU operator pods reach Ready state