### PR TITLE
fix: use merge patch in Set Component State keyword

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1428,7 +1428,7 @@ Set Nested Component State
         FAIL    Can not find datasciencecluster
     END
     ${cluster_name} =    Set Variable    ${result.stdout}
-    ${result} =    Run Process    oc patch ${cluster_name} --type 'json' -p '[{"op" : "replace" ,"path" : "/spec/components/${parent_component}/${nested_component}/managementState" ,"value" : "${state}"}]'
+    ${result} =    Run Process    oc patch ${cluster_name} --type merge -p '{"spec":{"components":{"${parent_component}":{"${nested_component}":{"managementState":"${state}"}}}}}'
     ...    shell=true    stderr=STDOUT
     IF    $result.rc != 0
         FAIL    Can not set ${parent_component}.${nested_component} to ${state}: ${result.stdout}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1412,7 +1412,7 @@ Set Component State
         FAIL    Can not find datasciencecluster
     END
     ${cluster_name} =    Set Variable    ${result.stdout}
-    ${result} =    Run Process    oc patch ${cluster_name} --type 'json' -p '[{"op" : "replace" ,"path" : "/spec/components/${component}/managementState" ,"value" : "${state}"}]'
+    ${result} =    Run Process    oc patch ${cluster_name} --type merge -p '{"spec":{"components":{"${component}":{"managementState":"${state}"}}}}'
     ...    shell=true    stderr=STDOUT
     IF    $result.rc != 0
         FAIL    Can not enable ${component}: ${result.stdout}


### PR DESCRIPTION
## Summary
- Fixes [RHOAIENG-69176](https://redhat.atlassian.net/browse/RHOAIENG-69176): `Set Component State` keyword fails for components missing from DSC spec after upgrade
- Changes the `oc patch` type from JSON patch (`replace` op) to merge patch in the `Set Component State` keyword
- Merge patch creates the path if it doesn't exist, fixing the failure for new components (e.g., ogx) not present in the pre-upgrade DSC YAML

## Root Cause
The JSON patch `replace` operation (RFC 6902) requires the target path to already exist. During upgrade testing, new components are intentionally omitted from the applied DSC spec, so `/spec/components/ogx/managementState` doesn't exist and the patch fails.

## Fix
Changed from:
```
oc patch --type json -p '[{"op":"replace","path":"/spec/components/<comp>/managementState","value":"<state>"}]'
```
To:
```
oc patch --type merge -p '{"spec":{"components":{"<comp>":{"managementState":"<state>"}}}}'
```

## Test plan
- [x] Verified merge patch succeeds on a component missing from DSC spec (ogx)
- [x] Verified merge patch still works on existing components (dashboard, ray)
- [x] Verified state transitions work correctly (Managed → Removed → Managed)
- [x] Verified old JSON patch approach fails (confirms the bug)
- [x] Verified DSC is not corrupted after patching

Resolves: https://redhat.atlassian.net/browse/RHOAIENG-69176


