### PR TITLE
Deprecate DW metrics UI upgrade tests (moved to shift-left)

### DIFF
--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot
@@ -159,7 +159,7 @@ Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    Creates the Ray Cluster and verify resource usage
-    [Tags]      Upgrade    WorkloadOrchestration
+    [Tags]      Upgrade    WorkloadOrchestration    deprecatedTest
     [Setup]     Prepare Codeflare-SDK Pre Upgrade Test Setup
     ${PRJ_UPGRADE}=     Set Variable        test-ns-rayupgrade
     ${JOB_NAME}=        Set Variable        mnist

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -206,7 +206,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
     # robocop: off=too-long-test-case
     # robocop: off=too-many-calls-in-test-case
     [Documentation]    check the Ray Cluster exists , submit ray job and    verify resource usage after upgrade
-    [Tags]      Upgrade    WorkloadOrchestration
+    [Tags]      Upgrade    WorkloadOrchestration    deprecatedTest
     [Setup]     Prepare Codeflare-SDK Test Setup
     ${PRJ_UPGRADE}      Set Variable        test-ns-rayupgrade
     ${LOCAL_QUEUE}      Set Variable        local-queue-mnist


### PR DESCRIPTION
 ## Summary

  - Add `deprecatedTest` tag to the Distributed Workloads metrics UI tests in pre/post upgrade Robot suites
  - These tests are replaced by shift-left codeflare-sdk containerized tests in `opendatahub-tests`

  ## Problem

  The Robot Framework tests `Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload` (pre-upgrade) and `Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job After
  Upgrade` (post-upgrade) open a browser via Selenium to verify the Dashboard Distributed Workloads page.

  These tests have **no `[Timeout]`** and the suite has no `Test Timeout`. When the Selenium session stalls on Dashboard page load (e.g., after Kueue state changes from shift-left codeflare-sdk tests), the Robot
  process hangs indefinitely — **blocking Jenkins builds for 20-34 hours** until manually aborted.

  **Observed in:**
  - Build #4: http://10.0.78.154:8080/job/rhoai/job/2.25/job/selfmanaged/job/cli/job/aws/job/rhoai-upgrade/4/
  - Build #6: Hung for 34 hours on this test
  - Build #7: Hung for 23 hours on this test

  ## Why deprecate instead of fix the timeout

  1. The DW upgrade validation is already covered by the **shift-left codeflare-sdk tests** (`opendatahub-tests` repo), making these Robot UI tests redundant
  3. Related Jenkins MR to stop running redundant shift-left tests on 2.25: https://gitlab.cee.redhat.com/ods/jenkins/-/merge_requests/2190

  ## Changes

  | File | Change |
  |------|--------|
  | `ods_ci/tests/Tests/0200__rhoai_upgrade/0201__pre_upgrade.robot` | Add `deprecatedTest` tag to `Verify Distributed Workload Metrics Resources By Creating Ray Cluster Workload` |
  | `ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot` | Add `deprecatedTest` tag to `Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job After Upgrade` |

  Jenkins upgrade jobs already run with `-e deprecatedTest`, so these tests will be skipped automatically.

  ## Test plan

  - [ ] Verify upgrade job runs without hanging on DW metrics UI tests
  - [ ] Verify shift-left codeflare-sdk tests still cover DW upgrade validation
  - [ ] Confirm no other tests depend on these via `[Setup]`/`[Teardown]` side effects

  Ref: [RHOAIENG-76664](https://redhat.atlassian.net/browse/RHOAIENG-76664)
