### PR TITLE
Fix CLI upgrade subscription name mismatch on release-2.25

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -145,7 +145,7 @@ Install RHODS
               Oc Apply   kind=List   src=${destination_file}
               Remove File    ${destination_file}
           ELSE
-              Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${OPERATOR_NAME}
+              Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${OPERATOR_SUBSCRIPTION_NAME}
           END
           Wait For Installplan And Approve It    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${OPERATOR_SUBSCRIPTION_NAME}    ${rhoai_version}    #robocop:disable
       ELSE
@@ -378,23 +378,38 @@ Install RHODS In Self Managed Cluster Using CLI
   ...    timeout=20 min
   Should Be Equal As Integers   ${return_code}   0   msg=Error detected while installing RHODS
 
+Get RHOAI Operator Subscription Name
+  [Documentation]    Returns the Subscription CR name for the RHOAI operator on the cluster.
+  ...                Prefers OPERATOR_SUBSCRIPTION_NAME (e.g. rhoai-operator-dev for Cli installs);
+  ...                falls back to OPERATOR_NAME (e.g. rhods-operator) for legacy or reused clusters.
+  FOR    ${candidate}    IN    ${OPERATOR_SUBSCRIPTION_NAME}    ${OPERATOR_NAME}
+      ${rc} =    Run And Return Rc    oc get subscription ${candidate} -n ${OPERATOR_NAMESPACE}
+      IF    ${rc} == 0
+          Log    Found RHOAI operator subscription: ${candidate}    console=yes
+          RETURN    ${candidate}
+      END
+  END
+  FAIL    No RHOAI operator subscription found in ${OPERATOR_NAMESPACE}. Tried: ${OPERATOR_SUBSCRIPTION_NAME}, ${OPERATOR_NAME}
+
 Upgrade RHODS In Self Managed Cluster Using CLI
   [Documentation]   Upgrade RHODS on self managed cluster using CLI by updating catalog source and subscription.
-  ...              Uses OPERATOR_NAME as the subscription name since setup.sh creates the subscription
-  ...              with that name (not OPERATOR_SUBSCRIPTION_NAME which differs for Cli installs).
+  ...              Uses OPERATOR_SUBSCRIPTION_NAME for Subscription CR operations (e.g. rhoai-operator-dev
+  ...              for Cli dev-catalog installs) and OPERATOR_NAME for CSV naming (e.g. rhods-operator.2.25.9).
   ...              When a catalog source image is provided, creates/updates the catalog and points
   ...              the subscription to it. Approves any intermediate install plans before the target.
   [Arguments]     ${image_url}     ${rhoai_version}
+  ${subscription_name} =    Get RHOAI Operator Subscription Name
   Log    Starting RHODS upgrade with image: ${image_url}    console=yes
   Log    Update channel: ${UPDATE_CHANNEL}    console=yes
-  Log    Using subscription name: ${OPERATOR_NAME} (from setup.sh -n flag)    console=yes
-  Set Subscription Install Plan Approval    ${OPERATOR_NAMESPACE}    Manual    ${OPERATOR_NAME}
-  Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${OPERATOR_NAME}
+  Log    Using subscription name: ${subscription_name} (operator package: ${OPERATOR_NAME})    console=yes
+  Set Subscription Install Plan Approval    ${OPERATOR_NAMESPACE}    Manual    ${subscription_name}
+  Set Subscription Update Channel    ${OPERATOR_NAMESPACE}    ${UPDATE_CHANNEL}    ${subscription_name}
   IF    "${image_url}" != "${EMPTY}"
       Set Catalog Source Image    ${image_url}    cs_name=${CATALOG_SOURCE}
-      Update Subscription Source    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${CATALOG_SOURCE}
+      Update Subscription Source    ${OPERATOR_NAMESPACE}    ${subscription_name}    ${CATALOG_SOURCE}
   END
-  Approve Intermediate Installplans    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${rhoai_version}
+  Approve Intermediate Installplans
+  ...    ${OPERATOR_NAMESPACE}    ${subscription_name}    ${OPERATOR_NAME}    ${rhoai_version}
   Wait For Target CSV    ${OPERATOR_NAMESPACE}    ${OPERATOR_NAME}    ${rhoai_version}
 
 Update Subscription Source
@@ -410,12 +425,12 @@ Update Subscription Source
 Approve Intermediate Installplans
   [Documentation]   Approves pending install plans until the target version's plan appears.
   ...              OLM may require intermediate upgrades (e.g. 2.25.0 -> 2.25.2 -> 2.25.3).
-  [Arguments]    ${namespace}    ${sub_name}    ${target_version}
-  ${target_csv} =    Set Variable    ${sub_name}.${target_version}
+  [Arguments]    ${namespace}    ${subscription_name}    ${operator_name}    ${target_version}
+  ${target_csv} =    Set Variable    ${operator_name}.${target_version}
   Log    Waiting for target CSV ${target_csv}, approving intermediate install plans    console=yes
   FOR    ${_}    IN RANGE    20
       ${ip_csv}    ${ip_name}    ${ip_approved} =    Get Current Installplan Info
-      ...    ${namespace}    ${sub_name}
+      ...    ${namespace}    ${subscription_name}
       IF    "${ip_name}" == ""
           Sleep    30s
           CONTINUE


### PR DESCRIPTION
## Summary

Fixes a subscription name mismatch in the CLI upgrade path on `release-2.25` that causes fresh-install upgrade jobs to fail during the DuringUpgrade Robot suite.

Commit `13815a49` (backport upgrade support to 2.25) patched the operator **package name** (`rhods-operator` / `${OPERATOR_NAME}`) when updating Subscription CRs. On fresh CLI dev-catalog installs, the actual Subscription CR is **`rhoai-operator-dev`** (`${OPERATOR_SUBSCRIPTION_NAME}`), so `Set Subscription Install Plan Approval` and related patches fail with:

This PR aligns `release-2.25` with the subscription/CSV naming pattern already used on `release-3.3` / `release-3.4` ([`47a9385d`](https://github.com/red-hat-data-services/ods-ci/commit/47a9385d)) while keeping the intermediate install-plan logic from the 2.25 backport.

### Changes

**File:** `ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot`

1. **Add `Get RHOAI Operator Subscription Name`**
   - Resolves the Subscription CR at runtime by probing `${OPERATOR_SUBSCRIPTION_NAME}` first (`rhoai-operator-dev`), then `${OPERATOR_NAME}` (`rhods-operator`) for legacy/reused clusters.

2. **Fix `Upgrade RHODS In Self Managed Cluster Using CLI`**
   - Use resolved `${subscription_name}` for all Subscription CR operations (`installPlanApproval`, channel, catalog source).
   - Keep `${OPERATOR_NAME}` for CSV targeting (`rhods-operator.<version>`).

3. **Fix `Approve Intermediate Installplans`**
   - Split arguments into `${subscription_name}` (for `oc get subscription`) and `${operator_name}` (for target CSV name).
   - Previously built target CSV as `${sub_name}.${target_version}`, which was wrong when `${sub_name}` was the subscription CR name.

4. **Fix OperatorHub upgrade path**
   - Use `${OPERATOR_SUBSCRIPTION_NAME}` instead of `${OPERATOR_NAME}` in `Set Subscription Update Channel` (consistent with 3.3/3.4).

### Variable reference

| Variable | Example value | Used for |
|----------|---------------|----------|
| `OPERATOR_SUBSCRIPTION_NAME` | `rhoai-operator-dev` (CLI) / `rhods-operator` (OperatorHub) | Subscription CR patches |
| `OPERATOR_NAME` | `rhods-operator` | CSV name prefix (`rhods-operator.2.25.9`) |

Set in `ods_ci/tests/Resources/RHOSi.resource` for self-managed CLI: `OPERATOR_SUBSCRIPTION_NAME=rhoai-operator-dev`, `OPERATOR_NAME=rhods-operator`.

## Test plan

- [ ] Re-run Jenkins `rhoai/job/2.25/job/selfmanaged/job/cli/job/aws/job/rhoai-upgrade` with **fresh install** params (`INSTALL_CLUSTER=true`, `DEPLOY_RHODS_OPERATOR=true`, `UPGRADE_TO_VERSION=<target>`)
- [ ] Verify DuringUpgrade Robot suite passes: subscription patch targets `rhoai-operator-dev`, operator upgrade completes, target CSV reaches `Succeeded`
- [ ] Verify **reused cluster** upgrade still works (subscription named `rhods-operator`) via runtime lookup fallback
- [ ] Verify OperatorHub upgrade path still patches the correct subscription name
- [ ] Confirm intermediate install-plan approval works when OLM requires stepping through versions (e.g. 2.25.x → 2.25.y)

## References
- JIRA ticket : [RHOAIENG-76253](https://redhat.atlassian.net/browse/RHOAIENG-76253)
- Failing job: [rhoai-upgrade #53]
- Correct pattern on 3.3: [`47a9385d`](https://github.com/red-hat-data-services/ods-ci/commit/47a9385d) — *add upgrade support by cli*
- Introduced regression on 2.25: [`13815a49`](https://github.com/red-hat-data-services/ods-ci/commit/13815a49) — *Backport upgrade support from master*