### PR TITLE
RHOAIENG-92935: Increase post-DSC component verify wait from 1 to 10 minutes

### DIFF
--- a/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
+++ b/ods_ci/tasks/Resources/RHODS_OLM/install/oc_install.robot
@@ -981,33 +981,37 @@ Component Is A Nested Component
 Component Should Be Enabled
     [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
     ${status} =   Set Variable   False
-    WHILE   '${status}' != 'true'    limit=60 seconds
+    WHILE   '${status}' != 'true'    limit=10 min
         ${status} =    Is Component Enabled    ${component}    ${dsc_name}
         IF    '${status}' == 'true'    BREAK
+        Sleep    1 sec
     END
 
 Nested Component Should Be Enabled
     [Arguments]    ${parent_component}    ${nested_component}     ${dsc_name}=${DSC_NAME}
     ${status} =   Set Variable   False
-    WHILE   '${status}' != 'true'    limit=60 seconds
+    WHILE   '${status}' != 'true'    limit=10 min
         ${status} =    Is Nested Component Enabled    ${parent_component}    ${nested_component}    ${dsc_name}
         IF    '${status}' == 'true'    BREAK
+        Sleep    1 sec
     END
 
 Component Should Not Be Enabled
     [Arguments]    ${component}    ${dsc_name}=${DSC_NAME}
     ${status} =   Set Variable   True
-    WHILE   '${status}' != 'false'    limit=60 seconds
+    WHILE   '${status}' != 'false'    limit=10 min
         ${status} =    Is Component Enabled    ${component}    ${dsc_name}
         IF    '${status}' == 'false'    BREAK
+        Sleep    1 sec
     END
 
 Nested Component Should Not Be Enabled
     [Arguments]    ${parent_component}    ${nested_component}     ${dsc_name}=${DSC_NAME}
     ${status} =   Set Variable   True
-    WHILE   '${status}' != 'false'    limit=60 seconds
+    WHILE   '${status}' != 'false'    limit=10 min
         ${status} =    Is Nested Component Enabled    ${parent_component}    ${nested_component}    ${dsc_name}
         IF    '${status}' == 'false'    BREAK
+        Sleep    1 sec
     END
 
 Is Component Enabled


### PR DESCRIPTION
Related: https://redhat.atlassian.net/browse/RHOAIENG-92935

## Summary
- Raise Robot WHILE `limit` from 60 seconds to 10 minutes after `default-dsc` apply when verifying DSC component `managementState` in `oc_install.robot`.

## Context
autotrigger-smoke (e.g. job/rhoai/job/autotrigger-smoke/1408) deploy failed on 1-minute WHILE timeout while CSV install in the same flow allows 10 minutes.

## Test plan
- [x] RHOAI CLI install on slow cluster completes deploy Robot step without false timeout
- [x] Component Removed/Unmanaged verify loops still pass on fast clusters