### PR TITLE
Add support for starting CSV in operator install keyword and fix RHCL version to 1.3.4

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -67,7 +67,7 @@ ${CERT_MANAGER_NS}=  cert-manager-operator
 ${CONNECTIVITY_LINK_OP_NAME}=  rhcl-operator
 ${CONNECTIVITY_LINK_SUB_NAME}=  rhcl-operator
 ${CONNECTIVITY_LINK_CHANNEL_NAME}=  stable
-${CONNECTIVITY_LINK_STARTING_CSV}=  1.3.4
+${CONNECTIVITY_LINK_STARTING_CSV}=  ${CONNECTIVITY_LINK_OP_NAME}.v1.3.4
 ${CONNECTIVITY_LINK_NS}=  kuadrant-system
 ${AUTHORINO_CSV_NAME}=  Authorino Operator
 ${RHODS_CSV_DISPLAY}=    Red Hat OpenShift AI
@@ -1060,6 +1060,7 @@ Install Connectivity Link Operator Via Cli
              ...    operator_group_ns=${CONNECTIVITY_LINK_NS}
              ...    operator_group_target_ns=${NONE}
              ...    starting_csv=${CONNECTIVITY_LINK_STARTING_CSV}
+             ...    approval=Manual
         Wait Until Operator Subscription Last Condition Is
              ...    type=CatalogSourcesUnhealthy    status=False
              ...    reason=AllCatalogSourcesHealthy    subscription_name=${CONNECTIVITY_LINK_SUB_NAME}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -67,6 +67,7 @@ ${CERT_MANAGER_NS}=  cert-manager-operator
 ${CONNECTIVITY_LINK_OP_NAME}=  rhcl-operator
 ${CONNECTIVITY_LINK_SUB_NAME}=  rhcl-operator
 ${CONNECTIVITY_LINK_CHANNEL_NAME}=  stable
+${CONNECTIVITY_LINK_STARTING_CSV}=  1.3.4
 ${CONNECTIVITY_LINK_NS}=  kuadrant-system
 ${AUTHORINO_CSV_NAME}=  Authorino Operator
 ${RHODS_CSV_DISPLAY}=    Red Hat OpenShift AI
@@ -1058,6 +1059,7 @@ Install Connectivity Link Operator Via Cli
              ...    operator_group_name=${CONNECTIVITY_LINK_OP_NAME}
              ...    operator_group_ns=${CONNECTIVITY_LINK_NS}
              ...    operator_group_target_ns=${NONE}
+             ...    starting_csv=${CONNECTIVITY_LINK_STARTING_CSV}
         Wait Until Operator Subscription Last Condition Is
              ...    type=CatalogSourcesUnhealthy    status=False
              ...    reason=AllCatalogSourcesHealthy    subscription_name=${CONNECTIVITY_LINK_SUB_NAME}

--- a/ods_ci/tests/Resources/Files/isv-operator-subscription.yaml
+++ b/ods_ci/tests/Resources/Files/isv-operator-subscription.yaml
@@ -9,3 +9,4 @@ spec:
   name: <OPERATOR_NAME>
   source: <CATALOG_SOURCE>
   sourceNamespace: <CS_NAMESPACE>
+  startingCSV: <STARTING_CSV>

--- a/ods_ci/tests/Resources/Files/isv-operator-subscription.yaml
+++ b/ods_ci/tests/Resources/Files/isv-operator-subscription.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: <OPERATOR_NAMESPACE>
 spec:
   channel: <UPDATE_CHANNEL>
-  installPlanApproval: Automatic
+  installPlanApproval: <INSTALL_PLAN_APPROVAL>
   name: <OPERATOR_NAME>
   source: <CATALOG_SOURCE>
   sourceNamespace: <CS_NAMESPACE>

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -387,8 +387,8 @@ Wait For Installplan And Approve It
     Wait Until Keyword Succeeds    10m    5s    Search Install Plan    ${csv}    ${subscription_name}    ${namespace}
     ${installplan_name}=    Run   oc get subscription ${subscription_name} -n ${namespace} -o json | jq '.status.installplan.name'    #robocop:disable
     IF    "${operator_version}" != "${EMPTY}"
-        ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.items[].spec.clusterServiceVersionNames[] | select(. | contains("${csv}"))'    #robocop:disable
-        IF    "${installplan_version_exist}" == "${EMPTY}"
+        ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.spec.clusterServiceVersionNames[] | select(. == "${csv}")'    #robocop:disable
+        IF    ${rc} != 0 or "${installplan_version_exist}" == "${EMPTY}"
             ${installplans}=    Run   oc get installplan -n ${namespace}
             FAIL    The install plan ${installplan_name} used in sub ${subscription_name} does not match the version: ${operator_version}\nExisting installplans:\n${installplans}    #robocop:disable
         ELSE

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -388,7 +388,7 @@ Wait For Installplan And Approve It
     ${installplan_name}=    Run   oc get subscription ${subscription_name} -n ${namespace} -o json | jq '.status.installplan.name'    #robocop:disable
     IF    "${operator_version}" != "${EMPTY}"
         ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.spec.clusterServiceVersionNames[] | select(. == "${csv}")'    #robocop:disable
-        IF    ${rc} != 0 or "${installplan_version_exist}" == "${EMPTY}"
+        IF     "${installplan_version_exist}" == "${EMPTY}"
             ${installplans}=    Run   oc get installplan -n ${namespace}
             FAIL    The install plan ${installplan_name} used in sub ${subscription_name} does not match the version: ${operator_version}\nExisting installplans:\n${installplans}    #robocop:disable
         ELSE

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -387,8 +387,8 @@ Wait For Installplan And Approve It
     Wait Until Keyword Succeeds    10m    5s    Search Install Plan    ${csv}    ${subscription_name}    ${namespace}
     ${installplan_name}=    Run   oc get subscription ${subscription_name} -n ${namespace} -o json | jq '.status.installplan.name'    #robocop:disable
     IF    "${operator_version}" != "${EMPTY}"
-        ${installplan_version_exist}=    Run And Return Rc   oc get installplan ${installplan_name} -n ${namespace} | grep "${operator_version}"    #robocop:disable
-        IF    ${installplan_version_exist} != 0
+        ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.items[].spec.clusterServiceVersionNames[] | select(. | contains("${csv}"))'    #robocop:disable
+        IF    "${installplan_version_exist}" == "${EMPTY}"
             ${installplans}=    Run   oc get installplan -n ${namespace}
             FAIL    The install plan ${installplan_name} used in sub ${subscription_name} does not match the version: ${operator_version}\nExisting installplans:\n${installplans}    #robocop:disable
         ELSE

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -387,7 +387,7 @@ Wait For Installplan And Approve It
     Wait Until Keyword Succeeds    10m    5s    Search Install Plan    ${csv}    ${subscription_name}    ${namespace}
     ${installplan_name}=    Run   oc get subscription ${subscription_name} -n ${namespace} -o json | jq '.status.installplan.name'    #robocop:disable
     IF    "${operator_version}" != "${EMPTY}"
-        ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.spec.clusterServiceVersionNames[] | select(. == "${csv}")'    #robocop:disable
+        ${rc}    ${installplan_version_exist}=    Run and Return Rc and Output   oc get installplan ${installplan_name} -n ${namespace} -ojson | jq '.spec.clusterServiceVersionNames[] | select(. == "${csv}")' | tr -d '"'    #robocop:disable
         IF     "${installplan_version_exist}" == "${EMPTY}"
             ${installplans}=    Run   oc get installplan -n ${namespace}
             FAIL    The install plan ${installplan_name} used in sub ${subscription_name} does not match the version: ${operator_version}\nExisting installplans:\n${installplans}    #robocop:disable

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -31,7 +31,7 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     IF     "${starting_csv}" != "${NONE}"
         ${operator_version}=    Replace String    ${starting_csv}    ${operator_name}.    ${EMPTY}
     ELSE
-        ${operator_version}=    ${EMPTY}
+        ${operator_version}=    Set Variable    ${EMPTY}
     END
     ${operator_sub_filepath}=    Set Variable    ${FILES_RESOURCES_DIRPATH}/${operator_name}-sub.yaml
     Copy File    ${SUBSCRIPTION_YAML_TEMPLATE_FILEPATH}    ${operator_sub_filepath}

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -20,7 +20,7 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ...            ${channel}=stable    ${catalog_source_name}=certified-operators
     ...            ${cs_namespace}=openshift-marketplace    ${operator_group_name}=${NONE}
     ...            ${operator_group_ns}=${NONE}    ${operator_group_target_ns}=${NONE}
-    ...            ${starting_csv}=${NONE}
+    ...            ${approval}=Automatic     ${starting_csv}=${NONE}    
     [Timeout]    10 minutes
     Log To Console    message=Installing the '${operator_name}' Operator
     IF    "${operator_group_name}" != "${NONE}"
@@ -28,9 +28,15 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
         ...    namespace=${operator_group_ns}    target_namespace=${operator_group_target_ns}
         ...    operator_name=${operator_name}
     END
+    IF     "${starting_csv}" != "${NONE}"
+        ${operator_version}=    Replace String    ${starting_csv}    ${operator_name}.    ${EMPTY}
+    ELSE
+        ${operator_version}=    ${EMPTY}
+    END
     ${operator_sub_filepath}=    Set Variable    ${FILES_RESOURCES_DIRPATH}/${operator_name}-sub.yaml
     Copy File    ${SUBSCRIPTION_YAML_TEMPLATE_FILEPATH}    ${operator_sub_filepath}
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<SUBSCRIPTION_NAME>/${subscription_name}/g" ${operator_sub_filepath}    # robocop: disable
+    ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<INSTALL_PLAN_APPROVAL>/${approval}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<OPERATOR_NAMESPACE>/${namespace}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<UPDATE_CHANNEL>/${channel}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<OPERATOR_NAME>/${operator_name}/g" ${operator_sub_filepath}    # robocop: disable
@@ -63,10 +69,9 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     IF  "${operator_name}" == "job-set"
         ${operator_name}=    Set Variable    jobset-operator
     END
-    Wait For Installplan And Approve It    ${namespace}    ${operator_name}    ${subscription_name}
+    Wait For Installplan And Approve It    ${namespace}    ${operator_name}    ${subscription_name}    ${operator_version}
     Wait Until Keyword Succeeds    1 min    0 sec
     ...    Is Resource Present    Subscription    ${subscription_name}     ${namespace}    ${IS_PRESENT}
-    Wait For Installplan And Approve It    ${namespace}    ${operator_name}    ${subscription_name}
     # Approve any pending installplans for transitive OLM dependencies (e.g. ServiceMesh)
     Approve All Pending Installplans    openshift-operators
 

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -20,7 +20,7 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ...            ${channel}=stable    ${catalog_source_name}=certified-operators
     ...            ${cs_namespace}=openshift-marketplace    ${operator_group_name}=${NONE}
     ...            ${operator_group_ns}=${NONE}    ${operator_group_target_ns}=${NONE}
-    ...            ${approval}=Automatic     ${starting_csv}=${NONE}    
+    ...            ${approval}=Automatic     ${starting_csv}=${NONE}
     [Timeout]    10 minutes
     Log To Console    message=Installing the '${operator_name}' Operator
     IF    "${operator_group_name}" != "${NONE}"
@@ -69,7 +69,8 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     IF  "${operator_name}" == "job-set"
         ${operator_name}=    Set Variable    jobset-operator
     END
-    Wait For Installplan And Approve It    ${namespace}    ${operator_name}    ${subscription_name}    ${operator_version}
+    Wait For Installplan And Approve It    ${namespace}    ${operator_name}    ${subscription_name}
+    ...    ${operator_version}
     Wait Until Keyword Succeeds    1 min    0 sec
     ...    Is Resource Present    Subscription    ${subscription_name}     ${namespace}    ${IS_PRESENT}
     # Approve any pending installplans for transitive OLM dependencies (e.g. ServiceMesh)

--- a/ods_ci/tests/Resources/Page/Operators/ISVs.resource
+++ b/ods_ci/tests/Resources/Page/Operators/ISVs.resource
@@ -20,6 +20,7 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ...            ${channel}=stable    ${catalog_source_name}=certified-operators
     ...            ${cs_namespace}=openshift-marketplace    ${operator_group_name}=${NONE}
     ...            ${operator_group_ns}=${NONE}    ${operator_group_target_ns}=${NONE}
+    ...            ${starting_csv}=${NONE}
     [Timeout]    10 minutes
     Log To Console    message=Installing the '${operator_name}' Operator
     IF    "${operator_group_name}" != "${NONE}"
@@ -35,6 +36,11 @@ Install ISV Operator From OperatorHub Via CLI    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<OPERATOR_NAME>/${operator_name}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<CATALOG_SOURCE>/${catalog_source_name}/g" ${operator_sub_filepath}    # robocop: disable
     ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<CS_NAMESPACE>/${cs_namespace}/g" ${operator_sub_filepath}    # robocop: disable
+    IF    "${starting_csv}" != "${NONE}"
+        ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "s/<STARTING_CSV>/${starting_csv}/g" ${operator_sub_filepath}    # robocop: disable
+    ELSE
+        ${rc}    ${out}=    Run And Return Rc And Output    sed -i'' -e "/<STARTING_CSV>/d" ${operator_sub_filepath}    # robocop: disable
+    END
     ${return_code}    ${output} =    Run And Return Rc And Output    oc apply -f ${operator_sub_filepath}
     Log To Console    ${output}
     # TODO: Remove this once the operator_name will be tempo-operator


### PR DESCRIPTION
We need to fix the RHCL version temporarily as requested by the component team.

Validation:
- `rhoai-test-flow/13274` Installed Successfully, although component tests seem failing. Question for component team
- `rhoai-upgrade/5` Install + upgrade to next .z version successful