### PR TITLE
RHOAIENG-78410: Fix 15-minute polling timeout in MaaS database setup

### DIFF
--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -31,17 +31,25 @@ derive_infra_namespace() {
 
 detect_infra_namespace() {
     local apps_ns="$1"
+    local oc_stderr oc_rc infra_val
+    oc_stderr=$(mktemp)
+    infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
+        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \
+        2>"${oc_stderr}") && oc_rc=0 || oc_rc=$?
 
-    # If maas-controller is already deployed, read INFRA_NAMESPACE from it.
-    # Otherwise fall back to derive_infra_namespace which matches the
-    # operator's AUTO default (RHOAIENG-78410: the old 90×10s polling loop
-    # always timed out when called before the operator was installed).
-    if oc get deployment maas-controller -n "${apps_ns}" &>/dev/null; then
-        local infra_val
-        infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
-            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \
-            2>/dev/null)
-
+    if [[ $oc_rc -ne 0 ]]; then
+        local err_msg
+        err_msg=$(<"${oc_stderr}")
+        rm -f "${oc_stderr}"
+        if [[ "${err_msg}" == *"NotFound"* ]]; then
+            echo "maas-controller not found in ${apps_ns}; using derived infra namespace" >&2
+            derive_infra_namespace "${apps_ns}"
+        else
+            echo "ERROR: unexpected failure querying maas-controller in ${apps_ns}: ${err_msg}" >&2
+            return 1
+        fi
+    else
+        rm -f "${oc_stderr}"
         if [[ "${infra_val}" == "AUTO" ]]; then
             derive_infra_namespace "${apps_ns}"
         elif [[ -n "${infra_val}" ]]; then
@@ -49,9 +57,6 @@ detect_infra_namespace() {
         else
             derive_infra_namespace "${apps_ns}"
         fi
-    else
-        echo "maas-controller not found in ${apps_ns}; using derived infra namespace" >&2
-        derive_infra_namespace "${apps_ns}"
     fi
 }
 

--- a/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
+++ b/ods_ci/tasks/Resources/Database/configure_maas_postgres.sh
@@ -31,31 +31,27 @@ derive_infra_namespace() {
 
 detect_infra_namespace() {
     local apps_ns="$1"
-    
-    # MaaS provisioning may run before the RHOAI operator has fully deployed
-    # the maas-controller (CRD registration, reconciliation, and pod scheduling
-    # can take 10+ minutes after the CSV is ready). Without waiting, detect
-    # would see no controller and fall back to the apps namespace — then when
-    # the operator deploys a controller with INFRA_NAMESPACE=AUTO it looks in
-    # the infra namespace where the secret doesn't exist, and maas-api never
-    # starts. Wait up to 15 minutes to cover slow clusters.
-    echo "Waiting for maas-controller deployment in ${apps_ns}..." >&2
-    for i in $(seq 1 90); do
-        oc get deployment maas-controller -n "${apps_ns}" &>/dev/null && break
-        sleep 10
-    done
 
-    local infra_val
-    infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
-        -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \
-        2>/dev/null)
+    # If maas-controller is already deployed, read INFRA_NAMESPACE from it.
+    # Otherwise fall back to derive_infra_namespace which matches the
+    # operator's AUTO default (RHOAIENG-78410: the old 90×10s polling loop
+    # always timed out when called before the operator was installed).
+    if oc get deployment maas-controller -n "${apps_ns}" &>/dev/null; then
+        local infra_val
+        infra_val=$(oc get deployment maas-controller -n "${apps_ns}" \
+            -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="INFRA_NAMESPACE")].value}' \
+            2>/dev/null)
 
-    if [[ "${infra_val}" == "AUTO" ]]; then
-        derive_infra_namespace "${apps_ns}"
-    elif [[ -n "${infra_val}" ]]; then
-        echo "${infra_val}"
+        if [[ "${infra_val}" == "AUTO" ]]; then
+            derive_infra_namespace "${apps_ns}"
+        elif [[ -n "${infra_val}" ]]; then
+            echo "${infra_val}"
+        else
+            derive_infra_namespace "${apps_ns}"
+        fi
     else
-        echo "${apps_ns}"
+        echo "maas-controller not found in ${apps_ns}; using derived infra namespace" >&2
+        derive_infra_namespace "${apps_ns}"
     fi
 }
 


### PR DESCRIPTION
## Summary
  - Remove the 90×10s polling loop in `detect_infra_namespace` that always timed out when called before the RHOAI operator was installed
  - Fall back to `derive_infra_namespace` (which matches the operator's `AUTO` default) instead of blocking for up to 15 minutes

detect_infra_namespace polled for maas-controller 90×10s (~15 min) but was called before the operator was installed, so the deployment could never exist. Replace the polling loop with a single probe: if the controller exists read INFRA_NAMESPACE from it, otherwise fall back immediately to derive_infra_namespace (matches the operator AUTO default). Also fixes the old else branch which incorrectly returned apps_ns instead of the derived infra namespace.

  ## Test plan
  - [x] Verify MaaS database setup completes without the 15-minute delay on a cluster where maas-controller is not yet deployed
  - [x] Verify correct infra namespace is detected when maas-controller is already running with `INFRA_NAMESPACE=AUTO`
  - [x] Verify explicit `INFRA_NAMESPACE` values are still respected