### PR TITLE
Fix XPath locator for pipeline run name in Elyra submission dialog

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/Elyra.resource
@@ -107,7 +107,7 @@ Select Runtime Config
 
 Get Pipeline Run Name
     [Documentation]    Gets the run ID after a pipeline is successfully submitted
-    ${job_id} =    Get Text    xpath=//a[.="Run Details."]/../p
+    ${job_id} =    Get Text    xpath=//a[.="Run Details."]/../following-sibling::p
     ${job_id} =    Fetch From Right    ${job_id}    /
     ${job_id} =    Fetch From Left    ${job_id}    working directory
     ${job_id} =    Strip String    ${job_id}


### PR DESCRIPTION
The HTML structure of the Elyra pipeline submission success dialog changed, moving the run name paragraph to a sibling element rather than a direct child. Update the XPath from `../p` to `../following-sibling::p` to correctly locate the pipeline run name.

Fixed for the RHOAI 3.5.0-GA that introduced the Elyra 4.0.0.

This should be hopefully the final fix for the elyra test:
```
./run_robot_test.sh --extra-robot-args '-i ODS-2197' --open-report true --skip-oclogin
```
<img width="845" height="279" alt="image" src="https://github.com/user-attachments/assets/63966058-168b-4f66-9937-dba010366ebf" />
