### PR TITLE
fix(must-gather): bound ODS-505 oc adm must-gather to 15m (RHOAIENG-8…

### DIFF
--- a/ods_ci/tests/Resources/CLI/MustGather/MustGather.resource
+++ b/ods_ci/tests/Resources/CLI/MustGather/MustGather.resource
@@ -11,6 +11,8 @@ Get Must-Gather Logs
     [Documentation]    Runs the must-gather image and obtains the ODH/RHOAI logs
     ${output}=    Run process    tests/Resources/CLI/MustGather/get-must-gather-logs.sh
     ...                          shell=yes
+    ...                          timeout=16 minutes
+    ...                          on_timeout=kill
     ...                          env:OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE}
     ...                          env:APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}
     ${disk_usage_err}=    Grep File    must-gather-results.txt    Disk usage exceeds the volume percentage
@@ -35,4 +37,5 @@ Verify Logs For ${namespace}
 
 Cleanup Must-Gather Logs
     [Documentation]    Deletes the folder with the must-gather logs
+    ${must_gather_dir}=    Get Variable Value    ${must_gather_dir}    ${EMPTY}
     Run Keyword If      "${must_gather_dir}" != "${EMPTY}"      Remove Directory   ${must_gather_dir}    recursive=True

--- a/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
+++ b/ods_ci/tests/Resources/CLI/MustGather/get-must-gather-logs.sh
@@ -1,6 +1,8 @@
 #!/bin/sh
 # Redirecting stdout/stderr of must-gather to a file, as it fills up the
 # process buffer and prevents the script from running further.
+# Bound the gather with GNU timeout so a hung oc/gather cannot stall CI
+# for hours (RHOAIENG-88048).
 #clean up must-gather.local*
 for dir in must-gather.local*; do
     if [ -d "$dir" ]; then
@@ -9,12 +11,48 @@ for dir in must-gather.local*; do
     fi
 done
 
-oc adm must-gather --image=quay.io/rhoai/odh-must-gather-rhel9:rhoai-3.0  --volume-percentage=90 -- "export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE};export APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}; /usr/bin/gather" &> must-gather-results.txt
+cleanup_gather_namespaces() {
+    oc get ns -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null \
+        | grep '^openshift-must-gather-' \
+        | while IFS= read -r ns; do
+            echo "Deleting leftover must-gather namespace: ${ns}"
+            oc delete ns "${ns}" --wait=false --ignore-not-found=true || true
+        done
+}
 
-if [ $? -eq 0 ]
+if ! command -v timeout >/dev/null 2>&1; then
+    echo "FAIL: GNU timeout is required to bound oc adm must-gather"
+    exit 1
+fi
+
+IMAGE="${MUST_GATHER_IMAGE:-quay.io/rhoai/odh-must-gather-rhel9:rhoai-3.0}"
+GATHER_TIMEOUT="${MUST_GATHER_TIMEOUT:-15m}"
+
+echo "Starting oc adm must-gather (timeout ${GATHER_TIMEOUT}, image ${IMAGE}) at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+
+timeout "${GATHER_TIMEOUT}" oc adm must-gather --image="${IMAGE}" --volume-percentage=90 -- \
+    "export OPERATOR_NAMESPACE=${OPERATOR_NAMESPACE};export APPLICATIONS_NAMESPACE=${APPLICATIONS_NAMESPACE}; /usr/bin/gather" \
+    > must-gather-results.txt 2>&1
+rc=$?
+
+echo "must-gather finished with rc=${rc} at $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+if [ -f must-gather-results.txt ]; then
+    echo "----- tail of must-gather-results.txt -----"
+    tail -n 50 must-gather-results.txt
+    echo "----- end tail -----"
+fi
+
+if [ "${rc}" -eq 124 ]; then
+    echo "FAIL: oc adm must-gather timed out after ${GATHER_TIMEOUT}"
+    cleanup_gather_namespaces
+    exit 1
+fi
+
+if [ "${rc}" -eq 0 ]
 then
     echo "SUCCESS: must-gather logs can be found in repo must-gather-local.*"
 else
     echo "FAIL : Unable to get must-gather logs"
+    cleanup_gather_namespaces
     exit 1
 fi

--- a/ods_ci/tests/Tests/0100__platform/0103__must_gather/test-must-gather-logs.robot
+++ b/ods_ci/tests/Tests/0100__platform/0103__must_gather/test-must-gather-logs.robot
@@ -16,6 +16,7 @@ Verify that the must-gather image provides RHODS logs and info
     ...      MustGather
     ...      ExcludeOnODH
     ...      ExcludeOnDisconnected
+    [Timeout]    20 minutes
     Get Must-Gather Logs
     Verify Logs For ${APPLICATIONS_NAMESPACE}
     IF  "${PRODUCT}" == "RHODS"

--- a/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
+++ b/ods_ci/tests/Tests/0200__rhoai_upgrade/0203__post_upgrade.robot
@@ -217,6 +217,7 @@ Verify Ray Cluster Exists And Monitor Workload Metrics By Submitting Ray Job Aft
 Verify that the must-gather image provides RHODS logs and info
     [Documentation]    Tests the must-gather image for ODH/RHOAI after upgrading
     [Tags]      Upgrade    ODS-505    ExcludeOnDisconnected    Platform
+    [Timeout]    20 minutes
     Get Must-Gather Logs
     Verify Logs For ${APPLICATIONS_NAMESPACE}
     IF    "${PRODUCT}" == "RHODS"


### PR DESCRIPTION
## Summary
- Bound `oc adm must-gather` with GNU `timeout` (default 15m, override via `MUST_GATHER_TIMEOUT`) so ODS-505 cannot stall PostUpgrade for 13+ hours (`rhoai/3.4/selfmanaged/cli/gcp/rhoai-upgrade` #35).
- Robot `Run process` now uses `timeout=16 minutes on_timeout=kill`; ODS-505 cases get `[Timeout] 20 minutes`.
- On timeout/failure, leftover `openshift-must-gather-*` namespaces are deleted; teardown no longer fails when `${must_gather_dir}` was never set.
- Image remains `quay.io/rhoai/odh-must-gather-rhel9:rhoai-3.0` by default; override with `MUST_GATHER_IMAGE`.

Fixes [RHOAIENG-88048](https://issues.redhat.com/browse/RHOAIENG-88048)

This PR targets **release-3.4** first. A follow-up to `master` (and `release-3.5`) will be opened after this lands.

## Test plan
- [ ] PostUpgrade ODS-505 on a healthy 3.4 cluster completes well under 20 minutes (or fails clearly on timeout instead of hanging)
- [ ] Jenkins console shows start/finish timestamps and a tail of `must-gather-results.txt`
- [ ] Timeout path: leftover `openshift-must-gather-*` namespaces are removed
- [ ] Teardown does not fail with `${must_gather_dir} not found` after a gather timeout