### PR TITLE
Wait for workbench image dropdown until ImageStreams finish loading

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDataScienceProject/Workbenches.resource
@@ -194,7 +194,10 @@ Select Workbench Image
     [Documentation]    Selects a Jupyter image in the workbench creation page
     [Arguments]     ${image_name}    ${version}=default
     Click Element    //a[@href="#name-and-description"]
-    Wait Until Page Contains Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}
+    # ImageStreams are fetched asynchronously; the dashboard renders a Skeleton until they
+    # load, so workbench-image-stream-selection is not in the DOM yet (default wait is 5s).
+    Wait Until Page Contains Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}    timeout=15s
+    Wait Until Element Is Enabled    ${WORKBENCH_IMAGE_MENU_BTN_XP}    timeout=10s
     Click Element    ${WORKBENCH_IMAGE_MENU_BTN_XP}
     Wait Until Page Contains Element    ${WORKBENCH_IMAGE_ITEM_BTN_XP}\[text()="${image_name}"]    timeout=10s
     Click Element    ${WORKBENCH_IMAGE_ITEM_BTN_XP}\[text()="${image_name}"]


### PR DESCRIPTION
The dashboard renders a Skeleton until ImageStreams load, so the 5s default wait can miss the select on slow or disconnected clusters.

To avoid issues like this:
<img width="1401" height="881" alt="selenium-screenshot-114" src="https://github.com/user-attachments/assets/dd6a3ae7-54ea-4ea4-93e2-bb2a6bfa067c" />

