### PR TITLE
fix: wait for model-registry-operator using control-plane label

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -430,14 +430,14 @@ Verify RHODS Installation
   IF    "${modelregistry}" == "true"
     # 3.6+ deploys AI Hub (and catalog on some overlays) instead of model-registry-operator.
     # Wait for whichever controllers the operator actually created.
-    ${legacy_mr}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
+    ${legacy_mr} =    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=control-plane=model-registry-operator    timeout=400s
-    ${aihub}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
+    ${aihub} =    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=control-plane=aihub-controller-manager    timeout=400s
-    ${catalog}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
+    ${catalog} =    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=control-plane=catalog-controller-manager    timeout=400s
     IF    not ${legacy_mr} and not ${aihub} and not ${catalog}
-        Fail    msg=modelregistry is Managed but no model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found
+        Fail    msg=modelregistry is Managed but no MR/AIHub/catalog controller Deployment was found
     END
   END
 

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -428,8 +428,10 @@ Verify RHODS Installation
 
   ${modelregistry} =    Is Component Enabled    modelregistry    ${DSC_NAME}
   IF    "${modelregistry}" == "true"
+    # Prefer control-plane=model-registry-operator (ODH overlay includeSelectors).
+    # part-of is on Deployment metadata only and is not present on pods in 3.6+.
     Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
-    ...    label_selector=app.kubernetes.io/part-of=model-registry-operator    timeout=400s
+    ...    label_selector=control-plane=model-registry-operator    timeout=400s
   END
 
   ${trainingoperator} =    Is Component Enabled    trainingoperator    ${DSC_NAME}

--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -428,10 +428,17 @@ Verify RHODS Installation
 
   ${modelregistry} =    Is Component Enabled    modelregistry    ${DSC_NAME}
   IF    "${modelregistry}" == "true"
-    # Prefer control-plane=model-registry-operator (ODH overlay includeSelectors).
-    # part-of is on Deployment metadata only and is not present on pods in 3.6+.
-    Wait For Deployment Replica To Be Ready    namespace=${APPLICATIONS_NAMESPACE}
+    # 3.6+ deploys AI Hub (and catalog on some overlays) instead of model-registry-operator.
+    # Wait for whichever controllers the operator actually created.
+    ${legacy_mr}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
     ...    label_selector=control-plane=model-registry-operator    timeout=400s
+    ${aihub}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=control-plane=aihub-controller-manager    timeout=400s
+    ${catalog}=    Wait For Deployment Replica If Present    namespace=${APPLICATIONS_NAMESPACE}
+    ...    label_selector=control-plane=catalog-controller-manager    timeout=400s
+    IF    not ${legacy_mr} and not ${aihub} and not ${catalog}
+        Fail    msg=modelregistry is Managed but no model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found
+    END
   END
 
   ${trainingoperator} =    Is Component Enabled    trainingoperator    ${DSC_NAME}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -168,8 +168,9 @@ Wait For Deployment Replica If Present
     ...    Returns ${TRUE} when a matching Deployment was found and became ready, ${FALSE} if none exist.
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=400s
     ${rc}    ${name}=    Run And Return Rc And Output
-    ...    oc get deployment -l ${label_selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
-    IF    ${rc} != ${0} or "${name}" == "${EMPTY}"
+    ...    oc get deployment -l ${label_selector} -n ${namespace} -o jsonpath='{.items[*].metadata.name}'
+    # Use $name (not "${name}") so oc errors with quotes cannot break the IF expression.
+    IF    $rc != $0 or $name == $EMPTY
         Log To Console    No Deployment with label "${label_selector}" in "${namespace}", skipping wait
         RETURN    ${FALSE}
     END
@@ -186,8 +187,8 @@ Get Model Registry Controller Label Selector
     ...    control-plane=catalog-controller-manager
     ...    control-plane=model-registry-operator
         ${rc}    ${name}=    Run And Return Rc And Output
-        ...    oc get deployment -l ${selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
-        IF    ${rc} == ${0} and "${name}" != "${EMPTY}"    RETURN    ${selector}
+        ...    oc get deployment -l ${selector} -n ${namespace} -o jsonpath='{.items[*].metadata.name}'
+        IF    $rc == $0 and $name != $EMPTY    RETURN    ${selector}
     END
     Fail    msg=No Model Registry, AI Hub, or catalog controller Deployment was found in ${namespace}
 

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -169,7 +169,7 @@ Wait For Deployment Replica If Present
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=400s
     ${rc}    ${name}=    Run And Return Rc And Output
     ...    oc get deployment -l ${label_selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
-    IF    "${name}" == "${EMPTY}"
+    IF    ${rc} != ${0} or "${name}" == "${EMPTY}"
         Log To Console    No Deployment with label "${label_selector}" in "${namespace}", skipping wait
         RETURN    ${FALSE}
     END
@@ -187,11 +187,9 @@ Get Model Registry Controller Label Selector
     ...    control-plane=model-registry-operator
         ${rc}    ${name}=    Run And Return Rc And Output
         ...    oc get deployment -l ${selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
-        IF    "${name}" != "${EMPTY}"
-            RETURN    ${selector}
-        END
+        IF    ${rc} == ${0} and "${name}" != "${EMPTY}"    RETURN    ${selector}
     END
-    Fail    msg=No model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found in ${namespace}
+    Fail    msg=No Model Registry, AI Hub, or catalog controller Deployment was found in ${namespace}
 
 Wait For Pods To Succeed
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -169,8 +169,9 @@ Wait For Deployment Replica If Present
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=400s
     ${rc}    ${name}=    Run And Return Rc And Output
     ...    oc get deployment -l ${label_selector} -n ${namespace} -o jsonpath='{.items[*].metadata.name}'
-    # Use $name (not "${name}") so oc errors with quotes cannot break the IF expression.
-    IF    $rc != $0 or $name == $EMPTY
+    # $name is the Python object so oc errors with quotes cannot break the IF.
+    # not $name is True for empty stdout; $EMPTY is not defined in RF evaluate.
+    IF    $rc != 0 or not $name
         Log To Console    No Deployment with label "${label_selector}" in "${namespace}", skipping wait
         RETURN    ${FALSE}
     END
@@ -188,7 +189,7 @@ Get Model Registry Controller Label Selector
     ...    control-plane=model-registry-operator
         ${rc}    ${name}=    Run And Return Rc And Output
         ...    oc get deployment -l ${selector} -n ${namespace} -o jsonpath='{.items[*].metadata.name}'
-        IF    $rc == $0 and $name != $EMPTY    RETURN    ${selector}
+        IF    $rc == 0 and $name    RETURN    ${selector}
     END
     Fail    msg=No Model Registry, AI Hub, or catalog controller Deployment was found in ${namespace}
 

--- a/ods_ci/tests/Resources/OCP.resource
+++ b/ods_ci/tests/Resources/OCP.resource
@@ -163,6 +163,36 @@ Wait For Deployment Replica To Be Ready
     ...    oc get deployment -l ${label_selector} -n ${namespace} -o json | jq -e '.status | .replicas == .readyReplicas'  #robocop: disable:line-too-long
     ...    print_to_log=${FALSE}
 
+Wait For Deployment Replica If Present
+    [Documentation]    Wait for a Deployment matching ${label_selector} only if one exists.
+    ...    Returns ${TRUE} when a matching Deployment was found and became ready, ${FALSE} if none exist.
+    [Arguments]    ${label_selector}    ${namespace}    ${timeout}=400s
+    ${rc}    ${name}=    Run And Return Rc And Output
+    ...    oc get deployment -l ${label_selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
+    IF    "${name}" == "${EMPTY}"
+        Log To Console    No Deployment with label "${label_selector}" in "${namespace}", skipping wait
+        RETURN    ${FALSE}
+    END
+    Wait For Deployment Replica To Be Ready    namespace=${namespace}
+    ...    label_selector=${label_selector}    timeout=${timeout}
+    RETURN    ${TRUE}
+
+Get Model Registry Controller Label Selector
+    [Documentation]    Return the control-plane selector for the Model Registry controller
+    ...    that is actually deployed (AI Hub in 3.6+, catalog overlay, or legacy operator).
+    [Arguments]    ${namespace}
+    FOR    ${selector}    IN
+    ...    control-plane=aihub-controller-manager
+    ...    control-plane=catalog-controller-manager
+    ...    control-plane=model-registry-operator
+        ${rc}    ${name}=    Run And Return Rc And Output
+        ...    oc get deployment -l ${selector} -n ${namespace} -o jsonpath='{.items[0].metadata.name}'
+        IF    "${name}" != "${EMPTY}"
+            RETURN    ${selector}
+        END
+    END
+    Fail    msg=No model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found in ${namespace}
+
 Wait For Pods To Succeed
     [Arguments]    ${label_selector}    ${namespace}    ${timeout}=300s    ${exp_replicas}=${NONE}
     Wait Until Keyword Succeeds    ${timeout}    3s

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
@@ -27,19 +27,19 @@ Verify Model Registry Operator Installation
 *** Keywords ***
 Verify Model Registry Operator Deployment
     [Documentation]    Verifies the  deployment of the model registry operator in the Applications namespace
-    ${legacy_mr}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ${legacy_mr} =    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
     ...    label_selector=control-plane=model-registry-operator    timeout=20s
-    ${aihub}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ${aihub} =    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
     ...    label_selector=control-plane=aihub-controller-manager    timeout=20s
-    ${catalog}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ${catalog} =    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
     ...    label_selector=control-plane=catalog-controller-manager    timeout=20s
     IF    not ${legacy_mr} and not ${aihub} and not ${catalog}
-        Fail    msg=No model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found
+        Fail    msg=No Model Registry, AI Hub, or catalog controller Deployment was found
     END
 
 Verify Model Registry ReplicaSets Info
     [Documentation]    Fetches and verifies information from Model Registry replicasets
-    ${selector}=    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
+    ${selector} =    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
     @{model_registry_replicasets_info} =   Oc Get    kind=ReplicaSet    api_version=v1    namespace=${MODEL_REGISTRY_NS}
     ...    label_selector=${selector}
     OpenShift Resource Field Value Should Be Equal As Strings    status.readyReplicas
@@ -47,7 +47,7 @@ Verify Model Registry ReplicaSets Info
 
 Verify Model Registry Container Names
     [Documentation]  Verifies RHODS Model Registry deployment
-    ${selector}=    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
+    ${selector} =    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
     @{model_registry} =  Oc Get    kind=Pod    namespace=${MODEL_REGISTRY_NS}    api_version=v1
     ...    label_selector=${selector}
     ${containerNames} =    Create List     manager

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
@@ -27,22 +27,29 @@ Verify Model Registry Operator Installation
 *** Keywords ***
 Verify Model Registry Operator Deployment
     [Documentation]    Verifies the  deployment of the model registry operator in the Applications namespace
-    Wait For Pods Number  1
-    ...                   namespace=${MODEL_REGISTRY_NS}
-    ...                   label_selector=control-plane=model-registry-operator
-    ...                   timeout=20
+    ${legacy_mr}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ...    label_selector=control-plane=model-registry-operator    timeout=20s
+    ${aihub}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ...    label_selector=control-plane=aihub-controller-manager    timeout=20s
+    ${catalog}=    Wait For Deployment Replica If Present    namespace=${MODEL_REGISTRY_NS}
+    ...    label_selector=control-plane=catalog-controller-manager    timeout=20s
+    IF    not ${legacy_mr} and not ${aihub} and not ${catalog}
+        Fail    msg=No model-registry-operator, aihub-controller-manager, or catalog-controller-manager Deployment was found
+    END
 
 Verify Model Registry ReplicaSets Info
     [Documentation]    Fetches and verifies information from Model Registry replicasets
+    ${selector}=    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
     @{model_registry_replicasets_info} =   Oc Get    kind=ReplicaSet    api_version=v1    namespace=${MODEL_REGISTRY_NS}
-    ...    label_selector=control-plane=model-registry-operator
+    ...    label_selector=${selector}
     OpenShift Resource Field Value Should Be Equal As Strings    status.readyReplicas
     ...    1    @{model_registry_replicasets_info}
 
 Verify Model Registry Container Names
     [Documentation]  Verifies RHODS Model Registry deployment
+    ${selector}=    Get Model Registry Controller Label Selector    ${MODEL_REGISTRY_NS}
     @{model_registry} =  Oc Get    kind=Pod    namespace=${MODEL_REGISTRY_NS}    api_version=v1
-    ...    label_selector=control-plane=model-registry-operator
+    ...    label_selector=${selector}
     ${containerNames} =    Create List     manager
     Verify Deployment    ${model_registry}    1    1    ${containerNames}
 

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0111__model_registry.robot
@@ -29,20 +29,20 @@ Verify Model Registry Operator Deployment
     [Documentation]    Verifies the  deployment of the model registry operator in the Applications namespace
     Wait For Pods Number  1
     ...                   namespace=${MODEL_REGISTRY_NS}
-    ...                   label_selector=app.kubernetes.io/part-of=model-registry-operator
+    ...                   label_selector=control-plane=model-registry-operator
     ...                   timeout=20
 
 Verify Model Registry ReplicaSets Info
     [Documentation]    Fetches and verifies information from Model Registry replicasets
     @{model_registry_replicasets_info} =   Oc Get    kind=ReplicaSet    api_version=v1    namespace=${MODEL_REGISTRY_NS}
-    ...    label_selector=app.kubernetes.io/part-of=model-registry-operator
+    ...    label_selector=control-plane=model-registry-operator
     OpenShift Resource Field Value Should Be Equal As Strings    status.readyReplicas
     ...    1    @{model_registry_replicasets_info}
 
 Verify Model Registry Container Names
     [Documentation]  Verifies RHODS Model Registry deployment
     @{model_registry} =  Oc Get    kind=Pod    namespace=${MODEL_REGISTRY_NS}    api_version=v1
-    ...    label_selector=app.kubernetes.io/part-of=model-registry-operator
+    ...    label_selector=control-plane=model-registry-operator
     ${containerNames} =    Create List     manager
     Verify Deployment    ${model_registry}    1    1    ${containerNames}
 


### PR DESCRIPTION
## Summary
- RHOAI 3.6 install verification waits for pods with `app.kubernetes.io/part-of=model-registry-operator`. That label is on Deployment metadata only; the ODH overlay stamps `control-plane=model-registry-operator` on the controller Deployment, ReplicaSet, and pods.
- Dashboard E2E (e.g. `dashboard-e2e-tests` #2492) then fails with `Check If Pod Exists` after 400s even when DSC is Ready and `model-registry-operator-controller-manager` is running.
- Switch the install wait (and the ODH post-install MR checks) to `control-plane=model-registry-operator`, matching `0113__dsc_components.robot`.

## Test plan
- [x] Rebuild `components/dashboard/dashboard-e2e-tests` with `ODS_CI_GIT_REPO_BRANCH=fix/model-registry-operator-wait-label`
- [x] Validated on https://jenkins-csb-rhods-opendatascience.dno.corp.redhat.com/job/components/job/dashboard/job/dashboard-e2e-tests/2526/
- [x] Confirm install passes the model-registry wait instead of 6m40s of `status:FAIL`
- [x] Confirm later component waits (feast, ogx, dashboard) still run
- [x] Optional: `oc get pods -n redhat-ods-applications -l control-plane=model-registry-operator` on the test cluster


Made with [Cursor](https://cursor.com)