### PR TITLE
Fix RHOAI 3.5 test failures: dismiss What's New modal and update Elyra runtime image names

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -92,6 +92,7 @@ Login To RHODS Dashboard
    END
    ${authorize_service_account}=  Is rhods-dashboard Service Account Authorization Required
    IF  ${authorize_service_account}  Authorize rhods-dashboard service account
+   Maybe Close Whats New Modal
 
 Logout From RHODS Dashboard
     [Documentation]  Logs out from the current user in the RHODS dashboard
@@ -109,6 +110,7 @@ Wait For RHODS Dashboard To Load
     ${half_timeout}=   Evaluate    int(${timeout}) / 2
     Wait For Condition    return document.title == ${dashboard_title}    timeout=${half_timeout}
     Wait Until Page Contains Element    xpath:${RHODS_LOGO_XPATH}    timeout=${timeout}
+    Maybe Close Whats New Modal
     IF    "${expected_page}" == "${NONE}"
         Wait Until Page Contains Element    //div[@data-testid="home-page"]    timeout=${timeout}
     ELSE
@@ -117,6 +119,15 @@ Wait For RHODS Dashboard To Load
     END
     IF    ${wait_for_cards} == ${TRUE}
         Wait Until Keyword Succeeds    3 times   5 seconds    Wait Until Cards Are Loaded
+    END
+
+Maybe Close Whats New Modal
+    [Documentation]    Closes the "What's New" modal if it appears after dashboard login
+    ${is_modal}=    Run Keyword And Return Status
+    ...    Wait Until Page Contains Element    xpath://div[@data-testid="whats-new-modal"]    timeout=5s
+    IF    ${is_modal}
+        Click Element    xpath://button[@data-testid="whats-new-skip-tour"]
+        Wait Until Page Does Not Contain Element    xpath://div[@data-testid="whats-new-modal"]    timeout=10s
     END
 
 Wait For Dashboard Page Title

--- a/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
+++ b/ods_ci/tests/Tests/0500__ide/0502__ide_elyra.robot
@@ -44,7 +44,7 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Image
     [Timeout]    10m
     Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     ...    img=Jupyter | Data Science | CPU | Python 3.12
-    ...    runtime_image=Runtime | Datascience | CPU | Python 3.12
+    ...    runtime_image=Runtime | Datascience | CPU | Python 3.12 | Latest
     ...    pipeline_name=standard-data-science-pipeline
 
 Verify Pipelines Integration With Elyra When Using Standard Data Science Based Images
@@ -55,9 +55,9 @@ Verify Pipelines Integration With Elyra When Using Standard Data Science Based I
     [Template]    Verify Pipelines Integration With Elyra Running Hello World Pipeline Test
     [Tags]        Tier1    ODS-2271
     [Timeout]     40m
-    Jupyter | PyTorch | CUDA | Python 3.12       Runtime | Datascience | CPU | Python 3.12    pytorch-pipeline      600s
-    Jupyter | TensorFlow | CUDA | Python 3.12    Runtime | Datascience | CPU | Python 3.12    tensorflow-pipeline   600s
-    Jupyter | TrustyAI | CPU | Python 3.12       Runtime | Datascience | CPU | Python 3.12    trustyai-pipeline     600s
+    Jupyter | PyTorch | CUDA | Python 3.12       Runtime | Datascience | CPU | Python 3.12 | Latest    pytorch-pipeline      600s
+    Jupyter | TensorFlow | CUDA | Python 3.12    Runtime | Datascience | CPU | Python 3.12 | Latest    tensorflow-pipeline   600s
+    Jupyter | TrustyAI | CPU | Python 3.12       Runtime | Datascience | CPU | Python 3.12 | Latest    trustyai-pipeline     600s
 
 
 *** Keywords ***


### PR DESCRIPTION
## Summary

- Dismiss the new "What's New" modal that RHOAI 3.5 shows on dashboard login, which blocks all page interaction and causes IDE test failures.
- Update Elyra pipeline runtime image references to include the new "| Latest" suffix added in RHOAI 3.5.

## Changes

### What's New modal (`ODHDashboard.robot`)
- Add `Maybe Close Whats New Modal` keyword that detects the modal (`data-testid="whats-new-modal"`) and clicks "Close" (`data-testid="whats-new-skip-tour"`) if present.
- Call it from `Login To RHODS Dashboard` (covers all login flows, including edge cases that skip the load wait).
- Call it from `Wait For RHODS Dashboard To Load` (covers post-navigation scenarios).

### Elyra runtime image name (`0502__ide_elyra.robot`)
- Update `Runtime | Datascience | CPU | Python 3.12` to `Runtime | Datascience | CPU | Python 3.12 | Latest` in 4 test cases to match the renamed runtime image in RHOAI 3.5.