### PR TITLE
fix: [release-3.5] remove HTTP listener from maas-default-gateway to prevent OOM

### DIFF
--- a/ods_ci/tasks/Resources/Gateway/configure_maas_gateway.sh
+++ b/ods_ci/tasks/Resources/Gateway/configure_maas_gateway.sh
@@ -49,13 +49,6 @@ metadata:
 spec:
   gatewayClassName: ${GW_CLASS_NAME}
   listeners:
-    - name: http
-      hostname: "maas.${CLUSTER_DOMAIN}"
-      port: 80
-      protocol: HTTP
-      allowedRoutes:
-        namespaces:
-          from: All
     - name: https
       hostname: "maas.${CLUSTER_DOMAIN}"
       port: 443


### PR DESCRIPTION
## Description

Cherry-pick of #3045 to `release-3.5`.

Removes the HTTP/80 listener from the `maas-default-gateway` in the e2e test setup script. The HTTP listener shares the same hostname as the HTTPS/443 listener, which triggers a Kuadrant sort instability bug — Go's `sort.Sort` is non-deterministic for equal keys, causing an infinite reconcile loop (~1/sec) where Envoy continuously re-fetches the 5.4MB Wasm binary until OOM at 1Gi (~45 seconds).

Production deployments already ship with only the HTTPS listener (models-as-a-service PR opendatahub-io/models-as-a-service#965).

## How Has This Been Tested?

Validated on dash-e2e-rhoai cluster:

| Metric | 2 listeners (before) | 1 listener (after) |
|--------|---------------------|---------------------|
| Memory | 200Mi → 1Gi in 45s (OOM) | Stable at 344-874Mi |
| Pod restarts | 3-4 per test run | 0 |
| MaaS e2e (testApiKeys) | OOMKilled, test killed | Passed (5:22) |
| Kuadrant reconciles | 120/min (infinite loop) | ~10 total |

Ref: [RHOAIENG-84569](https://redhat.atlassian.net/browse/RHOAIENG-84569)