### PR TITLE
Add ppc64le support to RHCL skip logic

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1584,6 +1584,11 @@ Patch DSC With Model Cache Config    #robocop:disable=TooManyKeywords
 
 Configure MaaS Gateway API
     [Documentation]    Configure Gateway API for MaaS traffic routing
+    ${arch_type} =    Get Variable Value    ${ARCH_TYPE}    amd64
+    IF    '${arch_type}' == 'ppc64le'
+        Log    Skipping MaaS Gateway API installation for ppc64le architecture    console=yes
+        RETURN
+    END
     Log To Console    Configuring Gateway API for MaaS
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    bash tasks/Resources/Gateway/configure_maas_gateway.sh
@@ -1592,6 +1597,11 @@ Configure MaaS Gateway API
 
 Configure MaaS Database
     [Documentation]    Provision PostgreSQL and maas-db-config secret required by maas-api
+    ${arch_type} =    Get Variable Value    ${ARCH_TYPE}    amd64
+    IF    '${arch_type}' == 'ppc64le'
+        Log    Skipping MaaS Database installation for ppc64le architecture    console=yes
+        RETURN
+    END
     Log To Console    Provisioning MaaS PostgreSQL prerequisites
     ${rc}    ${output} =    Run And Return Rc And Output
     ...    bash tasks/Resources/Database/configure_maas_postgres.sh --namespace ${APPLICATIONS_NAMESPACE}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1045,9 +1045,9 @@ Install Connectivity Link Operator Via Cli
     ...                Installing in ${CONNECTIVITY_LINK_NS} namespace with operator group
     ...                ensures all resources are created in ${CONNECTIVITY_LINK_NS}.
     ${arch_type} =    Get Variable Value    ${ARCH_TYPE}    amd64
-    IF    '${arch_type}' == 's390x'
-        Log    Skipping Red Hat Connectivity Link Operator installation for s390x architecture    console=yes
-        Log    Skipping Authorino Operator installation for s390x architecture    console=yes
+    IF    '${arch_type}' == 's390x' or '${arch_type}' == 'ppc64le'
+        Log    Skipping Red Hat Connectivity Link Operator installation for s390x/ppc64le architecture    console=yes
+        Log    Skipping Authorino Operator installation for s390x/ppc64le architecture    console=yes
         RETURN
     END
     ${is_installed} =   Check If Operator Is Installed Via CLI   ${CONNECTIVITY_LINK_OP_NAME}


### PR DESCRIPTION
Updates the architecture guard logic to skip installation/configuration of components not supported on  ppc64le architectures, preventing pipeline/install failures on these platforms.
 
Changes:

- Skip Connectivity Link operator installation for ppc64le
- Skip Authorino operator installation for ppc64le
- Skip MaaS Gateway API configuration for ppc64le
- Skip MaaS Database configuration for ppc64le