### PR TITLE
fix(e2e): update TrainingOperator smoke test for 3.6 deprecation

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0104__operators/0104__rhods_operator/0113__dsc_components.robot
@@ -168,20 +168,26 @@ Validate Ray Removed State
     [Teardown]      Restore DSC Component State     ray     ${RAY_DEPLOYMENT_NAME}      ${RAY_LABEL_SELECTOR}       ${SAVED_MANAGEMENT_STATES.RAY}
 
 Validate Training Operator Managed State
-    [Documentation]    Validate that the DSC Training Operator component Managed state creates the expected resources,
-    ...    check that Training deployment is created and pod is in Ready state
+    [Documentation]    Validate that setting TrainingOperator to Managed is correctly rejected in 3.6+.
+    ...    TrainingOperator v1 is obsolete; the webhook must block enabling it.
     [Tags]
     ...    Operator
     ...    RHOAIENG-6627
+    ...    RHOAIENG-84752
     ...    training-managed
     ...    Integration
     ...    Smoke
 
-    Set DSC Component Managed State And Wait For Completion
+    Set DSC Component Removed State And Wait For Completion
     ...    trainingoperator
     ...    ${TRAINING_DEPLOYMENT_NAME}
     ...    ${TRAINING_LABEL_SELECTOR}
-    Check That Image Pull Path Is Correct       ${TRAINING_DEPLOYMENT_NAME}     ${IMAGE_PULL_PATH}
+    ${error}=    Run Keyword And Expect Error    *
+    ...    Set DSC Component Managed State And Wait For Completion
+    ...    trainingoperator
+    ...    ${TRAINING_DEPLOYMENT_NAME}
+    ...    ${TRAINING_LABEL_SELECTOR}
+    Should Contain    ${error}    TrainingOperator v1 is obsolete
 
     [Teardown]      Restore DSC Component State     trainingoperator        ${TRAINING_DEPLOYMENT_NAME}     ${TRAINING_LABEL_SELECTOR}      ${SAVED_MANAGEMENT_STATES.TRAINING}
 
@@ -208,7 +214,6 @@ Validate Trainer Managed State
     ...    Operator
     ...    trainer-managed
     ...    Integration
-    ...    ExcludeOnODH
     ...    Smoke
 
     Set DSC Component Managed State And Wait For Completion


### PR DESCRIPTION
## Description

TrainingOperator v1 is obsolete in ODH/RHOAI 3.6. The webhook now actively rejects setting `managementState=Managed`, causing `Validate Training Operator Managed State` to fail consistently across all smoke runs.

**Root cause:** `Set Component State` calls `oc patch` on the DSC; in 3.6 the webhook returns:
```
TrainingOperator v1 is obsolete in RHOAI 3.6. Set managementState to Removed,
then delete the TrainingOperator CR to clean up. Use Trainer v2 instead.
```
This causes the test to FAIL — but it's the correct product behavior, not a regression.

## Changes

**1. `Validate Training Operator Managed State`** — flip from "assert deploy succeeds" to "assert webhook correctly rejects enabling a deprecated component". Keeps Smoke coverage, now tests the right thing.

**2. `Validate Trainer Managed State`** — remove `ExcludeOnODH`. Trainer v2 manifests are platform-agnostic (`opt/manifests/trainer/` has no ODH/RHOAI split), so ODH should run this smoke test. This replaces the coverage lost by the TrainingOperator test change.

## Jira

https://redhat.atlassian.net/browse/RHOAIENG-84752

## Risk

If Trainer v2 is not yet deployable on ODH (missing image in ODH build config), `Validate Trainer Managed State` will start failing on ODH. Revert the `ExcludeOnODH` removal and file a separate ticket if that happens.