### PR TITLE
RHOAIENG-76664: use codeflare-sdk post-upgrade on 2.25 with fix and not run pre_upgrade if upgrade to version is 3.x

### DIFF
--- a/ods_ci/tests/Resources/Files/kueue-batch-user-role.yaml
+++ b/ods_ci/tests/Resources/Files/kueue-batch-user-role.yaml
@@ -5,7 +5,7 @@ metadata:
 rules:
 - apiGroups: [""]
   resources: ["namespaces"]
-  verbs: ["create", "get", "list", "watch"]
+  verbs: ["create", "get", "list", "watch", "delete"]
 - apiGroups: ["kueue.x-k8s.io"]
   resources: ["clusterqueues", "resourceflavors", "localqueues"]
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete"]

--- a/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
+++ b/ods_ci/tests/Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
@@ -6,7 +6,7 @@ Resource          ../../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 
 
 *** Variables ***
-${CODEFLARE-SDK-RELEASE-TAG}             v0.31.3
+${CODEFLARE-SDK-RELEASE-TAG}             v0.31.6-sdk-test-fix
 ${CODEFLARE-SDK_DIR}                     codeflare-sdk
 ${CODEFLARE-SDK_REPO_URL}                %{CODEFLARE-SDK_REPO_URL=https://github.com/project-codeflare/codeflare-sdk.git}
 ${DISTRIBUTED_WORKLOADS_RELEASE_ASSETS}  https://github.com/opendatahub-io/distributed-workloads/releases/latest/download
@@ -65,15 +65,27 @@ Prepare Codeflare-SDK Test Setup
     # Perform oc login with Test User
     Login To OCP Using API    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}
 
+Skip Codeflare-SDK Pre Upgrade If Upgrade Target Is 3x
+    [Documentation]    Skips codeflare-sdk pre-upgrade when UPGRADE_TO_VERSION targets RHOAI 3.x or greater. That path is covered by shift-left container tests (pre on 2.25 image).
+    ${upgrade_to_version}=    Get Variable Value    ${UPGRADE_TO_VERSION}    ${EMPTY}
+    IF    '${upgrade_to_version}' == '${EMPTY}'
+        RETURN
+    END
+    ${is_upgrade_to_3x_or_greater}=    Evaluate    int("${upgrade_to_version}".split(".")[0]) >= 3
+    Skip If    ${is_upgrade_to_3x_or_greater}
+    ...    msg=Skipping codeflare-sdk pre-upgrade: UPGRADE_TO_VERSION is ${upgrade_to_version} (shift-left covers 2.25->3.x pre-upgrade)
+
+Prepare Codeflare-SDK Pre Upgrade Test Setup
+    [Documentation]   Prepare codeflare-sdk pre-upgrade tests; skip when upgrade target is 3.x
+    Skip Codeflare-SDK Pre Upgrade If Upgrade Target Is 3x
+    Prepare Codeflare-SDK Upgrade Test Setup
+
 Prepare Codeflare-SDK Upgrade Test Setup
-    [Documentation]   Prepare codeflare-sdk upgrade tests with RBAC setup and namespace creation
+    [Documentation]   Prepare codeflare-sdk upgrade tests with RBAC setup
     Clone Git Repository    ${CODEFLARE-SDK_REPO_URL}    ${CODEFLARE-SDK-RELEASE-TAG}    ${CODEFLARE-SDK_DIR}
 
     # Setup Kueue RBAC permissions as admin before switching to test user
     Setup Kueue Batch User RoleBinding
-
-    # Create the test namespace as admin
-    Create Test Namespace For Codeflare Test
 
     # Perform oc login with Test User
     Login To OCP Using API    ${TEST_USER.USERNAME}    ${TEST_USER.PASSWORD}
@@ -123,15 +135,6 @@ Cleanup Codeflare-SDK Setup
 
     # Cleanup Kueue RBAC resources
     Teardown Kueue Batch User RoleBinding
-
-Create Test Namespace For Codeflare Test
-    [Documentation]    Create the test namespace as admin for codeflare tests
-    Log To Console    "Creating test namespace test-ns-rayupgrade as admin"
-    ${rc}=    Run And Return Rc    oc create namespace test-ns-rayupgrade
-
-    IF    ${rc} != 0
-        Log To Console    "Warning: Unable to create namespace test-ns-rayupgrade (may already exist)"
-    END
 
 Prepare Training Operator KFTO E2E Test Suite
     [Documentation]    Prepare Training Operator KFTO E2E Test Suite

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -160,7 +160,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    Creates the Ray Cluster and verify resource usage
     [Tags]      Upgrade    WorkloadOrchestration
-    [Setup]     Prepare Codeflare-SDK Upgrade Test Setup
+    [Setup]     Prepare Codeflare-SDK Pre Upgrade Test Setup
     ${PRJ_UPGRADE}=     Set Variable        test-ns-rayupgrade
     ${JOB_NAME}=        Set Variable        mnist
     Run Codeflare-SDK Test

--- a/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/0601__workloads_orchestration/test-run-codeflare-sdk-e2e-tests.robot
@@ -31,7 +31,7 @@ Run TestRayLocalInteractiveOauth test with Python 3.11
 Run TestHeterogenousClustersOauth
     [Documentation]    Run Python E2E test: TestHeterogenousClustersOauth (workaround for 2.15)
     [Tags]
-    ...     Tier1
+    ...     deprecatedTest
     ...     DistributedWorkloads
     ...     WorkloadsOrchestration
     ...     HeterogeneousCluster
@@ -41,6 +41,7 @@ Run TestHeterogenousClustersOauth
 *** Keywords ***
 Prepare Codeflare-sdk E2E Test Suite
     [Documentation]    Prepare codeflare-sdk E2E Test Suite
+    Setup Kueue Batch User RoleBinding
     Prepare Codeflare-SDK Test Setup
     RHOSi Setup
 


### PR DESCRIPTION
## WHAT
[RHOAIENG-76664](https://redhat.atlassian.net/browse/RHOAIENG-76664): use codeflare-sdk post-upgrade on 2.25 with fix and not run pre_upgrade if upgrade to version is 3.x

## Jira
https://redhat.atlassian.net/browse/RHOAIENG-76664