### PR TITLE
RHOAIENG-88049: remove skipped tests from selection to prevents Jiras spamming (RHOAI 3.3)

### DIFF
--- a/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
+++ b/ods_ci/tests/Tests/0600__distributed_workloads/test-run-distributed-workloads-tests.robot
@@ -6,14 +6,16 @@ Library           OperatingSystem
 Library           Process
 Resource          ../../../tasks/Resources/RHODS_OLM/install/oc_install.robot
 Resource          ../../Resources/Page/DistributedWorkloads/DistributedWorkloads.resource
-Test Tags         DistributedWorkloads3.11
+Test Tags         DistributedWorkloads3.11    robot:skip
+# Tier1 and GPU tags are commented on each case so this skipped suite is not
+# selected by Smoke / Tier1 / GPU gates. Uncomment them and remove robot:skip together.
 
 
 *** Test Cases ***
 Run TestKueueRayCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayCpu
     [Tags]  ODS-2514
-    ...     Tier1
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration
@@ -21,18 +23,18 @@ Run TestKueueRayCpu ODH test with Python 3.11
 
 Run TestKueueRayCudaGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayCudaGpu
-    [Tags]  Resources-GPU    NVIDIA-GPUs
-    ...     Tier1
-    ...     DistributedWorkloads
+    [Tags]  DistributedWorkloads
+    # ...     Resources-GPU    NVIDIA-GPUs
+    # ...     Tier1
     ...     TrainingRay
     ...     WorkloadsOrchestration
     Run DistributedWorkloads ODH Test    TestMnistRayCudaGpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
 
 Run TestKueueRayROCmGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueRayROCmGpu
-    [Tags]  Resources-GPU    AMD-GPUs    ROCm
-    ...     Tier1
-    ...     DistributedWorkloads
+    [Tags]  DistributedWorkloads
+    # ...     Resources-GPU    AMD-GPUs    ROCm
+    # ...     Tier1
     ...     TrainingRay
     ...     WorkloadsOrchestration
     Run DistributedWorkloads ODH Test    TestMnistRayROCmGpu    ${RAY_ROCM_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
@@ -40,7 +42,7 @@ Run TestKueueRayROCmGpu ODH test with Python 3.11
 Run TestRayTuneHPOCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoCpu
     [Tags]  RHOAIENG-10004
-    ...     Tier1
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration
@@ -48,9 +50,9 @@ Run TestRayTuneHPOCpu ODH test with Python 3.11
 
 Run TestRayTuneHPOGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestMnistRayTuneHpoGpu
-    [Tags]  Resources-GPU    NVIDIA-GPUs
-    ...     Tier1
-    ...     DistributedWorkloads
+    [Tags]  DistributedWorkloads
+    # ...     Resources-GPU    NVIDIA-GPUs
+    # ...     Tier1
     ...     TrainingRay
     ...     WorkloadsOrchestration
     Run DistributedWorkloads ODH Test    TestMnistRayTuneHpoGpu    ${RAY_CUDA_IMAGE_3.11}    ${NOTEBOOK_IMAGE_3.11}
@@ -58,7 +60,7 @@ Run TestRayTuneHPOGpu ODH test with Python 3.11
 Run TestKueueCustomRayCudaCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayCudaCpu
     [Tags]  RHOAIENG-10013
-    ...     Tier1
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration
@@ -67,8 +69,8 @@ Run TestKueueCustomRayCudaCpu ODH test with Python 3.11
 Run TestKueueCustomRayCudaGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayCudaGpu
     [Tags]  RHOAIENG-10013
-    ...     Resources-GPU    NVIDIA-GPUs
-    ...     Tier1
+    # ...     Resources-GPU    NVIDIA-GPUs
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration
@@ -77,7 +79,7 @@ Run TestKueueCustomRayCudaGpu ODH test with Python 3.11
 Run TestKueueCustomRayRocmCpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayRocmCpu
     [Tags]  RHOAIENG-12484
-    ...     Tier1
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration
@@ -86,8 +88,8 @@ Run TestKueueCustomRayRocmCpu ODH test with Python 3.11
 Run TestKueueCustomRayRocmGpu ODH test with Python 3.11
     [Documentation]    Run Go ODH test: TestKueueCustomRayRocmGpu
     [Tags]  RHOAIENG-12484
-    ...     Resources-GPU    AMD-GPUs    ROCm
-    ...     Tier1
+    # ...     Resources-GPU    AMD-GPUs    ROCm
+    # ...     Tier1
     ...     DistributedWorkloads
     ...     TrainingRay
     ...     WorkloadsOrchestration


### PR DESCRIPTION
## WHAT
[RHOAIENG-88049](https://redhat.atlassian.net/browse/RHOAIENG-88049): remove skipped tests from selection to prevents Jiras spamming (RHOAI 3.3)