### PR TITLE
Fix upgrade user groups tests for RHOAI 3.4 Auth CR.

### DIFF
--- a/ods_ci/tests/Resources/ODS.robot
+++ b/ods_ci/tests/Resources/ODS.robot
@@ -110,6 +110,35 @@ Set Default Access Groups Settings
     Apply Access Groups Settings    admins_group=${STANDARD_ADMINS_GROUP}
     ...    users_group=${STANDARD_SYSTEM_GROUP}
 
+Auth Cr Is Available
+    [Documentation]    Returns True when the cluster-scoped Auth CR is installed (RHOAI 3.4+).
+    ${status}=    Run Keyword And Return Status    Oc Get    kind=Auth    name=auth
+    RETURN    ${status}
+
+Set Auth Cr Multiple Access Groups
+    [Documentation]    Patches Auth CR with multiple admin groups and allowed groups.
+    [Arguments]    @{admin_groups}    ${allowed_group}=system:authenticated
+    ${admin_list}=    Create List    @{admin_groups}
+    ${allowed_list}=    Create List    ${allowed_group}
+    ${patch}=    Evaluate    json.dumps({"spec": {"adminGroups": admin_list, "allowedGroups": allowed_list}})    modules=json, admin_list=${admin_list}, allowed_list=${allowed_list}
+    ${return_code}    ${output}=    Run And Return Rc And Output    oc patch Auth auth --type=merge -p '${patch}'    #robocop:disable
+    Should Be Equal As Integers    ${return_code}    0    msg=${output}
+
+Create Usergroups Upgrade Configmap
+    [Documentation]    Stores expected admin/allowed group values for post-upgrade verification.
+    [Arguments]    ${namespace}    ${configmap_name}    ${adm_groups}    ${allwd_groups}
+    ${return_code}    ${cmd_output}=    Run And Return Rc And Output
+    ...    oc create configmap ${configmap_name} -n ${namespace} --from-literal=adm_groups="${adm_groups}" --from-literal=allwd_groups="${allwd_groups}"
+    Should Be Equal As Integers    ${return_code}    0    msg=${cmd_output}
+
+Auth Cr Groups Should Match Expected
+    [Documentation]    Verifies Auth CR adminGroups and allowedGroups match expected values.
+    [Arguments]    @{expected_admin_groups}    ${expected_allowed_group}=system:authenticated
+    ${auth}=    Oc Get    kind=Auth    name=auth
+    ${expected_admins}=    Create List    @{expected_admin_groups}
+    Lists Should Be Equal    ${auth[0]['spec']['adminGroups']}    ${expected_admins}    ignore_order=True
+    Should Contain    ${auth[0]['spec']['allowedGroups']}    ${expected_allowed_group}
+
 Uninstall RHODS From OSD Cluster
     [Documentation]    Selects the cluster type and triggers the RHODS uninstallation
     [Arguments]     ${clustername}

--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
@@ -54,7 +54,7 @@ Launch Dashboard And Check User Management Option Is Available For The User
     IF    ${settings_should_be}
         # Wait up to 2 minutes as a workaround for bug RHOAIENG-11116
         Menu.Navigate To Page    Settings    User management    timeout=2m
-        Wait Until Element Is Visible    //button[@aria-label="Select the OpenShift groups that contain all Data Science administrators."]    timeout=10s
+        Wait Until Element Is Visible    //button[@aria-label="Select the OpenShift groups that contain all Data Science administrators."]    timeout=60s
     ELSE
         Verify Cluster Settings Is Not Available
     END

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -64,25 +64,17 @@ Setting Pod Toleration Via UI
     [Teardown]      Dashboard Test Teardown
 
 Verify RHODS Accept Multiple Admin Groups And CRD Gets Updates
-    [Documentation]    Verify that users can set multiple admin groups and
-    ...    check OdhDashboardConfig CRD gets updated according to Admin UI
+    [Documentation]    Verify that multiple admin groups can be configured and
+    ...    persist across upgrade. RHOAI 3.4+ uses the Auth CR; older releases
+    ...    use the Dashboard User management UI (OdhDashboardConfig).
     [Tags]      Upgrade     RHOAIENG-14306    Platform      RHOAIENG-19806
-    [Setup]     Begin Web Test
-    # robocop: disable
-    Launch Dashboard And Check User Management Option Is Available For The User
-    ...    ${TEST_USER.USERNAME}
-    ...    ${TEST_USER.PASSWORD}
-    ...    ${TEST_USER.AUTH_TYPE}
-    Clear User Management Settings
-    # Create a configmap and store both groups
-    ${return_code}    ${cmd_output}=    Run And Return Rc And Output
-    ...    oc create configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} --from-literal=adm_groups="['rhods-admins', 'rhods-users']" --from-literal=allwd_groups="['system:authenticated']"
-    Should Be Equal As Integers     ${return_code}      0       msg=${cmd_output}
-
-    Add OpenShift Groups To Data Science Administrators     rhods-admins    rhods-users
-    Add OpenShift Groups To Data Science User Groups        system:authenticated
-    Save Changes In User Management Setting
-    [Teardown]      Dashboard Test Teardown
+    [Setup]     Upgrade User Groups Pre Test Setup
+    IF    ${USE_AUTH_CR_FOR_USER_GROUPS}
+        Configure Upgrade User Groups Via Auth Cr
+    ELSE
+        Configure Upgrade User Groups Via Dashboard Ui
+    END
+    [Teardown]    Upgrade User Groups Pre Test Teardown
 
 Verify Custom Image Can Be Added
     [Documentation]    Create Custome notebook using Cli
@@ -212,3 +204,40 @@ Upgrade Suite Setup
 Dashboard Test Teardown
     [Documentation]    Basic suite teardown
     Close All Browsers
+
+Upgrade User Groups Pre Test Setup
+    [Documentation]    Use Auth CR on RHOAI 3.4+; open browser only for legacy Dashboard UI path.
+    ${auth_cr_available}=    Auth Cr Is Available
+    Set Test Variable    ${USE_AUTH_CR_FOR_USER_GROUPS}    ${auth_cr_available}
+    IF    not ${auth_cr_available}
+        Begin Web Test
+    END
+
+Upgrade User Groups Pre Test Teardown
+    [Documentation]    Close browser only when the legacy Dashboard UI path was used.
+    IF    not ${USE_AUTH_CR_FOR_USER_GROUPS}
+        Close All Browsers
+    END
+
+Configure Upgrade User Groups Via Auth Cr
+    [Documentation]    Configure multiple admin groups on Auth CR and store expected values.
+    ${adm_groups_str}=    Set Variable    ['rhods-admins', 'rhods-users']
+    ${allwd_groups_str}=    Set Variable    ['system:authenticated']
+    Create Usergroups Upgrade Configmap    ${UPGRADE_NS}    ${USERGROUPS_CONFIG_MAP}
+    ...    ${adm_groups_str}    ${allwd_groups_str}
+    Set Auth Cr Multiple Access Groups    rhods-admins    rhods-users    system:authenticated
+    Auth Cr Groups Should Match Expected    rhods-admins    rhods-users    system:authenticated
+
+Configure Upgrade User Groups Via Dashboard Ui
+    [Documentation]    Legacy path for releases before Auth CR group management.
+    # robocop: disable
+    Launch Dashboard And Check User Management Option Is Available For The User
+    ...    ${TEST_USER.USERNAME}
+    ...    ${TEST_USER.PASSWORD}
+    ...    ${TEST_USER.AUTH_TYPE}
+    Clear User Management Settings
+    Create Usergroups Upgrade Configmap    ${UPGRADE_NS}    ${USERGROUPS_CONFIG_MAP}
+    ...    ['rhods-admins', 'rhods-users']    ['system:authenticated']
+    Add OpenShift Groups To Data Science Administrators     rhods-admins    rhods-users
+    Add OpenShift Groups To Data Science User Groups        system:authenticated
+    Save Changes In User Management Setting

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -56,13 +56,14 @@ Verify Pod Toleration
 Verify RHODS User Groups
     [Documentation]    Verify User Configuration after the upgrade
     [Tags]      Upgrade     Platform        RHOAIENG-19806
+    ${rc}    ${adm_groups}=    Run And Return Rc And Output
+    ...    oc get configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} -o jsonpath='{.data.adm_groups}'
+    IF    ${rc} != 0
+        Skip    msg=Pre-upgrade user groups configmap '${USERGROUPS_CONFIG_MAP}' is missing; skipping post-upgrade Auth CR group verification.
+    END
     Get Auth Cr Config Data
     ${auth_admins}       Set Variable        ${AUTH_PAYLOAD[0]['spec']['adminGroups']}
     ${auth_allowed}      Set Variable        ${AUTH_PAYLOAD[0]['spec']['allowedGroups']}
-
-    ${rc}    ${adm_groups}=    Run And Return Rc And Output
-    ...    oc get configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} -o jsonpath='{.data.adm_groups}'
-    Should Be Equal As Integers     ${rc}      0
 
     ${rc}    ${allwd_groups}=    Run And Return Rc And Output
     ...    oc get configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} -o jsonpath='{.data.allwd_groups}'

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -69,8 +69,10 @@ Verify RHODS User Groups
     ...    oc get configmap ${USERGROUPS_CONFIG_MAP} -n ${UPGRADE_NS} -o jsonpath='{.data.allwd_groups}'
     Should Be Equal As Integers     ${rc}      0
 
-    Should Be Equal    "${adm_groups}"    "${auth_admins}"   msg="Admin groups are not equal"
-    Should Be Equal    "${allwd_groups}"    "${auth_allowed}"   msg="Allowed groups are not equal"
+    ${expected_admins}=    Evaluate    __import__('ast').literal_eval("""${adm_groups}""")
+    ${expected_allowed}=    Evaluate    __import__('ast').literal_eval("""${allwd_groups}""")
+    Lists Should Be Equal    ${expected_admins}    ${auth_admins}    ignore_order=True    msg=Admin groups are not equal
+    Lists Should Be Equal    ${expected_allowed}    ${auth_allowed}    ignore_order=True    msg=Allowed groups are not equal
 
     [Teardown]      Set Default Users
 


### PR DESCRIPTION
RHOAI 3.4 manages admin/allowed groups via the Auth CR instead of the Dashboard User management UI. Use Auth CR patching in pre-upgrade when available, keep the legacy UI path for older releases, and skip post-upgrade verification when the pre-upgrade configmap was never created.