### PR TITLE
Remove redundant TensorFlow/PyTorch notebook tests from during-upgrade phase

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0202__during_upgrade.robot
@@ -3,13 +3,7 @@ Documentation       Test Suite for Upgrade testing,to be run during the upgrade
 
 Resource            ../../Resources/ODS.robot
 Resource            ../../Resources/Common.robot
-Resource            ../../Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
-Resource            ../../Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
-Resource            ../../Resources/Page/ODH/ODHDashboard/ODHDashboardSettings.resource
-Resource            ../../Resources/Page/ODH/JupyterHub/ODHJupyterhub.resource
 Library             DebugLibrary
-Library             JupyterLibrary
 
 Test Tags           DuringUpgrade
 
@@ -29,45 +23,8 @@ Upgrade RHODS
     Operator Pod Creation Date Should Be Updated        ${initial_creation_date}
     OpenShiftLibrary.Wait For Pods Status       namespace=${OPERATOR_NAMESPACE}     timeout=300
 
-TensorFlow Image Test
-    [Documentation]    Run basic tensorflow notebook during upgrade
-    [Tags]      Upgrade    IDE
-    Launch Notebook
-    ...    tensorflow
-    ...    ${TEST_USER.USERNAME}
-    ...    ${TEST_USER.PASSWORD}
-    ...    ${TEST_USER.AUTH_TYPE}
-
-PyTorch Image Workload Test
-    [Documentation]    Run basic pytorch notebook during upgrade
-    [Tags]      Upgrade    IDE
-    Launch Notebook
-    ...    pytorch
-    ...    ${TEST_USER.USERNAME}
-    ...    ${TEST_USER.PASSWORD}
-    ...    ${TEST_USER.AUTH_TYPE}
-    Run Repo And Clean
-    ...    https://github.com/lugi0/notebook-benchmarks
-    ...    notebook-benchmarks/pytorch/PyTorch-MNIST-Minimal.ipynb
-    Capture Page Screenshot
-    JupyterLab Code Cell Error Output Should Not Be Visible
-
 
 *** Keywords ***
-Launch Notebook
-    [Documentation]    Launch notebook for the suite
-    [Arguments]     ${notebook_image}=minimal-notebook
-    ...    ${username}=${TEST_USER2.USERNAME}
-    ...    ${password}=${TEST_USER2.PASSWORD}
-    ...    ${auth_type}=${TEST_USER2.AUTH_TYPE}
-    Begin Web Test    username=${username}    password=${password}    auth_type=${auth_type}
-    Launch Jupyter From RHODS Dashboard Link
-    Spawn Notebook With Arguments
-    ...    image=${notebook_image}
-    ...    username=${username}
-    ...    password=${password}
-    ...    auth_type=${auth_type}
-
 RHODS Version Should Be Greater Than
     [Documentation]    Checks if the RHODS version is greater than the given initial version.
     ...    Fails if the version is not greater.


### PR DESCRIPTION
The "TensorFlow Image Test" and "PyTorch Image Workload Test" in 0202__during_upgrade.robot were originally added in PR #779 (May 2023) as a quick smoke check to verify notebook spawning right after the operator upgrade. At that time, there were no dedicated post-upgrade smoke test runs, so these tests were the only notebook verification after an upgrade.

Since then, the upgrade pipeline has been extended to run post-upgrade
smoke tests that include the IDE suite, which triggers the workbench
creation too (though different image flavor), we shouldn't need these tests
anymore. On top of that, we also included some CLI-level only tests for
the workbenches upgrade testing in the opendatahub-tests repository too.

The unique upgrade-specific notebook scenario (verifying a pre-existing
notebook is not restarted during upgrade via timestamp comparison) is
preserved in the pre/post upgrade phases and is unaffected by this
change.


## Summary
- Remove the `TensorFlow Image Test` and `PyTorch Image Workload Test` from `0202__during_upgrade.robot`, along with their supporting `Launch Notebook` keyword and now-unused resource imports
- These tests have been a source of flaky upgrade job failures (timing out on workbench "Ready" status after the operator upgrade)

## Motivation

These two tests were originally introduced in [PR #779](https://github.com/red-hat-data-services/ods-ci/pull/779) (May 2023) as the only notebook spawning verification after an upgrade. Since then, the upgrade pipeline has been extended to run **post-upgrade smoke tests** that include the IDE suite, which triggers the workbench creation too (though different image flavor), we shouldn't need these tests anymore. On top of that, we also included some CLI-level only tests for the workbenches upgrade testing in the opendatahub-tests repository too.

The during-upgrade tests also lack stabilization waits for application-level pods after the operator upgrade, making them inherently fragile — the Dashboard/notebook controller may not be fully ready to process notebook spawn requests immediately after the operator pods come up.

## What is preserved

The **unique** upgrade-specific notebook scenario is unaffected: the pre-upgrade phase starts a long-running notebook and records its creation timestamp in a ConfigMap, and the post-upgrade phase verifies the notebook pod was **not restarted** during the upgrade by comparing timestamps. This is a genuinely upgrade-specific check that cannot be covered by regular smoke tests.

## Test plan
- [ ] Verify the upgrade job still runs successfully (the `Upgrade RHODS` test case is unchanged)
- [ ] Verify post-upgrade smoke tests still cover TensorFlow/PyTorch notebook spawning and workload execution
- [ ] Verify the pre/post notebook restart check (`Long Running Jupyter Notebook` / `Verify Notebook Has Not Restarted`) is unaffected