### PR TITLE
fix: remove HTTP listener from maas-default-gateway to prevent OOM

### DIFF
--- a/ods_ci/tasks/Resources/Gateway/configure_maas_gateway.sh
+++ b/ods_ci/tasks/Resources/Gateway/configure_maas_gateway.sh
@@ -49,13 +49,6 @@ metadata:
 spec:
   gatewayClassName: ${GW_CLASS_NAME}
   listeners:
-    - name: http
-      hostname: "maas.${CLUSTER_DOMAIN}"
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: All
     - name: https
       hostname: "maas.${CLUSTER_DOMAIN}"
       port: 443


### PR DESCRIPTION
## Problem

The `maas-default-gateway` pod OOMs every ~45 seconds on e2e test clusters (e.g. dash-e2e-rhoai), blocking MaaS Cypress e2e tests.

**Root cause:** The `configure_maas_gateway.sh` script creates the gateway with two listeners (HTTP/80 + HTTPS/443) sharing the same hostname. This triggers a Kuadrant sort bug — Go's `sort.Sort` is non-deterministic for equal keys, causing the listener order to flip on every reconcile (~1/sec). Each flip triggers Envoy to re-fetch the 5.4MB Wasm binary, and overlapping downloads pile up in memory until OOM at 1Gi.

## Fix

Remove the HTTP/80 listener, leaving only HTTPS/443. This aligns with the production configuration — `models-as-a-service` already ships with only the HTTPS listener (PR [#965](https://github.com/opendatahub-io/models-as-a-service/pull/965), merged June 2026).

## Validation

Tested on dash-e2e-rhoai by patching the gateway to remove the HTTP listener:

| Metric | 2 listeners (before) | 1 listener (after) |
|--------|---------------------|---------------------|
| Memory | 200Mi → 1Gi in 45s (OOM) | Stable at 344-874Mi |
| Pod restarts | 3-4 per test run | 0 |
| MaaS e2e (testApiKeys) | OOMKilled, test killed | Passed (5:22) |
| Kuadrant reconciles | 120/min (infinite loop) | ~10 total |

Ref: [RHOAIENG-84569](https://redhat.atlassian.net/browse/RHOAIENG-84569)