### PR TITLE
[release-2.25] fix two transient-wait races wasting CI time on every notebook spawn and git clone

### DIFF
--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -153,19 +153,24 @@ Lists Size Should Be Equal
     Should Be Equal As Integers  ${length_one}  ${length_two}
 
 Page Should Contain A String In List
-    [Documentation]    Verifies that page contains at least one of the strings in text_list
+    [Documentation]    Verifies that page contains at least one of the strings in text_list.
+    ...    Returns the first matching string in list order (list order defines
+    ...    precedence when more than one candidate is simultaneously present).
     [Arguments]  ${text_list}
     FOR    ${text}    IN    @{text_list}
         ${text_found}=    Run Keyword And Return Status    Page Should Contain   ${text}
-        IF  ${text_found}    RETURN
+        IF  ${text_found}    RETURN    ${text}
     END
     Fail    Current page doesn't contain any of the strings in: @{text_list}
 
 Wait Until Page Contains A String In List
-    [Documentation]    Waits until page contains at least one of the strings in text_list
+    [Documentation]    Waits until page contains at least one of the strings in text_list.
+    ...    Returns the first matching string in list order (see
+    ...    Page Should Contain A String In List for precedence semantics).
     [Arguments]    ${text_list}    ${retry}=12x    ${retry_interval}=5s
-    Wait Until Keyword Succeeds    ${retry}   ${retry_interval}
+    ${matched} =    Wait Until Keyword Succeeds    ${retry}   ${retry_interval}
     ...    Page Should Contain A String In List     ${text_list}
+    RETURN    ${matched}
 
 #robocop: disable: line-too-long
 Get RHODS Version

--- a/ods_ci/tests/Resources/Common.robot
+++ b/ods_ci/tests/Resources/Common.robot
@@ -168,7 +168,7 @@ Wait Until Page Contains A String In List
     ...    Returns the first matching string in list order (see
     ...    Page Should Contain A String In List for precedence semantics).
     [Arguments]    ${text_list}    ${retry}=12x    ${retry_interval}=5s
-    ${matched} =    Wait Until Keyword Succeeds    ${retry}   ${retry_interval}
+    ${matched}=    Wait Until Keyword Succeeds    ${retry}   ${retry_interval}
     ...    Page Should Contain A String In List     ${text_list}
     RETURN    ${matched}
 

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot
@@ -350,11 +350,15 @@ Spawn Notebook With Arguments  # robocop: disable
                 END
             END
             Spawn Notebook    ${spawner_timeout}    ${same_tab}
-            Run Keyword And Warn On Failure    Wait Until Page Contains    Log in with    timeout=15s
-            ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
-            IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
-            Run Keyword And Warn On Failure   Login To Openshift  ${username}  ${password}  ${auth_type}
-            Verify Service Account Authorization Not Required
+            ${status}    ${matched} =    Run Keyword And Warn On Failure
+            ...    Wait Until Page Contains Text Or Visible Element
+            ...    Log in with    ${JL_TABBAR_CONTENT_XPATH}    retry=15x    retry_interval=1s
+            IF    "${status}" == "FAIL" or "${matched}" != "element"
+                ${oauth_prompt_visible} =    Is OpenShift OAuth Login Prompt Visible
+                IF  ${oauth_prompt_visible}    Click Button     Log in with OpenShift
+                Run Keyword And Warn On Failure   Login To Openshift  ${username}  ${password}  ${auth_type}
+                Verify Service Account Authorization Not Required
+            END
 
             Wait Notebook To Be Loaded  ${image}    ${version}
             ${spawn_fail} =  Has Spawn Failed

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -252,6 +252,25 @@ JupyterLab Is Visible
   ${jupyterlab_visible} =  Run Keyword and Return Status  Wait Until Element Is Visible  xpath:${JL_TABBAR_CONTENT_XPATH}  timeout=30
   RETURN  ${jupyterlab_visible}
 
+Page Contains Text Or Visible Element
+    [Documentation]    Returns "text" if ${text} is present on the page, or "element" if the
+    ...    element at ${element_xpath} is visible. Fails if neither is true.
+    [Arguments]    ${text}    ${element_xpath}
+    ${text_found} =    Run Keyword And Return Status    Page Should Contain    ${text}
+    IF    ${text_found}    RETURN    text
+    ${element_found} =    Run Keyword And Return Status
+    ...    Element Should Be Visible    xpath:${element_xpath}
+    IF    ${element_found}    RETURN    element
+    Fail    Neither '${text}' nor visible element '${element_xpath}' found on page
+
+Wait Until Page Contains Text Or Visible Element
+    [Documentation]    Waits until the page contains the given text OR the given element is visible.
+    ...    Returns "text" or "element" depending on which matched first.
+    [Arguments]    ${text}    ${element_xpath}    ${retry}=15x    ${retry_interval}=1s
+    ${matched} =    Wait Until Keyword Succeeds    ${retry}    ${retry_interval}
+    ...    Page Contains Text Or Visible Element    ${text}    ${element_xpath}
+    RETURN    ${matched}
+
 Wait Until JupyterLab Is Loaded
   [Arguments]   ${timeout}=60
   Wait Until Element Is Visible  xpath:${JL_TABBAR_CONTENT_XPATH}  timeout=${timeout}

--- a/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
+++ b/ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot
@@ -617,11 +617,22 @@ Clone Repo
 
 
 Clone Repo and Return Error Message
-    [Documentation]    Clones the github repository and returns the error
+    [Documentation]    Clones the github repository and returns the error.
     [Tags]    Private Keyword
     [Arguments]    ${repo_url}
     Clone Repo    ${repo_url}
-    Run Keyword And Warn On Failure    Wait Until Page Contains    Cloning...    timeout=5s
+    ${matched} =    Wait Until Page Contains A String In List
+    ...    ${{["Successfully cloned", "Failed to clone", "Cloning..."]}}
+    ...    retry=5x    retry_interval=1s
+    IF    "${matched}" == "Cloning..."
+        Log    Clone still in progress, extending wait    console=yes
+        ${matched} =    Wait Until Page Contains A String In List
+        ...    ${{["Successfully cloned", "Failed to clone"]}}
+        ...    retry=30x    retry_interval=1s
+    END
+    IF    "${matched}" == "Successfully cloned"
+        Fail    msg=Clone succeeded, no error to report
+    END
     ${err_msg} =    Get Git Clone Error Message
     RETURN    ${err_msg}
 


### PR DESCRIPTION
## Summary

Two independent, 100%-reproducible timing-race bugs found while triaging CI in a downstream consumer (`jiridanek/rhoai-in-kind`), both caused by the same underlying pattern: waiting for a specific transient/expected string that has often already come and gone (or hasn't shown up yet) by the time the wait starts polling, instead of racing against the actual set of possible states.

- **Commit 1** fixes [#3025](https://github.com/red-hat-data-services/ods-ci/issues/3025): a ~75-80s wasted defensive re-login check that runs unconditionally after every `Spawn Notebook`, even when JupyterLab's own Launcher is already visible.
- **Commit 2** fixes [#3026](https://github.com/red-hat-data-services/ods-ci/issues/3026): a ~8.25s wasted wait on every successful git clone, caused by polling for a transient "Cloning..." toast that a fast clone has already passed, followed by an unconditional 3s wait for "Failed to clone" even on success.

Both fixes follow the same technique: instead of waiting for one specific string with a fixed timeout, race against the actual set of possible terminal (and, for the clone fix, transient-but-informative) states, and branch on which one wins.

## Bug 1: redundant post-spawn login re-check (#3025)

<img width="200" height="88" alt="bug1-before-jupyterlab-already-visible-during-login-recheck" src="https://github.com/user-attachments/assets/2c3f0d83-3a7c-49a4-aac6-3b6ed514ee1d"/>

**File:** `ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterHubSpawner.robot` (+ one new shared helper in `JupyterLabLauncher.robot`)

After `Spawn Notebook` succeeds, the browser is often already on JupyterLab's own Launcher page, but the code unconditionally still ran a defensive OpenShift re-login check: a standalone `Wait Until Page Contains "Log in with" timeout=15s` (already a pure duplicate — `Login To Openshift`'s own internal race already checks for that same string as one of its 4 candidates) followed by `Login To Openshift`'s own ~60s internal retry. When JupyterLab has already loaded, both waits are guaranteed to fail, at a cost of ~75-80s per spawn.

The fix races the same "Log in with" text against JupyterLab's own `${JL_TABBAR_CONTENT_XPATH}` locator (already used elsewhere by `JupyterLab Is Visible`), reusing the *exact* 15s budget the original code already allocated for this decision point — no new arbitrary timeout is introduced. Genuinely-needed logins are unaffected byte-for-byte (same 15s+60s path, unchanged code); already-arrived cases now resolve in ~1-2s instead of ~80s.

## Bug 2: git-clone toast-wait race (#3026)

<img width="200" height="88" alt="bug2-before-clone-already-succeeded-during-cloning-wait" src="https://github.com/user-attachments/assets/68beb3cb-b1d4-4cb6-8cd2-c3cd621472f3"/>
<img width="200" height="88" alt="bug2-before-wasted-failed-to-clone-wait" src="https://github.com/user-attachments/assets/dfd5c94d-c817-4841-8cd5-e21ec84f4e56"/>

**Files:** `ods_ci/tests/Resources/Common.robot` (return-value addition), `ods_ci/tests/Resources/Page/ODH/JupyterHub/JupyterLabLauncher.robot`

`Clone Repo and Return Error Message` waited for a transient "Cloning..." toast that's already gone on fast/small-repo clones (confirmed via CI screenshot: the "Successfully cloned" toast was already visible when the "Cloning..." wait timed out), then `Get Git Clone Error Message` unconditionally waited 3 more seconds for "Failed to clone" even on success.

The clone flow is really a 3-state machine: an optional transient state ("Cloning...") followed by one of two terminal states ("Successfully cloned" / "Failed to clone"). The fix extends `Page Should Contain A String In List` / `Wait Until Page Contains A String In List` (`Common.robot`) to return which string matched — additive, backward-compatible (no existing caller captured the return value before) — then races all three candidates. A genuine terminal state wins immediately; if the transient "Cloning..." toast is observed instead, it's logged (a useful diagnostic for slow clones, currently invisible) and the wait is extended with a bigger budget for just the two terminal states, rather than padding every clone with a large fixed timeout up front.

**Contract note (worth a careful look in review):** the sole caller, `Clone Git Repository`, uses `Run Keyword and Ignore Error` and interprets `PASS` from `Clone Repo and Return Error Message` as "clone succeeded with an unexpected error present" (triggering its delete-and-retry path) and `FAIL` as "no error, clone genuinely succeeded." So `Clone Repo and Return Error Message` must **raise** on a successful clone and **return normally with the error text** on a genuine failure — this looks backwards at a glance. An earlier draft of this fix used a plain early `RETURN` on the success branch, which would have inverted this and made `Clone Git Repository` fail on *every* successful clone. The current fix uses `Fail msg=Clone succeeded, no error to report` on the success branch specifically to preserve the existing contract. Flagging this here in case it's non-obvious to reviewers too.

## Validation

<img width="1000" height="620" alt="infographic" src="https://github.com/user-attachments/assets/4aaa5fd0-25d1-43ba-b563-6264a383443d"/>

**Primary, main evidence: validated end-to-end on a real, freshly-provisioned ROSA HCP OpenShift cluster** — 2× `m5.2xlarge` workers (x86_64, CPU-only, no GPU), OCP 4.21.0, RHOAI 2.25.9 installed via OperatorHub (`stable-2.25`, `dashboard`+`workbenches` components). This exercises real OAuth (htpasswd IdP), real image pulls from `registry.redhat.io`, and real network latency — none of which the local `kind`/fake-OAuth setup used in an earlier validation pass (see below) can fully reproduce.

Two runs each, same warmed-up node/image cache, differing only by which branch (`release-2.25` baseline vs. this PR's fix) was checked out — isolating the code change from cold-cache noise:

**Bug 1** — `Verify All OOTB Images Spawn Previous Versions` (`multiple-image-tags.robot`), which spawns 5 notebook images in sequence in one authenticated session:

| | Before (`release-2.25`) | After (this PR) |
|---|---|---|
| Total suite time | 1107.02 s | 730.75 s |
| Redundant login-recheck WARNs | 4 | 0 |
| Result | PASS | PASS |

**34% faster**, with the redundant re-check completely eliminated (4→0 WARNs) and no functional regression (both PASS with identical assertions). Each "before" WARN pair cost ~94s (measured, including page-settle overhead) — matching the original bug analysis. The screenshot above was captured at the moment of one of these failed waits: JupyterLab's Launcher is already fully rendered, so there was never a login page to find.

**Bug 2** — `PyTorch Image Workload Test` (`minimal-pytorch-test.robot`), which clones a real GitHub repo (`lugi0/notebook-benchmarks`) into the running notebook via JupyterLab's git extension:

| | Before | After |
|---|---|---|
| `Clone Repo and Return Error Message` duration | 10.796 s | 4.499 s |
| Wasted "Failed to clone" wait on a successful clone | 3.548 s (ran to completion) | 0 s (`NOT RUN` — short-circuited) |
| Result | PASS | PASS |

**58% faster** on the clone-wait step, by eliminating the guaranteed-to-fail 3s "Failed to clone" wait that ran on every successful clone. The screenshots above show the real evidence: at the exact moment the old code is still waiting on the transient "Cloning..." toast (5s budget), the "Successfully cloned" toast is already visible and about to disappear — the transient state had already come and gone.

Both runs PASS on both branches for both tests — the fix removes wasted waits with zero functional regression. Additionally verified via `robot --dryrun` (both files parse cleanly, all keyword calls resolve against the real call chains) and `robocop` (no new issues beyond pre-existing, unrelated style debt already present in these files).

Full write-up, logs, and xunit timing data:

* [SUMMARY.md](https://github.com/user-attachments/files/30853532/SUMMARY.md)

[bug1-before.log](https://github.com/user-attachments/files/30853555/bug1-before.log)
[bug1-before-xunit.xml](https://github.com/user-attachments/files/30853556/bug1-before-xunit.xml)
[bug1-after.log](https://github.com/user-attachments/files/30853552/bug1-after.log)
[bug1-after-xunit.xml](https://github.com/user-attachments/files/30853554/bug1-after-xunit.xml)
[bug2-before.log](https://github.com/user-attachments/files/30853559/bug2-before.log)
[bug2-before-xunit.xml](https://github.com/user-attachments/files/30853560/bug2-before-xunit.xml)
[bug2-after.log](https://github.com/user-attachments/files/30853557/bug2-after.log)
[bug2-after-xunit.xml](https://github.com/user-attachments/files/30853558/bug2-after-xunit.xml)

**Earlier local validation pass (superseded by the above, kept for transparency):** an initial attempt against a local `kind`-based OpenShift AI deployment reproduced Bug 2's original failure exactly (matching the CI evidence in #3026), and confirmed Bug 1's fallback path stays intact when a genuine login is required — but that environment's fake OAuth provider forces a fresh login on *every* spawn, so it couldn't reproduce Bug 1's "guaranteed-skip" timing win, and after ~90 minutes of continuous Selenium automation it showed clear resource-exhaustion artifacts (keyword calls slowing 20x) unrelated to this change, before a clean "after" repro of Bug 2's happy path could be captured. The real-cluster run above has none of these caveats and is the evidence this PR should be judged on.

## Not included in this PR

- No test exercises the git-clone *failure* path at all today (nothing calls `Clone Git Repository` with a bad URL anywhere in the suite) — tracked separately in [jiridanek/rhoai-in-kind#60](https://github.com/jiridanek/rhoai-in-kind/issues/60), out of scope for this perf fix.
- `master` branch may have drifted from `release-2.25` for this code — not checked here, flagging for maintainers to assess separately if a backport/forward-port is wanted.

Fixes #3025
Fixes #3026
