### PR TITLE
fix: version-aware MaaS DSC field selection for 3.4 vs 3.5 clusters

### DIFF
--- a/ods_ci/tasks/Resources/Files/dsc_template.yml
+++ b/ods_ci/tasks/Resources/Files/dsc_template.yml
@@ -12,6 +12,8 @@ spec:
       managementState: <aipipelines_value>
     kserve:
       managementState: <kserve_value>
+      modelsAsService:
+        managementState: <modelsasservice_legacy_value>
     aigateway:
       managementState: <aigateway_value>
       modelsAsAService:

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -870,14 +870,15 @@ Create DataScienceCluster CustomResource Using Test Variables
     ${file_path} =    Set Variable    tasks/Resources/Files/
     Copy File    source=${file_path}${dsc_template}    destination=${file_path}dsc_apply.yml
     Run    sed -i'' -e 's/<dsc_name>/${dsc_name}/' ${file_path}dsc_apply.yml
-    # Detect installed RHOAI version to select the correct MaaS DSC field.
+    # Detect whether this cluster uses the 3.5+ MaaS DSC field (aigateway.modelsAsAService)
+    # or the legacy 3.4 field (kserve.modelsAsService). Check the installed CRD schema
+    # directly — this works for both ODH and RHOAI and is version-string-independent.
     # In 3.5+, MaaS moved from kserve.modelsAsService → aigateway.modelsAsAService (operator #3723).
-    # On 3.4.x clusters the aigateway.* fields are unknown and silently dropped, so we must
-    # populate kserve.modelsAsService instead and leave aigateway out of the MaaS config.
-    ${_csv_version} =    Run
-    ...    oc get csv -n ${OPERATOR_NAMESPACE} -o jsonpath='{.items[?(@.spec.displayName=="Red Hat OpenShift AI")].spec.version}' 2>/dev/null || echo "0.0.0"
-    ${_is_pre_35} =    Evaluate    '${_csv_version}'.startswith('3.4') or ('${_csv_version}' != '0.0.0' and '${_csv_version}' < '3.5')
-    Log To Console    Detected RHOAI version: ${_csv_version} — pre-3.5 MaaS path: ${_is_pre_35}
+    # On 3.4.x clusters, aigateway.* fields are unknown and silently dropped by the API server.
+    ${_aigateway_in_schema} =    Run
+    ...    oc get crd datascienceclusters.datasciencecluster.opendatahub.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.components.properties.aigateway.properties.modelsAsAService}' 2>/dev/null
+    ${_is_pre_35} =    Evaluate    '${_aigateway_in_schema}' == ''
+    Log To Console    aigateway.modelsAsAService in DSC CRD schema: ${_aigateway_in_schema != ''} — pre-3.5 MaaS path: ${_is_pre_35}
     ${maas_configured} =    Run Keyword And Return Status
     ...    Dictionary Should Contain Key    ${COMPONENTS}    modelsasservice
     IF    ${maas_configured} and '${COMPONENTS.modelsasservice}' == 'Managed'

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -884,11 +884,8 @@ Create DataScienceCluster CustomResource Using Test Variables
     ${_crd_rc}    ${_aigateway_in_schema} =    Run And Return Rc And Output
     ...    oc get crd datascienceclusters.datasciencecluster.opendatahub.io
     ...    -o jsonpath='${_crd_jsonpath}' 2>/dev/null
-    IF    ${_crd_rc} != 0
-        Log To Console    WARNING: CRD query failed (rc=${_crd_rc}); defaulting to 3.5+ MaaS path
-    END
     ${_is_pre_35} =    Evaluate    ${_crd_rc} == 0 and '${_aigateway_in_schema}' == ''
-    Log To Console    DSC CRD aigateway.modelsAsAService present: ${not ${_is_pre_35}}
+    Log To Console    DSC CRD rc=${_crd_rc} aigateway.modelsAsAService present: ${not ${_is_pre_35}}
     ${maas_configured} =    Run Keyword And Return Status
     ...    Dictionary Should Contain Key    ${COMPONENTS}    modelsasservice
     IF    ${maas_configured} and '${COMPONENTS.modelsasservice}' == 'Managed'

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -875,10 +875,20 @@ Create DataScienceCluster CustomResource Using Test Variables
     # directly — this works for both ODH and RHOAI and is version-string-independent.
     # In 3.5+, MaaS moved from kserve.modelsAsService → aigateway.modelsAsAService (operator #3723).
     # On 3.4.x clusters, aigateway.* fields are unknown and silently dropped by the API server.
-    ${_aigateway_in_schema} =    Run
-    ...    oc get crd datascienceclusters.datasciencecluster.opendatahub.io -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.properties.components.properties.aigateway.properties.modelsAsAService}' 2>/dev/null
-    ${_is_pre_35} =    Evaluate    '${_aigateway_in_schema}' == ''
-    Log To Console    aigateway.modelsAsAService in DSC CRD schema: ${_aigateway_in_schema != ''} — pre-3.5 MaaS path: ${_is_pre_35}
+    # Use the storage version to avoid hardcoding version index.
+    # Empty output on non-zero rc → legacy path; non-zero exit treated as unknown (safe default).
+    ${_crd_jsonpath} =    Set Variable
+    ...    {.spec.versions[?(@.storage==true)].schema.openAPIV3Schema
+    ...    .properties.spec.properties.components
+    ...    .properties.aigateway.properties.modelsAsAService}
+    ${_crd_rc}    ${_aigateway_in_schema} =    Run And Return Rc And Output
+    ...    oc get crd datascienceclusters.datasciencecluster.opendatahub.io
+    ...    -o jsonpath='${_crd_jsonpath}' 2>/dev/null
+    IF    ${_crd_rc} != 0
+        Log To Console    WARNING: CRD query failed (rc=${_crd_rc}); defaulting to 3.5+ MaaS path
+    END
+    ${_is_pre_35} =    Evaluate    ${_crd_rc} == 0 and '${_aigateway_in_schema}' == ''
+    Log To Console    DSC CRD aigateway.modelsAsAService present: ${not ${_is_pre_35}}
     ${maas_configured} =    Run Keyword And Return Status
     ...    Dictionary Should Contain Key    ${COMPONENTS}    modelsasservice
     IF    ${maas_configured} and '${COMPONENTS.modelsasservice}' == 'Managed'

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -870,25 +870,40 @@ Create DataScienceCluster CustomResource Using Test Variables
     ${file_path} =    Set Variable    tasks/Resources/Files/
     Copy File    source=${file_path}${dsc_template}    destination=${file_path}dsc_apply.yml
     Run    sed -i'' -e 's/<dsc_name>/${dsc_name}/' ${file_path}dsc_apply.yml
-    # modelsAsAService requires parent aigateway Managed (operator #3723).
-    # Force aigateway=Managed whenever modelsasservice is Managed, even if callers
-    # explicitly set aigateway=Removed (invalid combo that left MaaS Managed alone).
+    # Detect installed RHOAI version to select the correct MaaS DSC field.
+    # In 3.5+, MaaS moved from kserve.modelsAsService → aigateway.modelsAsAService (operator #3723).
+    # On 3.4.x clusters the aigateway.* fields are unknown and silently dropped, so we must
+    # populate kserve.modelsAsService instead and leave aigateway out of the MaaS config.
+    ${_csv_version} =    Run
+    ...    oc get csv -n ${OPERATOR_NAMESPACE} -o jsonpath='{.items[?(@.spec.displayName=="Red Hat OpenShift AI")].spec.version}' 2>/dev/null || echo "0.0.0"
+    ${_is_pre_35} =    Evaluate    '${_csv_version}'.startswith('3.4') or ('${_csv_version}' != '0.0.0' and '${_csv_version}' < '3.5')
+    Log To Console    Detected RHOAI version: ${_csv_version} — pre-3.5 MaaS path: ${_is_pre_35}
     ${maas_configured} =    Run Keyword And Return Status
     ...    Dictionary Should Contain Key    ${COMPONENTS}    modelsasservice
     IF    ${maas_configured} and '${COMPONENTS.modelsasservice}' == 'Managed'
-        ${aigateway_present} =    Run Keyword And Return Status
-        ...    Dictionary Should Contain Key    ${COMPONENTS}    aigateway
-        ${aigateway_already_managed} =    Set Variable    ${FALSE}
-        IF    ${aigateway_present}
-            ${aigateway_already_managed} =    Evaluate    '${COMPONENTS.aigateway}' == 'Managed'
-        END
-        IF    not ${aigateway_already_managed}
-            Set To Dictionary    ${COMPONENTS}    aigateway=Managed
-            # Keep COMPONENTS visible to Apply DataScienceCluster verification/logging
-            Set Global Variable    ${COMPONENTS}    # robocop: disable:replace-set-variable-with-var
-            Log To Console    modelsasservice=Managed requires aigateway=Managed; updated COMPONENTS
+        IF    ${_is_pre_35}
+            # 3.4.x: populate kserve.modelsAsService (legacy field); aigateway section not understood.
+            Run    sed -i'' -e 's/<modelsasservice_legacy_value>/Managed/' ${file_path}dsc_apply.yml
+            Log To Console    3.4 cluster: using kserve.modelsAsService=Managed for MaaS
+        ELSE
+            # 3.5+: modelsAsAService requires parent aigateway Managed (operator #3723).
+            # Force aigateway=Managed when callers only set modelsasservice=Managed.
+            ${aigateway_present} =    Run Keyword And Return Status
+            ...    Dictionary Should Contain Key    ${COMPONENTS}    aigateway
+            ${aigateway_already_managed} =    Set Variable    ${FALSE}
+            IF    ${aigateway_present}
+                ${aigateway_already_managed} =    Evaluate    '${COMPONENTS.aigateway}' == 'Managed'
+            END
+            IF    not ${aigateway_already_managed}
+                Set To Dictionary    ${COMPONENTS}    aigateway=Managed
+                # Keep COMPONENTS visible to Apply DataScienceCluster verification/logging
+                Set Global Variable    ${COMPONENTS}    # robocop: disable:replace-set-variable-with-var
+                Log To Console    modelsasservice=Managed requires aigateway=Managed; updated COMPONENTS
+            END
         END
     END
+    # Fill legacy placeholder with Removed when not on 3.4 or MaaS not Managed
+    Run    sed -i'' -e 's/<modelsasservice_legacy_value>/Removed/' ${file_path}dsc_apply.yml
     FOR    ${cmp}    IN    @{COMPONENT_LIST}
             IF    $cmp not in $COMPONENTS
                 Run    sed -i'' -e 's/<${cmp}_value>/Removed/' ${file_path}dsc_apply.yml


### PR DESCRIPTION
## Summary

Fixes Jenkins install failure on RHOAI 3.4 clusters where `ModelsAsServiceReady` shows `False - Removed` and the install WHILE loop times out.

**Root cause:** The ODS-CI DSC template was applying a 3.5-style configuration (`aigateway.modelsAsAService`) to 3.4.x clusters. On 3.4.x, `aigateway.*` is an unknown field silently dropped by the API server, leaving `kserve.modelsAsService` unset → MaaS defaults to `Removed` → install fails.

## Changes

### `dsc_template.yml`
Adds `modelsAsService: <modelsasservice_legacy_value>` placeholder back under `kserve` for 3.4 compatibility. Filled with `Removed` on 3.5+ (harmless — field exists in schema but ignored when Removed).

### `oc_install.robot` — `Create DataScienceCluster CustomResource Using Test Variables`
Detects the installed CRD schema via `oc get crd ... -o jsonpath` targeting `aigateway.properties.modelsAsAService` on the storage version:
- **Empty (3.4.x):** fills `kserve.modelsAsService=Managed` — legacy path
- **Non-empty (3.5+):** existing `aigateway.modelsAsAService` path, unchanged

On CRD query failure (RBAC error, missing CRD), defaults to the 3.5+ path. Approach is version-string-independent and works for both ODH and RHOAI.

## Cluster validation — RHOAI 3.4.2

Validated manually on a real RHOAI 3.4.2 cluster (`api.test-rh-1-pool-b56b7.aws.rh-ods.com`):

1. **CRD schema check** — `aigateway.modelsAsAService` absent from 3.4 CRD schema → `_is_pre_35=True` ✅
2. **Template output** — patched code generates `kserve.modelsAsService: Managed` and `aigateway: Removed` for 3.4 ✅
3. **End-to-end** — applying `kserve.modelsAsService: Managed` on 3.4 cluster:
   ```
   ModelsAsServiceReady: True — Reconciled: MaaS platform manifests applied and maas-api deployment is available
   ```
   ✅

## Test plan
- [x] 3.4.x cluster: CRD schema returns empty → `kserve.modelsAsService: Managed` → `ModelsAsServiceReady: True`
- [ ] 3.5+ cluster: CRD schema returns non-empty → `aigateway.modelsAsAService: Managed` → `ModelsAsServiceReady: True`
- [x] 3.5+ cluster: `kserve.modelsAsService` placeholder filled with `Removed` — no CEL rejection

## Risk Analysis

**Risk rating: 2** — `oc get crd` call is read-only and fast. 3.5+ behavior is unchanged. 3.4 behavior is restored to the working state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)