### PR TITLE
RHOAIENG-69393: Increase cleanup timeout from 10 to 30 minutes

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot
@@ -47,7 +47,7 @@ Uninstall RHODS In OSD
   Clone OLM Install Repo
   ${return_code}    Run and Watch Command
   ...    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t addon -a "authorino serverless servicemesh clusterobservability tempo opentelemetry kueue certmanager cma"
-  ...    timeout=10 min
+  ...    timeout=30 min
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing ODH/RHOAI
 
 Uninstall RHODS In Self Managed Cluster
@@ -69,7 +69,7 @@ Uninstall RHODS In Self Managed Cluster Using CLI
   Clone OLM Install Repo
   ${return_code}    Run and Watch Command
   ...    cd ${EXECDIR}/${OLM_DIR} && ./cleanup.sh -t operator -a "authorino serverless servicemesh clusterobservability tempo opentelemetry kueue certmanager cma"
-  ...    timeout=10 min
+  ...    timeout=30 min
   Should Be Equal As Integers  ${return_code}   0   msg=Error detected while un-installing ODH/RHOAI
 
 Uninstall RHODS In Self Managed Cluster For Operatorhub


### PR DESCRIPTION
## Summary
- Backport cleanup timeout increase from master (`aca681ec`) to `release-2.25`
- Changes `timeout=10 min` to `timeout=30 min` in both `Uninstall RHODS In OSD` and `Uninstall RHODS In Self Managed Cluster Using CLI` keywords
- File: `ods_ci/tasks/Resources/RHODS_OLM/uninstall/uninstall.robot`

## Problem
The `cleanup.sh` script processes 9 operators and needs more than 10 minutes to complete. The Robot Framework `Run and Watch Command` keyword times out and kills the process mid-cleanup, resulting in:
- Tier1 jobs failing with zero tests executed
- Orphaned CRs with uncleared finalizers left on the cluster
- Subsequent job runs failing on the same cluster until manual cleanup

**Evidence:** RHOAI 2.25 tier1 builds [#66](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/rhoai/job/2.25/job/selfmanaged/job/cli/job/aws/job/rhoai-tier1/66/) and [#67](https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/rhoai/job/2.25/job/selfmanaged/job/cli/job/aws/job/rhoai-tier1/67/) both failed with this issue.

## Jira
[RHOAIENG-69393](https://redhat.atlassian.net/browse/RHOAIENG-69393)

## Test plan
- [x] Robocop linter passes with no new findings
- [ ] Verify next tier1 run on 2.25 completes the cleanup phase successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)