### PR TITLE
Fix backward compatibility for MaaS DB config namespace detection

### DIFF
--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -32,13 +32,15 @@ derive_infra_namespace() {
 detect_infra_namespace() {
     local apps_ns="$1"
 
-    # MaaS provisioning may run before the RHOAI operator has deployed the
-    # maas-controller. Without waiting, detect would see no controller and
-    # always fall back to the apps namespace — then when the operator deploys
-    # a controller with INFRA_NAMESPACE=AUTO it looks in the infra namespace
-    # where the secret doesn't exist, and maas-api never starts.
+    # MaaS provisioning may run before the RHOAI operator has fully deployed
+    # the maas-controller (CRD registration, reconciliation, and pod scheduling
+    # can take 10+ minutes after the CSV is ready). Without waiting, detect
+    # would see no controller and fall back to the apps namespace — then when
+    # the operator deploys a controller with INFRA_NAMESPACE=AUTO it looks in
+    # the infra namespace where the secret doesn't exist, and maas-api never
+    # starts. Wait up to 15 minutes to cover slow clusters.
     echo "Waiting for maas-controller deployment in ${apps_ns}..." >&2
-    for i in $(seq 1 30); do
+    for i in $(seq 1 90); do
         oc get deployment maas-controller -n "${apps_ns}" &>/dev/null && break
         sleep 10
     done

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -37,7 +37,7 @@ detect_infra_namespace() {
     # always fall back to the apps namespace — then when the operator deploys
     # a controller with INFRA_NAMESPACE=AUTO it looks in the infra namespace
     # where the secret doesn't exist, and maas-api never starts.
-    echo "Waiting for maas-controller deployment in ${apps_ns}..."
+    echo "Waiting for maas-controller deployment in ${apps_ns}..." >&2
     for i in $(seq 1 30); do
         oc get deployment maas-controller -n "${apps_ns}" &>/dev/null && break
         sleep 10

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -29,7 +29,23 @@ derive_infra_namespace() {
     esac
 }
 
-INFRA_NS=$(derive_infra_namespace "${APPS_NS}")
+detect_infra_namespace() {
+    local apps_ns="$1"
+    local infra_val
+    infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
+        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \
+        2>/dev/null)
+
+    if [[ "${infra_val}" == "AUTO" ]]; then
+        derive_infra_namespace "${apps_ns}"
+    elif [[ -n "${infra_val}" ]]; then
+        echo "${infra_val}"
+    else
+        echo "${apps_ns}"
+    fi
+}
+
+INFRA_NS=$(detect_infra_namespace "${APPS_NS}")
 
 # Ensure namespaces exist
 oc create namespace "${APPS_NS}" --dry-run=client -o yaml | oc apply -f -

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -31,6 +31,18 @@ derive_infra_namespace() {
 
 detect_infra_namespace() {
     local apps_ns="$1"
+
+    # MaaS provisioning may run before the RHOAI operator has deployed the
+    # maas-controller. Without waiting, detect would see no controller and
+    # always fall back to the apps namespace — then when the operator deploys
+    # a controller with INFRA_NAMESPACE=AUTO it looks in the infra namespace
+    # where the secret doesn't exist, and maas-api never starts.
+    echo "Waiting for maas-controller deployment in ${apps_ns}..."
+    for i in $(seq 1 30); do
+        oc get deployment maas-controller -n "${apps_ns}" &>/dev/null && break
+        sleep 10
+    done
+
     local infra_val
     infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
         -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \


### PR DESCRIPTION
  Summary

  - Replaces static derive_infra_namespace() call with detect_infra_namespace() that reads the INFRA_NAMESPACE env var from the deployed maas-controller
  before deciding where to place maas-db-config
  - Fixes [RHOAIENG-76264](https://redhat.atlassian.net/browse/RHOAIENG-76264): PR #2987 broke backward compatibility with operators that don't support infra namespace separation

  Problem

  PR #2987 unconditionally placed maas-db-config in a separate infra namespace (redhat-ai-gateway-infra), assuming all operators have INFRA_NAMESPACE=AUTO
  (added by MaaS PR #1051, merged July 7). Operators built before that date — including all EA2 FBC images prior to the July 13 rebuild — expect
  maas-db-config in the applications namespace. This caused MaaS DB secret not-found errors on older operator versions.

  How it works

  detect_infra_namespace() queries the maas-controller deployment for its INFRA_NAMESPACE env var:
  - AUTO → derives the infra namespace (e.g. redhat-ai-gateway-infra for RHOAI, odh-ai-gateway-infra for ODH)
  - Non-empty custom value → uses that namespace as-is
  - Empty or absent → falls back to the applications namespace (pre-infra-separation behavior)
  - maas-controller not deployed → safe fallback to applications namespace
  
  
  Testing:
  dashboard-e2e-tests/1814 
  Using: quay.io/rhoai/rhoai-fbc-fragment@sha256:6f8c6350ec16320668c7977c12219b2170432fff4d3626ca82dfc4ed909b7405 (Same that failed in  ob/rhoai/job/3.5-ea.2/job/selfmanaged/job/cli/job/aws/job/rhoai-smoke/6/)
  Before this change:
  
<img width="390" height="599" alt="image" src="https://github.com/user-attachments/assets/41661a94-eace-4c11-8d5d-1f91e5a68faa" />

Build dashboard-e2e-tests/1815 
Using the same operater image
After this change:
<img width="380" height="549" alt="image" src="https://github.com/user-attachments/assets/367393f8-52d2-4896-bb59-0a98648c686e" />

dashboard-e2e-tests/1817 
Using: Latest 3.5 GA
With this fix running:
WIP



