### PR TITLE
fix(custom-image): match dashboard's actual duplicate-image error text

### DIFF
--- a/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
+++ b/ods_ci/tests/Resources/Page/ODH/ODHDashboard/ODHDashboard.robot
@@ -577,7 +577,10 @@ Open Notebook Images Page
     [Documentation]    Opens the RHODS dashboard and navigates to the Notebook Image Settings page
     Wait Until Page Contains    Settings
     Page Should Contain    Settings
-    Menu.Navigate To Page    Settings    Workbench images
+    # Workbench images is nested under the "Environment setup" group, not a direct child of
+    # Settings - a 2-level Navigate To Page call leaves it hidden inside a collapsed accordion,
+    # causing an ElementNotInteractableException when the click is attempted.
+    Menu.Navigate To Page    Settings    Environment setup    Workbench images
     Wait Until Page Contains    Workbench images
     Wait Until Page Contains    Import new image    # This should assure us that the page content is ready
 

--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
@@ -72,8 +72,12 @@ Test Duplicate Image
     ...    software=${IMG_SOFTWARE}
     ...    packages=${IMG_PACKAGES}
     # Assure that the expected error message is shown in the modal window
-    ${image_name_id}=  Replace String  ${IMG_NAME}  ${SPACE}  -
-    Wait Until Page Contains    Unable to add notebook image: imagestreams.image.openshift.io "${image_name_id}" already exists
+    # The dashboard builds this text itself from kindApiVersion(ImageStreamModel) + the raw
+    # display name (frontend/src/utilities/imageStreamUtils.ts byonDuplicatedErrorMessage) -
+    # it does not surface the k8s API's own "imagestreams.image.openshift.io ... already
+    # exists" conflict message, so the expected text here must match the dashboard's format,
+    # not the k8s one.
+    Wait Until Page Contains    Unable to add notebook image: image.openshift.io/v1 "${IMG_NAME}" already exists
     # Since the image cannot be created, we need to cancel the modal window now
     Click Button    ${GENERIC_CANCEL_BTN_XP}
     [Teardown]  Duplicate Image Teardown


### PR DESCRIPTION
## Summary

Two fixes needed together to get `Test Duplicate Image` in `custom-image.robot` passing again:

**1. Stale expected error text.** The test waits for:

```
Unable to add notebook image: imagestreams.image.openshift.io "<hyphenated-name>" already exists
```

but the actual RHOAI Dashboard shows:

```
Unable to add notebook image: image.openshift.io/v1 "<raw display name, with spaces>" already exists
```

`byonDuplicatedErrorMessage()` in odh-dashboard's frontend (`frontend/src/utilities/imageStreamUtils.ts`) builds this message itself from `kindApiVersion(ImageStreamModel)` (a GroupVersion string, `image.openshift.io/v1`) plus the raw, un-sanitized display name — it never actually surfaces the k8s API's own `imagestreams.image.openshift.io ... already exists` conflict text (which *is* group-resource-qualified and hyphenated). Confirmed this directly against a live cluster: creating a duplicate `ImageStream` via `kubectl create` returns the group-resource-qualified message straight from the k8s apiserver, so the mismatch is entirely in the dashboard's own message construction — not something that varies between real OpenShift and any test/dev backend.

**2. Stale sidebar navigation, breaking Suite Setup for every test in the file.** `Open Notebook Images Page` calls `Menu.Navigate To Page` with only 2 levels (`Settings`, `Workbench images`), but the dashboard sidebar now nests `Workbench images` (along with `Hardware profiles` and `Connection types`) inside an intermediate **"Environment setup"** group under Settings. With the 2-level call, the code expands "Settings" and then immediately tries to click the "Workbench images" link — which exists in the DOM but is still hidden inside the collapsed "Environment setup" accordion, since that group was never expanded. This throws `ElementNotInteractableException` deterministically (not a flake) on any current dashboard build with this nav structure. `Navigate To Page` already supports a 3-level (`subsubmenu`) call for exactly this case; this just uses it.

**Version bracket for backporting:** checked `frontend/src/plugins/extensions/navigation.ts` across red-hat-data-services/odh-dashboard release branches directly. `rhoai-2.25` still has the old **flat** structure (`Workbench images` a direct child of `Settings`, no `Environment setup` group at all) — the 2-level call is correct there and this fix must NOT be backported to anything targeting 2.25 (it would break navigation the other way). The nested `Environment setup` group is present on `rhoai-3.0`, `rhoai-3.2`, `rhoai-3.3`, and `rhoai-3.4` (didn't check every intermediate tag; `rhoai-3.1` branch doesn't exist in the repo) — so this is a RHOAI-3.x-only regression, introduced sometime between the 2.25 and 3.0 dashboard releases.

## Context

Found while investigating [jiridanek/rhoai-in-kind#56](https://github.com/jiridanek/rhoai-in-kind/issues/56) (a from-scratch kind-based CI harness for RHOAI), where issue 1 was one of two failures in `custom-image.robot`. Not yet ported to `opendatahub-tests` (checked — no `BYON`/duplicate-image-conflict test exists there yet), so this fix is still relevant to the active robot suite.

## When did this regress?

The expected text (issue 1) was last deliberately fixed to the current (now-stale) form on 2025-01-14 (7d593c4a, "[fix] tests for the BYON feature"), correctly matching the dashboard's behavior at the time.

`byonDuplicatedErrorMessage()` first appears in odh-dashboard at opendatahub-io/odh-dashboard#4470 ("Migrate /images POST, PUT, and DELETE endpoints to frontend", merged 2025-08-08) — confirmed absent from `imageStreamUtils.ts` as of the June 2025 GET-only migration commit, present fully-formed in #4470's merge commit. Before that PR, image creation/duplicate-conflict handling ran through the backend (which relayed the k8s API's own conflict message, matching what this test expected); after the migration to frontend-only handling, the frontend started constructing its own message client-side, causing the mismatch this PR fixes.

A later ods-ci fix pass (723340be, 2025-10-27, "fix jupyterhub/workbenches related tests for RHOAI3.0") touched this same file but didn't revisit this specific assertion, so it's been silently broken since roughly August 2025.

## Testing

**Verified against a real cluster (RHOAI 3.5.0)**, not just static analysis:
- Manually reproduced the duplicate-image scenario via the dashboard UI and confirmed it shows exactly `Unable to add notebook image: image.openshift.io/v1 "<name>" already exists`, matching this fix's expected text.
- Ran `Test Duplicate Image` end-to-end with both commits applied against the same RHOAI 3.5.0 cluster: `1 test, 1 passed, 0 failed`. Before the second commit, Suite Setup failed 100% of the time with `ElementNotInteractableException` trying to click "Workbench images" (confirmed twice, not a one-off flake).
