### PR TITLE
Fix MaaS install verification and DSC tests to use infra namespace

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1614,7 +1614,9 @@ Detect MaaS Infra Namespace
     ...    derives the namespace from APPLICATIONS_NAMESPACE using the same mapping as
     ...    configure_maas_postgres.sh. Returns APPLICATIONS_NAMESPACE if no mapping matches.
     ${rc}    ${infra_val} =    Run And Return Rc And Output
-    ...    oc get deployment maas-controller -n ${APPLICATIONS_NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' 2>/dev/null
+    ...    oc get deployment maas-controller -n ${APPLICATIONS_NAMESPACE}
+    ...    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}'
+    ...    2>/dev/null
     IF    ${rc} == 0 and "${infra_val}" != "" and "${infra_val}" != "AUTO"
         RETURN    ${infra_val}
     END

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1613,10 +1613,11 @@ Detect MaaS Infra Namespace
     ...    Reads the INFRA_NAMESPACE env var from the controller; when AUTO or absent,
     ...    derives the namespace from APPLICATIONS_NAMESPACE using the same mapping as
     ...    configure_maas_postgres.sh. Returns APPLICATIONS_NAMESPACE if no mapping matches.
-    ${rc}    ${infra_val} =    Run And Return Rc And Output
+    ${cmd}=    Catenate
     ...    oc get deployment maas-controller -n ${APPLICATIONS_NAMESPACE}
     ...    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}'
     ...    2>/dev/null
+    ${rc}    ${infra_val} =    Run And Return Rc And Output    ${cmd}
     IF    ${rc} == 0 and "${infra_val}" != "" and "${infra_val}" != "AUTO"
         RETURN    ${infra_val}
     END

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -1613,7 +1613,7 @@ Detect MaaS Infra Namespace
     ...    Reads the INFRA_NAMESPACE env var from the controller; when AUTO or absent,
     ...    derives the namespace from APPLICATIONS_NAMESPACE using the same mapping as
     ...    configure_maas_postgres.sh. Returns APPLICATIONS_NAMESPACE if no mapping matches.
-    ${cmd}=    Catenate
+    ${cmd} =    Catenate
     ...    oc get deployment maas-controller -n ${APPLICATIONS_NAMESPACE}
     ...    -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}'
     ...    2>/dev/null

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -461,7 +461,8 @@ Verify RHODS Installation
 
   ${modelsasservice} =    Is Nested Component Enabled    kserve    modelsAsService    ${DSC_NAME}
   IF    "${modelsasservice}" == "true"
-    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ${maas_infra_ns} =    Detect MaaS Infra Namespace
+    Wait For Deployment Replica To Be Ready    namespace=${maas_infra_ns}
     ...    label_selector=app.kubernetes.io/part-of=modelsasservice
   END
 
@@ -482,6 +483,15 @@ Verify RHODS Installation
       Log To Console    Waiting for pod status in ${APPLICATIONS_NAMESPACE}
       Wait For Pods Status  namespace=${APPLICATIONS_NAMESPACE}  timeout=600
       Log  Verified Applications NS: ${APPLICATIONS_NAMESPACE}  console=yes
+  END
+
+  IF    "${modelsasservice}" == "true"
+      ${maas_infra_ns} =    Detect MaaS Infra Namespace
+      IF    "${maas_infra_ns}" != "${APPLICATIONS_NAMESPACE}"
+          Log To Console    Waiting for pod status in MaaS infra namespace ${maas_infra_ns}
+          Wait For Pods Status  namespace=${maas_infra_ns}  timeout=600
+          Log  Verified MaaS Infra NS: ${maas_infra_ns}  console=yes
+      END
   END
 
   # Monitoring stack only deployed for managed, as modelserving monitoring stack is no longer deployed
@@ -1597,3 +1607,21 @@ Configure MaaS Database
     ...    bash tasks/Resources/Database/configure_maas_postgres.sh --namespace ${APPLICATIONS_NAMESPACE}
     Log To Console    ${output}
     Should Be Equal As Integers    ${rc}    0    msg=Error provisioning MaaS PostgreSQL prerequisites
+
+Detect MaaS Infra Namespace
+    [Documentation]    Detect the MaaS infrastructure namespace from the maas-controller deployment.
+    ...    Reads the INFRA_NAMESPACE env var from the controller; when AUTO or absent,
+    ...    derives the namespace from APPLICATIONS_NAMESPACE using the same mapping as
+    ...    configure_maas_postgres.sh. Returns APPLICATIONS_NAMESPACE if no mapping matches.
+    ${rc}    ${infra_val} =    Run And Return Rc And Output
+    ...    oc get deployment maas-controller -n ${APPLICATIONS_NAMESPACE} -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' 2>/dev/null
+    IF    ${rc} == 0 and "${infra_val}" != "" and "${infra_val}" != "AUTO"
+        RETURN    ${infra_val}
+    END
+    # Derive from APPLICATIONS_NAMESPACE (matches configure_maas_postgres.sh derive_infra_namespace)
+    IF    "${APPLICATIONS_NAMESPACE}" == "redhat-ods-applications"
+        RETURN    redhat-ai-gateway-infra
+    ELSE IF    "${APPLICATIONS_NAMESPACE}" == "opendatahub"
+        RETURN    odh-ai-gateway-infra
+    END
+    RETURN    ${APPLICATIONS_NAMESPACE}

--- a/ods_ci/tests/Resources/Page/Components/Components.resource
+++ b/ods_ci/tests/Resources/Page/Components/Components.resource
@@ -129,7 +129,7 @@ Set DSC Nested Component Managed State And Wait For Completion
     END
 
     IF     ${wait_for_completion}
-            Wait For Resources To Be Available    ${deployment_name}    ${label_selector}
+            Wait For Resources To Be Available    ${deployment_name}    ${label_selector}    ${namespace}
     END
 
 Restore DSC Nested Component State
@@ -142,7 +142,7 @@ Restore DSC Nested Component State
     IF    "${current_state}" != "${saved_state}"
         IF    "${saved_state}" == "Managed"
             # This will ensure parent is Managed if needed
-            Set DSC Nested Component Managed State And Wait For Completion    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}
+            Set DSC Nested Component Managed State And Wait For Completion    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}    ${namespace}
         ELSE IF    "${saved_state}" == "Removed"
             Set DSC Nested Component Removed State And Wait For Completion    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}      ${namespace}
         ELSE IF    "${saved_state}" == "${EMPTY}" or "${saved_state}" == ""

--- a/ods_ci/tests/Resources/Page/Components/Components.resource
+++ b/ods_ci/tests/Resources/Page/Components/Components.resource
@@ -142,7 +142,8 @@ Restore DSC Nested Component State
     IF    "${current_state}" != "${saved_state}"
         IF    "${saved_state}" == "Managed"
             # This will ensure parent is Managed if needed
-            Set DSC Nested Component Managed State And Wait For Completion    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}    ${namespace}
+            Set DSC Nested Component Managed State And Wait For Completion
+            ...    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}    ${namespace}
         ELSE IF    "${saved_state}" == "Removed"
             Set DSC Nested Component Removed State And Wait For Completion    ${parent_component}    ${nested_component}    ${deployment_name}    ${label_selector}      ${namespace}
         ELSE IF    "${saved_state}" == "${EMPTY}" or "${saved_state}" == ""

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -609,20 +609,24 @@ Validate Modelsasservice Managed State
     ...    Integration
     ...    Smoke
 
+    ${maas_infra_ns} =    Detect MaaS Infra Namespace
     Set DSC Nested Component Managed State And Wait For Completion
     ...    kserve
     ...    modelsAsService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    namespace=${maas_infra_ns}
     Check That Image Pull Path Is Correct
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
     ...    ${IMAGE_PULL_PATH}
+    ...    namespace=${maas_infra_ns}
 
     [Teardown]      Restore Nested Component And Parent State
     ...    kserve    modelsAsService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
     ...    ${KSERVE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${KSERVE_CONTROLLER_MANAGER_LABEL_SELECTOR}
     ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.KSERVE}
+    ...    nested_namespace=${maas_infra_ns}
 
 Validate Modelsasservice Removed State
     [Documentation]    Validate that ModelsAsService management state Removed does remove relevant resources.
@@ -632,17 +636,20 @@ Validate Modelsasservice Removed State
     ...    modelsasservice-removed
     ...    Integration
 
+    ${maas_infra_ns} =    Detect MaaS Infra Namespace
     Set DSC Nested Component Removed State And Wait For Completion
     ...    kserve
     ...    modelsAsService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    namespace=${maas_infra_ns}
 
     [Teardown]      Restore Nested Component And Parent State
     ...    kserve    modelsAsService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
     ...    ${KSERVE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${KSERVE_CONTROLLER_MANAGER_LABEL_SELECTOR}
     ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.KSERVE}
+    ...    nested_namespace=${maas_infra_ns}
 
 Validate Support For Configuration Of Controller Resources
     [Documentation]    Validate support for configuration of controller resources in component deployments
@@ -775,6 +782,7 @@ Restore Nested Component And Parent State
     ...                Restores nested component first, then parent component to handle dependencies correctly.
     [Arguments]    ${parent_component}    ${nested_component}    ${nested_deployment_name}    ${nested_label_selector}
     ...            ${parent_deployment_name}    ${parent_label_selector}    ${nested_saved_state}    ${parent_saved_state}
+    ...            ${nested_namespace}=${APPLICATIONS_NAMESPACE}
 
     # First restore the nested component
     Restore DSC Nested Component State
@@ -783,6 +791,7 @@ Restore Nested Component And Parent State
     ...    ${nested_deployment_name}
     ...    ${nested_label_selector}
     ...    ${nested_saved_state}
+    ...    ${nested_namespace}
 
     # Then restore the parent component to its original state
     # This ensures parent is in the correct state after the test

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -609,7 +609,7 @@ Validate Modelsasservice Managed State
     ...    Integration
     ...    Smoke
 
-    ${maas_infra_ns} =    Detect MaaS Infra Namespace
+    ${maas_infra_ns}=    Detect MaaS Infra Namespace
     Set DSC Nested Component Managed State And Wait For Completion
     ...    kserve
     ...    modelsAsService
@@ -636,7 +636,7 @@ Validate Modelsasservice Removed State
     ...    modelsasservice-removed
     ...    Integration
 
-    ${maas_infra_ns} =    Detect MaaS Infra Namespace
+    ${maas_infra_ns}=    Detect MaaS Infra Namespace
     Set DSC Nested Component Removed State And Wait For Completion
     ...    kserve
     ...    modelsAsService


### PR DESCRIPTION
maas-api now deploys to a separate infrastructure namespace (e.g. redhat-ai-gateway-infra) but the Robot Framework tests were still looking for it in APPLICATIONS_NAMESPACE, causing timeouts.

Add a Detect MaaS Infra Namespace keyword that reads the controller's INFRA_NAMESPACE env var with a derivation fallback matching configure_maas_postgres.sh (PR #2987). Use it in Verify RHODS Installation and the modelsasservice DSC component lifecycle tests.

Also fix Components.resource to pass the namespace argument through in the Managed state path — previously only the Removed path forwarded it.