### PR TITLE
Fix(oc_install): Change label used for checking readiness of OGX

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -454,7 +454,7 @@ Verify RHODS Installation
   ${ogx} =     Is Component Enabled    ogx    ${DSC_NAME}
   IF    "${ogx}" == "true"
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
-    ...    label_selector=platform.opendatahub.io/part-of=ogx
+    ...    label_selector=app.kubernetes.io/name=ogx-k8s-operator
   END
 
   ${mlflowoperator} =    Is Component Enabled    mlflowoperator    ${DSC_NAME}

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -35,7 +35,7 @@ ${TRUSTYAI_CONTROLLER_MANAGER_LABEL_SELECTOR}               app.kubernetes.io/pa
 ${TRUSTYAI_CONTROLLER_MANAGER_DEPLOYMENT_NAME}              trustyai-service-operator-controller-manager
 ${FEASTOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}          app.kubernetes.io/part-of=feastoperator
 ${FEASTOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}         feast-operator-controller-manager
-${OGX_CONTROLLER_MANAGER_LABEL_SELECTOR}                    platform.opendatahub.io/part-of=ogx
+${OGX_CONTROLLER_MANAGER_LABEL_SELECTOR}                    app.kubernetes.io/name=ogx-k8s-operator
 ${OGX_CONTROLLER_MANAGER_DEPLOYMENT_NAME}                   ogx-k8s-operator-controller-manager
 ${MLFLOWOPERATOR_CONTROLLER_MANAGER_LABEL_SELECTOR}         app.kubernetes.io/name=mlflow-operator
 ${MLFLOWOPERATOR_CONTROLLER_MANAGER_DEPLOYMENT_NAME}        mlflow-operator-controller-manager


### PR DESCRIPTION
component

There are different labels on `Deployment` and `Pod` of OGX, this fix changes label to the common one.

Signed-off-by: Radim Kubis, rkubis@redhat.com