### PR TITLE
RHOAIENG-65532: Add mcplifecycleoperator support to QE repositories

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -44,3 +44,5 @@ spec:
       managementState: <mlflowoperator_value>
     sparkoperator:
       managementState: <sparkoperator_value>
+    mcplifecycleoperator:
+      managementState: <mcplifecycleoperator_value>

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -29,6 +29,7 @@ ${DSCI_NAME} =    default-dsci
 ...    modelsasservice
 ...    sparkoperator
 ...    batchgateway
+...    mcplifecycleoperator
 # MaaS moved from kserve.modelsAsService to aigateway.modelsAsAService (ODH operator #3723)
 &{NESTED_COMPONENT_TO_PARENT_COMPONENT}=    modelsasservice=aigateway    batchgateway=aigateway
 &{COMPONENT_TO_COMPONENT_NAME_IN_DSC}=    modelsasservice=modelsAsAService    batchgateway=batchGateway
@@ -469,6 +470,12 @@ Verify RHODS Installation
     ...    label_selector=app.kubernetes.io/name=spark-operator
   END
 
+  ${mcplifecycleoperator} =    Is Component Enabled    mcplifecycleoperator    ${DSC_NAME}
+  IF    "${mcplifecycleoperator}" == "true"
+    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=app.kubernetes.io/name=mcp-lifecycle-module-operator
+  END
+
   # AIGateway parent must be ready before nested MaaS / BatchGateway (AGO deploys them).
   ${aigateway} =    Is Component Enabled    aigateway    ${DSC_NAME}
   IF    "${aigateway}" == "true"
@@ -502,7 +509,7 @@ Verify RHODS Installation
     END
   END
 
-  IF    "${dashboard}" == "true" or "${workbenches}" == "true" or "${aipipelines}" == "true" or "${kserve}" == "true" or "${kueue}" == "true" or "${ray}" == "true" or "${trustyai}" == "true" or "${modelregistry}" == "true" or "${trainingoperator}" == "true" or "${sparkoperator}" == "true" or "${aigateway}" == "true" or "${batchgateway}" == "true"    # robocop: disable
+  IF    "${dashboard}" == "true" or "${workbenches}" == "true" or "${aipipelines}" == "true" or "${kserve}" == "true" or "${kueue}" == "true" or "${ray}" == "true" or "${trustyai}" == "true" or "${modelregistry}" == "true" or "${trainingoperator}" == "true" or "${sparkoperator}" == "true" or "${aigateway}" == "true" or "${batchgateway}" == "true" or "${mcplifecycleoperator}" == "true"    # robocop: disable
       Log To Console    Waiting for pod status in ${APPLICATIONS_NAMESPACE}
       Wait For Pods Status  namespace=${APPLICATIONS_NAMESPACE}  timeout=600
       Log  Verified Applications NS: ${APPLICATIONS_NAMESPACE}  console=yes

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -49,6 +49,8 @@ ${BATCHGATEWAY_CONTROLLER_MANAGER_LABEL_SELECTOR}           app.kubernetes.io/na
 ${BATCHGATEWAY_CONTROLLER_MANAGER_DEPLOYMENT_NAME}          llm-d-batch-gateway-operator
 ${SPARKOPERATOR_LABEL_SELECTOR}                             app.kubernetes.io/name=spark-operator
 ${SPARKOPERATOR_DEPLOYMENT_NAME}                            spark-operator-controller
+${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}   app.kubernetes.io/name=mcp-lifecycle-module-operator
+${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}  mcp-lifecycle-module-operator-controller-manager
 ${NOTEBOOK_CONTROLLER_DEPLOYMENT_LABEL_SELECTOR}            component.opendatahub.io/name=kf-notebook-controller
 ${NOTEBOOK_CONTROLLER_MANAGER_LABEL_SELECTOR}               component.opendatahub.io/name=odh-notebook-controller
 ${NOTEBOOK_DEPLOYMENT_NAME}                                 notebook-controller-deployment
@@ -71,6 +73,7 @@ ${IS_NOT_PRESENT}                                           1
 ...                                                         MODELSASSERVICE=${EMPTY}
 ...                                                         SPARKOPERATOR=${EMPTY}
 ...                                                         BATCHGATEWAY=${EMPTY}
+...                                                         MCPLIFECYCLEOPERATOR=${EMPTY}
 
 @{CONTROLLERS_LIST}                                     # dashboard added in Suite Setup, since it's different in RHOAI vs ODH
 ...                                                     data-science-pipelines-operator-controller-manager
@@ -608,6 +611,52 @@ Validate Spark Removed State
     ...    ${SPARKOPERATOR_DEPLOYMENT_NAME}      ${SPARKOPERATOR_LABEL_SELECTOR}
     ...    ${SAVED_MANAGEMENT_STATES.SPARKOPERATOR}
 
+Validate Mcplifecycleoperator Managed State
+    [Documentation]    Validate that the DSC Mcplifecycleoperator component Managed state creates the expected resources,
+    ...    check that MCP Lifecycle Module Operator deployment is created and pod is in Ready state
+    [Tags]
+    ...    Operator
+    ...    Smoke
+    ...    mcplifecycleoperator-managed
+    ...    Integration
+
+    Set DSC Component Managed State And Wait For Completion
+    ...    mcplifecycleoperator
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    Check That Image Pull Path Is Correct
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${IMAGE_PULL_PATH}
+
+    [Teardown]      Restore DSC Component State     mcplifecycleoperator
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    ${SAVED_MANAGEMENT_STATES.MCPLIFECYCLEOPERATOR}
+
+Validate Mcplifecycleoperator Removed State
+    [Documentation]    Validate that Mcplifecycleoperator management state Removed does remove relevant resources.
+    ...                Since mcplifecycleoperator is in tech preview and defaults to Removed state, first set it to Managed
+    ...                to ensure resources exist before testing removal.
+    [Tags]
+    ...    Operator
+    ...    Tier1
+    ...    mcplifecycleoperator-removed
+    ...    Integration
+
+    [Setup]     Set DSC Component Managed State And Wait For Completion     mcplifecycleoperator
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}
+
+    Set DSC Component Removed State And Wait For Completion
+    ...    mcplifecycleoperator
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}
+
+    [Teardown]      Restore DSC Component State     mcplifecycleoperator
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}
+    ...    ${MCPLIFECYCLEOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}
+    ...    ${SAVED_MANAGEMENT_STATES.MCPLIFECYCLEOPERATOR}
+
 Validate AIGateway Managed State
     [Documentation]    Validate that the DSC AIGateway component Managed state creates the expected resources,
     ...    check that AIGateway deployment is created and pod is in Ready state
@@ -825,6 +874,8 @@ Suite Setup
     ${SAVED_MANAGEMENT_STATES.OGX}=    Get DSC Component State    ${DSC_NAME}    ogx    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.MLFLOWOPERATOR}=    Get DSC Component State    ${DSC_NAME}    mlflowoperator    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.SPARKOPERATOR}=    Get DSC Component State    ${DSC_NAME}    sparkoperator
+    ...    ${OPERATOR_NS}
+    ${SAVED_MANAGEMENT_STATES.MCPLIFECYCLEOPERATOR}=    Get DSC Component State    ${DSC_NAME}    mcplifecycleoperator
     ...    ${OPERATOR_NS}
     ${SAVED_MANAGEMENT_STATES.BATCHGATEWAY}=    Get DSC Nested Component State    ${DSC_NAME}
     ...    aigateway    batchGateway    ${OPERATOR_NS}


### PR DESCRIPTION
## Summary
- Add `mcplifecycleoperator` to the DSC YAML template with `<mcplifecycleoperator_value>` placeholder
- Add `mcplifecycleoperator` to `COMPONENT_LIST` and `Verify RHODS Installation` readiness check (label selector: `app.kubernetes.io/name=mcp-lifecycle-module-operator`)
- Add `Validate Mcplifecycleoperator Managed State` and `Validate Mcplifecycleoperator Removed State` integration test cases to `0113__dsc_components.robot`

## Jira
[RHOAIENG-65532](https://redhat.atlassian.net/browse/RHOAIENG-65532) — Add support for the new component in the QE related repositories

## Test plan
- [x] `Validate Mcplifecycleoperator Managed State` — passed on RHOAI 3.5 nightly cluster
- [x] `Validate Mcplifecycleoperator Removed State` — passed on RHOAI 3.5 nightly cluster
- Tests run with: `sh run_robot_test.sh --include mcplifecycleoperator-managed --include mcplifecycleoperator-removed`

## Notes
- Component defaults to `Removed` (Tech Preview); the Removed test includes a `[Setup]` that first sets it to Managed before validating removal
- Deployment name: `mcp-lifecycle-module-operator-controller-manager`
- Label selector: `app.kubernetes.io/name=mcp-lifecycle-module-operator`
- Related upstream bug: [RHOAIENG-78873](https://redhat.atlassian.net/browse/RHOAIENG-78873)

🤖 Generated with [Claude Code](https://claude.com/claude-code)