### PR TITLE
fix: increase GPU operator pod readiness timeouts

### DIFF
--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -52,8 +52,9 @@ function wait_until_pod_ready_status() {
   local pod_label=$1
   local namespace=nvidia-gpu-operator
   local timeout=${2:-600}
-  local start_time=$(date +%s)
-  while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
+  local start_time
+  start_time=$(date +%s)
+  while [ $(($(date +%s) - start_time)) -lt "$timeout" ]; do
      pod_status="$(oc get pod -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
      daemon_status="$(oc get daemonset -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
      if [[ -n "$daemon_status" || -n "$pod_status" ]] ; then
@@ -85,7 +86,7 @@ function rerun_accelerator_migration() {
   # Context: https://github.com/opendatahub-io/odh-dashboard/issues/1938
   echo "Creating NVIDIA Accelerator Profile via RHOAI Dashboard deployment rollout"
   configmap=$(oc get configmap migration-gpu-status --ignore-not-found -n redhat-ods-applications -oname)
-  if [ -z $configmap ];
+  if [ -z "$configmap" ];
     then
       echo "migration-gpu-status not found. Is RHOAI Installed? NVIDIA Accelerator Profile creation SKIPPED."
       return 0

--- a/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
+++ b/ods_ci/tasks/Resources/Provisioning/GPU/NVIDIA/gpu_deploy.sh
@@ -51,7 +51,7 @@ oc wait --timeout=3m --for jsonpath='{.status.components.labelSelector.matchExpr
 function wait_until_pod_ready_status() {
   local pod_label=$1
   local namespace=nvidia-gpu-operator
-  local timeout=${2:-360}
+  local timeout=${2:-600}
   local start_time=$(date +%s)
   while [ $(($(date +%s) - start_time)) -lt $timeout ]; do
      pod_status="$(oc get pod -l app="$pod_label" -n "$namespace" --no-headers=true 2>/dev/null)"
@@ -114,7 +114,7 @@ function rerun_accelerator_migration() {
 wait_until_pod_ready_status  "gpu-operator"
 oc get csv -n nvidia-gpu-operator "$CSVNAME" -o jsonpath='{.metadata.annotations.alm-examples}' | jq .[0] > clusterpolicy.json
 oc apply -f clusterpolicy.json
-wait_until_pod_ready_status "nvidia-device-plugin-daemonset" 600
+wait_until_pod_ready_status "nvidia-device-plugin-daemonset" 1800
 wait_until_pod_ready_status "nvidia-container-toolkit-daemonset"
 wait_until_pod_ready_status "nvidia-dcgm-exporter"
 wait_until_pod_ready_status "gpu-feature-discovery"


### PR DESCRIPTION
  Default timeout raised from 360s to 600s for all GPU pods.
  nvidia-device-plugin-daemonset timeout raised from 600s to 1800s
  to accommodate driver compilation time on first deployment.