### PR TITLE
test: update DSC format from kserve.modelsAsService to aigateway.modelsAsAService

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -12,7 +12,9 @@ spec:
       managementState: <aipipelines_value>
     kserve:
       managementState: <kserve_value>
-      modelsAsService:
+    aigateway:
+      managementState: <aigateway_value>
+      modelsAsAService:
         managementState: <modelsasservice_value>
     kueue:
       managementState: <kueue_value>

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -24,12 +24,12 @@ ${DSCI_NAME} =    default-dsci
 ...    llamastackoperator
 ...    ogx
 ...    mlflowoperator
+...    aigateway
 ...    modelsasservice
 ...    sparkoperator
-...    aigateway
 ...    batchgateway
-&{NESTED_COMPONENT_TO_PARENT_COMPONENT} =    modelsasservice=kserve    batchgateway=aigateway
-&{COMPONENT_TO_COMPONENT_NAME_IN_DSC} =   modelsasservice=modelsAsService    batchgateway=batchGateway
+&{NESTED_COMPONENT_TO_PARENT_COMPONENT}=    modelsasservice=aigateway    batchgateway=aigateway
+&{COMPONENT_TO_COMPONENT_NAME_IN_DSC}=    modelsasservice=modelsAsAService    batchgateway=batchGateway
 ${LWS_OP_NAME}=    leader-worker-set
 ${LWS_OP_NS}=    openshift-lws-operator
 ${LWS_SUB_NAME}=    leader-worker-set
@@ -276,9 +276,9 @@ Get Helm Path For Component
     [Arguments]    ${component}
 
     # Handling of special component cases:
-    # 1. modelsasservice is nested under kserve
+    # 1. modelsasservice is nested under aigateway
     IF    "${component}" == "modelsasservice"
-        RETURN    components.kserve.dsc.modelsAsService.managementState
+        RETURN    components.aigateway.dsc.modelsAsAService.managementState
     END
     # 2. batchgateway is nested under aigateway
     IF    "${component}" == "batchgateway"
@@ -465,7 +465,13 @@ Verify RHODS Installation
     ...    label_selector=app.kubernetes.io/name=spark-operator
   END
 
-  ${modelsasservice} =    Is Nested Component Enabled    kserve    modelsAsService    ${DSC_NAME}
+  ${aigateway} =    Is Component Enabled    aigateway    ${DSC_NAME}
+  IF    "${aigateway}" == "true"
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app.kubernetes.io/name=ai-gateway-operator
+  END
+
+  ${modelsasservice} =    Is Nested Component Enabled    aigateway    modelsAsAService    ${DSC_NAME}
   IF    "${modelsasservice}" == "true"
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=app.kubernetes.io/part-of=modelsasservice
@@ -1444,7 +1450,7 @@ Set Component State
     Log To Console    Component ${component} state was set to ${state}
 
 Set Nested Component State
-    [Documentation]    Set nested component state in Data Science Cluster (e.g., kserve.modelsAsService)
+    [Documentation]    Set nested component state in Data Science Cluster (e.g., aigateway.modelsAsAService)
     [Arguments]    ${parent_component}    ${nested_component}    ${state}
     ${result} =    Run Process    oc get datascienceclusters.datasciencecluster.opendatahub.io -o name
     ...    shell=true    stderr=STDOUT
@@ -1471,7 +1477,7 @@ Get DSC Component State
     RETURN    ${state}
 
 Get DSC Nested Component State
-    [Documentation]    Get nested component management state (e.g., kserve.modelsAsService)
+    [Documentation]    Get nested component management state (e.g., aigateway.modelsAsAService)
     [Arguments]    ${dsc}    ${parent_component}    ${nested_component}    ${namespace}
 
     ${rc}   ${state}=    Run And Return Rc And Output

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -39,6 +39,8 @@ ${OGX_CONTROLLER_MANAGER_LABEL_SELECTOR}                    app.kubernetes.io/pa
 ${OGX_CONTROLLER_MANAGER_DEPLOYMENT_NAME}                   ogx-k8s-operator-controller-manager
 ${MLFLOWOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}         app.kubernetes.io/name=mlflow-operator
 ${MLFLOWOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}        mlflow-operator-controller-manager
+${AIGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}              app.kubernetes.io/name=ai-gateway-operator
+${AIGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}             ai-gateway-operator
 ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}        app.kubernetes.io/part-of=modelsasservice
 ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}       maas-api
 ${SPARKOPERATOR_LABEL_SELECTOR}                             app.kubernetes.io/name=spark-operator
@@ -65,6 +67,7 @@ ${IS_NOT_PRESENT}                                           1
 ...                                                         FEASTOPERATOR=${EMPTY}
 ...                                                         OGX=${EMPTY}
 ...                                                         MLFLOWOPERATOR=${EMPTY}
+...                                                         AIGATEWAY=${EMPTY}
 ...                                                         MODELSASSERVICE=${EMPTY}
 ...                                                         SPARKOPERATOR=${EMPTY}
 ...                                                         AIGATEWAY=${EMPTY}
@@ -704,8 +707,8 @@ Validate Modelsasservice Managed State
     ...    Smoke
 
     Set DSC Nested Component Managed State And Wait For Completion
-    ...    kserve
-    ...    modelsAsService
+    ...    aigateway
+    ...    modelsAsAService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
     Check That Image Pull Path Is Correct
@@ -713,13 +716,13 @@ Validate Modelsasservice Managed State
     ...    ${IMAGE_PULL_PATH}
 
     [Teardown]      Restore Nested Component And Parent State
-    ...    kserve    modelsAsService
+    ...    aigateway    modelsAsAService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
-    ...    ${KSERVE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${KSERVE_CONTROLLER_MANAGER_LABEL_SELECTOR}
-    ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.KSERVE}
+    ...    ${AIGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${AIGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.AIGATEWAY}
 
 Validate Modelsasservice Removed State
-    [Documentation]    Validate that ModelsAsService management state Removed does remove relevant resources.
+    [Documentation]    Validate that ModelsAsAService management state Removed does remove relevant resources.
     [Tags]
     ...    Operator
     ...    Tier1
@@ -727,16 +730,16 @@ Validate Modelsasservice Removed State
     ...    Integration
 
     Set DSC Nested Component Removed State And Wait For Completion
-    ...    kserve
-    ...    modelsAsService
+    ...    aigateway
+    ...    modelsAsAService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
 
     [Teardown]      Restore Nested Component And Parent State
-    ...    kserve    modelsAsService
+    ...    aigateway    modelsAsAService
     ...    ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}
-    ...    ${KSERVE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${KSERVE_CONTROLLER_MANAGER_LABEL_SELECTOR}
-    ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.KSERVE}
+    ...    ${AIGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}    ${AIGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}    ${SAVED_MANAGEMENT_STATES.AIGATEWAY}
 
 Validate Support For Configuration Of Controller Resources
     [Documentation]    Validate support for configuration of controller resources in component deployments
@@ -817,7 +820,8 @@ Suite Setup
     ...    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.BATCHGATEWAY}=    Get DSC Nested Component State    ${DSC_NAME}
     ...    aigateway    batchGateway    ${OPERATOR_NS}
-    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}=    Get DSC Nested Component State    ${DSC_NAME}    kserve    modelsAsService    ${OPERATOR_NS}
+    ${SAVED_MANAGEMENT_STATES.MODELSASSERVICE}=    Get DSC Nested Component State    ${DSC_NAME}
+    ...    aigateway    modelsAsAService    ${OPERATOR_NS}
     Set Suite Variable    ${SAVED_MANAGEMENT_STATES}
     Append To List  ${CONTROLLERS_LIST}    ${DASHBOARD_DEPLOYMENT_NAME}
 

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -45,8 +45,6 @@ ${MODELSASSERVICE_CONTROLLER_MANAGER_LABEL_SELECTOR}        app.kubernetes.io/pa
 ${MODELSASSERVICE_CONTROLLER_MANAGER_DEPLOYMENT_NAME}       maas-api
 ${SPARKOPERATOR_LABEL_SELECTOR}                             app.kubernetes.io/name=spark-operator
 ${SPARKOPERATOR_DEPLOYMENT_NAME}                            spark-operator-controller
-${AIGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}              app.kubernetes.io/name=ai-gateway-operator
-${AIGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}             ai-gateway-operator
 ${BATCHGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}           app.kubernetes.io/name=llm-d-batch-gateway-operator
 ${BATCHGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}          llm-d-batch-gateway-operator
 ${NOTEBOOK_CONTROLLER_DEPLOYMENT_LABEL_SELECTOR}            component.opendatahub.io/name=kf-notebook-controller
@@ -70,7 +68,6 @@ ${IS_NOT_PRESENT}                                           1
 ...                                                         AIGATEWAY=${EMPTY}
 ...                                                         MODELSASSERVICE=${EMPTY}
 ...                                                         SPARKOPERATOR=${EMPTY}
-...                                                         AIGATEWAY=${EMPTY}
 ...                                                         BATCHGATEWAY=${EMPTY}
 
 @{CONTROLLERS_LIST}                                     # dashboard added in Suite Setup, since it's different in RHOAI vs ODH


### PR DESCRIPTION
## Summary

- Migrates DSC template and test framework from deprecated `kserve.modelsAsService` to the new `aigateway.modelsAsAService` format introduced in RHOAI 3.5+
- Adds `aigateway` as a new top-level DSC component (deployment: `ai-gateway-operator`, label: `app.kubernetes.io/name=ai-gateway-operator`)
- Updates all modelsAsService test cases to use `aigateway` as the parent component instead of `kserve`

Resolves [RHOAIENG-77653](https://redhat.atlassian.net/browse/RHOAIENG-77653)

## Context

In RHOAI 3.5, MaaS was modularized from a KServe sub-component to an AI Gateway sub-component. The DSC format changed:

```yaml
# Old (deprecated, still works through 3.6 via handler fallback)
spec.components.kserve.modelsAsService.managementState: Managed

# New (3.5+)
spec.components.aigateway.managementState: Managed
spec.components.aigateway.modelsAsAService.managementState: Managed
```

## Test plan

- [x] Verify aigateway deployment name and label selector match what the ODH/RHOAI operator deploys on a cluster
- [x] Run DSC component tests (`0113__dsc_components.robot`) against a RHOAI 3.5+ cluster
- [x] Verify Managed/Removed state toggling works for `aigateway.modelsAsAService`