### PR TITLE
fix(custom-image): match dashboard's actual duplicate-image error text (2.25 backport)

### DIFF
--- a/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
+++ b/ods_ci/tests/Tests/0500__ide/0501__ide_jupyterhub/custom-image.robot
@@ -72,8 +72,12 @@ Test Duplicate Image
     ...    software=${IMG_SOFTWARE}
     ...    packages=${IMG_PACKAGES}
     # Assure that the expected error message is shown in the modal window
-    ${image_name_id}=  Replace String  ${IMG_NAME}  ${SPACE}  -
-    Wait Until Page Contains    Unable to add notebook image: imagestreams.image.openshift.io "${image_name_id}" already exists
+    # The dashboard builds this text itself from kindApiVersion(ImageStreamModel) + the raw
+    # display name (frontend/src/utilities/imageStreamUtils.ts byonDuplicatedErrorMessage) -
+    # it does not surface the k8s API's own "imagestreams.image.openshift.io ... already
+    # exists" conflict message, so the expected text here must match the dashboard's format,
+    # not the k8s one.
+    Wait Until Page Contains    Unable to add notebook image: image.openshift.io/v1 "${IMG_NAME}" already exists
     # Since the image cannot be created, we need to cancel the modal window now
     Click Button    ${GENERIC_CANCEL_BTN_XP}
     [Teardown]  Duplicate Image Teardown


### PR DESCRIPTION
## Summary

2.25 backport of #3059 — cherry-pick of only the first commit.

`Test Duplicate Image` in `custom-image.robot` waits for:

```
Unable to add notebook image: imagestreams.image.openshift.io "<hyphenated-name>" already exists
```

but the actual RHOAI Dashboard shows:

```
Unable to add notebook image: image.openshift.io/v1 "<raw display name, with spaces>" already exists
```

`byonDuplicatedErrorMessage()` in odh-dashboard's frontend (`frontend/src/utilities/imageStreamUtils.ts`) builds this message itself from `kindApiVersion(ImageStreamModel)` (a GroupVersion string, `image.openshift.io/v1`) plus the raw, un-sanitized display name — it never actually surfaces the k8s API's own `imagestreams.image.openshift.io ... already exists` conflict text. This has been the dashboard's behavior since [opendatahub-io/odh-dashboard#4470](https://github.com/opendatahub-io/odh-dashboard/pull/4470) (merged 2025-08-08), well before any RHOAI 2.25 dashboard build, so this fix applies here too.

## Why not the second commit from #3059

#3059 has a second commit fixing `Open Notebook Images Page`'s sidebar navigation, needed because 3.x dashboards nest `Workbench images` under an intermediate **"Environment setup"** group. Checked `frontend/src/plugins/extensions/navigation.ts` directly on `red-hat-data-services/odh-dashboard`'s `rhoai-2.25` branch: it still has the **old flat structure** (`Workbench images` a direct child of `Settings`, no `Environment setup` group). Backporting that second commit here would break navigation instead of fixing it — the existing 2-level `Menu.Navigate To Page Settings Workbench images` call is already correct for 2.25's dashboard. Only the first (error-text) commit applies.

## Testing

**Verified against the [jiridanek/rhoai-in-kind](https://github.com/jiridanek/rhoai-in-kind) local kind-based RHOAI 2.25 harness** (issue [#56](https://github.com/jiridanek/rhoai-in-kind/issues/56), where this mismatch was originally found): ran `Test Duplicate Image` end-to-end with this commit applied against the local kind cluster's dashboard — `1 test, 1 passed, 0 failed`.