### PR TITLE
chore: Remove sanity tests from platform directory

### DIFF
--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0101__post_install.robot
@@ -80,7 +80,6 @@ Verify That CUDA Build Chain Succeeds
 Verify That "Usage Data Collection" Is Enabled By Default
     [Documentation]    Verify that "Usage Data Collection" is enabled by default when installing ODS
     [Tags]    Tier1
-    ...       Sanity
     ...       ODS-1234
 
     ${version_check} =    Is RHODS Version Greater Or Equal Than    1.8.0
@@ -95,7 +94,6 @@ Verify That "Usage Data Collection" Is Enabled By Default
 Verify Tracking Key Used For "Usage Data Collection"
     [Documentation]    Verify that "Usage Data Collection" is enabled by default when installing ODS
     [Tags]    Tier1
-    ...       Sanity
     ...       ODS-1235
 
     ODS.Verify "Usage Data Collection" Key

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0108__operator.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0108__operator.robot
@@ -40,7 +40,7 @@ Verify That DSC And DSCI Release.Version Attribute matches the value in the subs
 
 Verify That The Operator Pod Does Not Get Stuck After Upgrade
     [Documentation]    Verifies that the operator pod doesn't get stuck after an upgrade
-    [Tags]    Sanity
+    [Tags]    Smoke
     ...       ODS-818
     ...       Operator
     ${operator_pod_info}=    Fetch operator Pod Info

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0113__installation.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0101__installation/0113__installation.robot
@@ -42,45 +42,6 @@ Verify User Can Access RHODS Documentation From OCM Console
   Page Should Contain Element       //div[@class="pf-l-flex pf-m-space-items-lg pf-m-column"]//a
   Verify Documentation Is Accessible
 
-Verify RHOAI Addon Validates Notification E-Mail Format
-  [Tags]  Sanity
-  ...     ODS-672
-  ...     RHOAI-13065
-  [Setup]   OCM Test Setup
-  Grant Cluster Editor To User  ${SSO.USERNAME}
-  Decide OCM URL And Open Link
-  Login To HCC  ${SSO.USERNAME}  ${SSO.PASSWORD}
-  Maybe Skip OCM Tour
-  Open Cluster By Name
-  Wait Until Page Contains Element    //*[@data-ouia-component-id="Add-ons"]
-  Click Element      //*[@data-ouia-component-id="Add-ons"]
-  Wait Until Page Contains Element      //div[@data-ouia-component-id="card-addon-managed-odh"]     10
-  Click Element     //div[@data-ouia-component-id="card-addon-managed-odh"]
-  Click Button    Install
-  Wait Until Page Contains Element  //input[@id="notification-email"]
-  @{email_values} =  Set Variable
-  ...       test@
-  ...       test@test.com,
-  ...       test@test.com test@test.com test@test.com
-  FOR  ${email_value}  IN   @{email_values}
-      Input Text    //input[@id="notification-email"]  ${email_value}
-      Click Button    //div[@aria-label="Configure Red Hat OpenShift AI"]//button[@type="submit"]
-      Wait Until Page Contains Element    //div[@aria-label="Configure Red Hat OpenShift AI"]//div[@data-testid="alert-error"]
-      Element Should Contain    //div[@aria-label="Configure Red Hat OpenShift AI"]//p      Add-on parameter value for 'notification-email' is invalid.
-  END
-
-Verify RHOAI Is Present In List Of Subscriptions
-  [Tags]  Sanity
-  ...     ODS-701
-  ...     RHOAI-13070
-  Skip If RHODS Is Self-Managed
-  ${addons} =  Run
-  ...    ocm get addons --parameter search="id like 'managed-odh'"
-  ${addons} =    Load Json String    ${addons}
-  ${num_addons}=  Get From Dictionary    ${addons}  size
-  Should Be Equal    ${num_addons}  ${1}
-
-
 *** Keywords ***
 Installation Suite Setup
   Set Library Search Order    SeleniumLibrary

--- a/ods_ci/tests/Tests/0100__platform/0101__deploy/0102__auth_providers_and_rbac/0102__rbac.robot
+++ b/ods_ci/tests/Tests/0100__platform/0101__deploy/0102__auth_providers_and_rbac/0102__rbac.robot
@@ -8,8 +8,7 @@ Suite Setup         Rbac Suite Setup
 *** Test Cases ***
 Verify RHODS Has The Expected Default Access Groups Settings
     [Documentation]    Verify that RHODS is installed with the expected default user groups configuration
-    [Tags]    Sanity
-    ...       Tier1
+    [Tags]    Tier1
     ...       ODS-1164
     [Setup]    Set Standard RHODS Groups Variables
     Verify Default Access Groups Settings


### PR DESCRIPTION
Remove Sanity tags and move tests either to Smoke or Tier1.

Following tests were also removed since they test managed installation, which we don't do anymore.
- Verify RHOAI Addon Validates Notification E-Mail Format
- Verify RHOAI Is Present In List Of Subscriptions